### PR TITLE
Add stat formulas and expansion job proficiencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,18 @@ Simple text RPG UI inspired by Final Fantasy XI. The project is organized so tha
 
 ## Running
 Open `index.html` in a browser. No build step is required.
+
+## Data
+- A set of data files define FFXI races and jobs. Jobs include traits, abilities and proficiency grades for all jobs through the Adoulin expansion.
+- Races now list letter-graded stat proficiencies and a helper to access race names.
+- Jobs also include letter-graded stat proficiencies for HP, MP and core stats.
+- A randomize button on the main menu can generate a race and job combination.
+- Characters can be created from the main menu and are listed with their race,
+  job and level.
+- Character equipment now tracks left and right rings and earrings as well as main and off-hand weapons.
+- A utility function can calculate a character's current stats factoring in race, job and equipment.
+- `updateDerivedStats()` computes HP, MP and status values using level-based formulas derived from race and job proficiencies.
+- Characters now store numeric scaling values derived from their race and job
+  proficiencies. The `proficiencyScale` table maps letter grades to HP, MP and
+  status base/scale numbers. These values are kept separately for race and job
+  (e.g. `raceHpScale` and `jobHpScale`) alongside level-based placeholders.

--- a/data/characters.js
+++ b/data/characters.js
@@ -1,5 +1,297 @@
+import { jobs, jobNames } from './jobs.js';
+import { races, raceNames } from './races.js';
+import { getScale, proficiencyScale } from './scales.js';
+
+const aldoScale = buildScaleFields('Hume', 'Thief');
+const shantottoScale = buildScaleFields('Tarutaru', 'Black Mage');
+
+function buildScaleFields(raceName, jobName) {
+  const raceInfo = races.find(r => r.name === raceName);
+  const jobInfo = jobs.find(j => j.name === jobName);
+
+  const raceHP = getScale(raceInfo?.proficiencies?.hp);
+  const raceMP = getScale(raceInfo?.proficiencies?.mp);
+  const raceStatus = getScale(raceInfo?.proficiencies?.str);
+
+  const jobHP = getScale(jobInfo?.proficiencies?.hp);
+  const jobMP = getScale(jobInfo?.proficiencies?.mp);
+  const jobStatus = getScale(jobInfo?.proficiencies?.str);
+
+  return {
+    raceHpScale: raceHP.hpScale,
+    raceHpBase: raceHP.hpBase,
+    raceHpScaleXXX: raceHP.hpScaleXXX,
+    raceMpScale: raceMP.mpScale,
+    raceMpBase: raceMP.mpBase,
+    raceStatusScale: raceStatus.statusScale,
+    raceStatusBase: raceStatus.statusBase,
+    jobHpScale: jobHP.hpScale,
+    jobHpBase: jobHP.hpBase,
+    jobHpScaleXXX: jobHP.hpScaleXXX,
+    jobMpScale: jobMP.mpScale,
+    jobMpBase: jobMP.mpBase,
+    jobStatusScale: jobStatus.statusScale,
+    jobStatusBase: jobStatus.statusBase
+  };
+}
+
 export const characters = [
-    { name: 'Warrior' },
-    { name: 'Mage' },
-    { name: 'Thief' }
+  {
+    name: 'Aldo',
+    race: 'Hume',
+    job: 'Thief',
+    level: 99,
+    stats: { str: 70, dex: 90, vit: 70, agi: 80, int: 60, mnd: 60, chr: 70 },
+    hp: 1200,
+    mp: 200,
+    tp: 0,
+    skills: [],
+    traits: [],
+    abilities: [],
+    jobs: { Thief: 99, Ninja: 49 },
+    gil: 100000,
+    combatSkills: {},
+    magicSkills: {},
+    crafting: {},
+    ...aldoScale,
+    mLvX: 0,
+    mLvXXX: 0,
+    sLvX: 0,
+    raceHP: 0,
+    jobHP: 0,
+    sJobHP: 0,
+    raceMP: 0,
+    jobMP: 0,
+    sJobMP: 0,
+    equipment: {
+      head: null,
+      body: null,
+      hands: null,
+      legs: null,
+      feet: null,
+      mainHand: null,
+      offHand: null,
+      ranged: null,
+      ammo: null,
+      back: null,
+      waist: null,
+      neck: null,
+      leftEar: null,
+      rightEar: null,
+      leftRing: null,
+      rightRing: null
+    }
+  },
+  {
+    name: 'Shantotto',
+    race: 'Tarutaru',
+    job: 'Black Mage',
+    level: 99,
+    stats: { str: 40, dex: 60, vit: 50, agi: 60, int: 95, mnd: 80, chr: 70 },
+    hp: 1000,
+    mp: 1500,
+    tp: 0,
+    skills: [],
+    traits: [],
+    abilities: [],
+    jobs: { 'Black Mage': 99, 'White Mage': 49 },
+    gil: 500000,
+    combatSkills: {},
+    magicSkills: {},
+    crafting: {},
+    ...shantottoScale,
+    mLvX: 0,
+    mLvXXX: 0,
+    sLvX: 0,
+    raceHP: 0,
+    jobHP: 0,
+    sJobHP: 0,
+    raceMP: 0,
+    jobMP: 0,
+    sJobMP: 0,
+    equipment: {
+      head: null,
+      body: null,
+      hands: null,
+      legs: null,
+      feet: null,
+      mainHand: null,
+      offHand: null,
+      ranged: null,
+      ammo: null,
+      back: null,
+      waist: null,
+      neck: null,
+      leftEar: null,
+      rightEar: null,
+      leftRing: null,
+      rightRing: null
+    }
+  }
 ];
+
+characters.forEach(ch => updateDerivedStats(ch));
+
+export function createNewCharacter() {
+  const race = raceNames[Math.floor(Math.random() * raceNames.length)];
+  const job = jobNames[Math.floor(Math.random() * jobNames.length)];
+  const character = {
+    name: `Adventurer ${characters.length + 1}`,
+    race,
+    job,
+    level: 1,
+    stats: { str: 10, dex: 10, vit: 10, agi: 10, int: 10, mnd: 10, chr: 10 },
+    hp: 50,
+    mp: 30,
+    tp: 0,
+    skills: [],
+    traits: [],
+    abilities: [],
+    jobs: { [job]: 1 },
+    gil: 0,
+    combatSkills: {},
+    magicSkills: {},
+    crafting: {},
+    ...buildScaleFields(race, job),
+    mLvX: 0,
+    mLvXXX: 0,
+    sLvX: 0,
+    raceHP: 0,
+    jobHP: 0,
+    sJobHP: 0,
+    raceMP: 0,
+    jobMP: 0,
+    sJobMP: 0,
+    equipment: {
+      head: null,
+      body: null,
+      hands: null,
+      legs: null,
+      feet: null,
+      mainHand: null,
+      offHand: null,
+      ranged: null,
+      ammo: null,
+      back: null,
+      waist: null,
+      neck: null,
+      leftEar: null,
+      rightEar: null,
+      leftRing: null,
+      rightRing: null
+    }
+  };
+  characters.unshift(character);
+  updateDerivedStats(character);
+  return character;
+}
+
+export function calculateCharacterStats(character) {
+  const totals = {
+    hp: character.hp || 0,
+    mp: character.mp || 0,
+    str: character.stats?.str || 0,
+    dex: character.stats?.dex || 0,
+    vit: character.stats?.vit || 0,
+    agi: character.stats?.agi || 0,
+    int: character.stats?.int || 0,
+    mnd: character.stats?.mnd || 0,
+    chr: character.stats?.chr || 0
+  };
+
+  const raceInfo = races.find(r => r.name === character.race);
+  if (raceInfo) {
+    applyProficiencies(totals, raceInfo.proficiencies);
+  }
+
+  const jobInfo = jobs.find(j => j.name === character.job);
+  if (jobInfo) {
+    if (jobInfo.proficiencies) {
+      applyProficiencies(totals, jobInfo.proficiencies);
+    }
+    // TODO: adjust totals based on job traits/abilities
+  }
+
+  if (character.equipment) {
+    // TODO: incorporate equipment stat bonuses
+  }
+
+  return totals;
+}
+
+export function updateDerivedStats(character) {
+  const mainLevel = character.jobs?.[character.job] || character.level || 1;
+  const subJobName = Object.keys(character.jobs || {}).find(j => j !== character.job);
+  const subLevel = subJobName ? character.jobs[subJobName] : 0;
+
+  const raceInfo = races.find(r => r.name === character.race);
+  const jobInfo = jobs.find(j => j.name === character.job);
+  const subInfo = subJobName ? jobs.find(j => j.name === subJobName) : null;
+
+  const raceHP = getScale(raceInfo?.proficiencies?.hp);
+  const raceMP = getScale(raceInfo?.proficiencies?.mp);
+  const raceStatus = getScale(raceInfo?.proficiencies?.str);
+
+  const jobHP = getScale(jobInfo?.proficiencies?.hp);
+  const jobMP = getScale(jobInfo?.proficiencies?.mp);
+  const jobStatus = getScale(jobInfo?.proficiencies?.str);
+
+  const subHP = subInfo ? getScale(subInfo.proficiencies?.hp) : proficiencyScale.X;
+  const subMP = subInfo ? getScale(subInfo.proficiencies?.mp) : proficiencyScale.X;
+  const subStatus = subInfo ? getScale(subInfo.proficiencies?.str) : proficiencyScale.X;
+
+  const mLvX = Math.max(mainLevel - 10, 0);
+  const mLvXXX = Math.max(mainLevel - 30, 0);
+  const sLvX = subInfo ? Math.max(subLevel - 10, 0) : 0;
+
+  const raceHPVal = (raceHP.hpScale * (mainLevel - 1) + raceHP.hpBase) + (2 * mLvX) + (raceHP.hpScaleXXX * mLvXXX);
+  const jobHPVal = (jobHP.hpScale * (mainLevel - 1) + jobHP.hpBase) + (jobHP.hpScaleXXX * mLvXXX);
+  const sJobHPVal = subInfo ? ((subHP.hpScale * (subLevel - 1) + subHP.hpBase + sLvX) / 2) : 0;
+  const hpTotal = raceHPVal + jobHPVal + sJobHPVal;
+
+  let raceMPVal = 0;
+  if (jobMP.mpScale > 0) {
+    raceMPVal = raceMP.mpScale * (mainLevel - 1) + raceMP.mpBase;
+  } else if (subInfo && subMP.mpScale > 0) {
+    raceMPVal = (subMP.mpScale * (subLevel - 1) + subMP.mpBase) / 2;
+  }
+  const jobMPVal = jobMP.mpScale * (mainLevel - 1) + jobMP.mpBase;
+  const sJobMPVal = subInfo && subMP.mpScale > 0 ? (subMP.mpScale * (subLevel - 1) + subMP.mpBase) / 2 : 0;
+  const mpTotal = raceMPVal + jobMPVal + sJobMPVal;
+
+  const raceStatusVal = raceStatus.statusScale * (mainLevel - 1) + raceStatus.statusBase;
+  const jobStatusVal = jobStatus.statusScale * (mainLevel - 1) + jobStatus.statusBase;
+  const sJobStatusVal = subInfo ? (subStatus.statusScale * (subLevel - 1) + subStatus.statusBase) / 2 : 0;
+  const statusTotal = raceStatusVal + jobStatusVal + sJobStatusVal;
+
+  Object.assign(character, {
+    mLvX,
+    mLvXXX,
+    sLvX,
+    raceHP: raceHPVal,
+    jobHP: jobHPVal,
+    sJobHP: sJobHPVal,
+    raceMP: raceMPVal,
+    jobMP: jobMPVal,
+    sJobMP: sJobMPVal,
+    raceStatus: raceStatusVal,
+    jobStatus: jobStatusVal,
+    sJobStatus: sJobStatusVal,
+    hp: hpTotal,
+    mp: mpTotal,
+    status: statusTotal
+  });
+
+  return character;
+}
+
+function applyProficiencies(stats, profs) {
+  for (const key in profs) {
+    stats[key] += gradeToValue(profs[key]);
+  }
+}
+
+function gradeToValue(grade) {
+  const mapping = { A: 6, B: 5, C: 4, D: 3, E: 2, F: 1, G: 0, X: 0 };
+  return mapping[grade] ?? 0;
+}

--- a/data/index.js
+++ b/data/index.js
@@ -1,0 +1,4 @@
+export { jobs, jobNames } from './jobs.js';
+export { races, raceNames } from './races.js';
+export { characters, createNewCharacter, calculateCharacterStats, updateDerivedStats } from './characters.js';
+export { proficiencyScale, getScale } from './scales.js';

--- a/data/jobs.js
+++ b/data/jobs.js
@@ -1,0 +1,224 @@
+export const jobs = [
+  {
+    name: 'Warrior',
+    proficiencies: { hp: 'B', mp: 'X', str: 'A', dex: 'C', vit: 'D', agi: 'C', int: 'F', mnd: 'F', chr: 'E' },
+    traits: [
+      { name: 'Defense Bonus', effect: 'Increases defense', level: 10 }
+    ],
+    abilities: [
+      { name: 'Provoke', effect: 'Forces enemy attention', level: 5 }
+    ]
+  },
+  {
+    name: 'Monk',
+    proficiencies: { hp: 'A', mp: 'X', str: 'C', dex: 'B', vit: 'A', agi: 'F', int: 'G', mnd: 'D', chr: 'E' },
+    traits: [
+      { name: 'Max HP Boost', effect: 'Raises maximum HP', level: 10 }
+    ],
+    abilities: [
+      { name: 'Chakra', effect: 'Restores HP', level: 35 }
+    ]
+  },
+  {
+    name: 'White Mage',
+    proficiencies: { hp: 'E', mp: 'C', str: 'D', dex: 'F', vit: 'D', agi: 'E', int: 'E', mnd: 'A', chr: 'C' },
+    traits: [
+      { name: 'Auto Refresh', effect: 'Regenerates MP over time', level: 45 }
+    ],
+    abilities: [
+      { name: 'Benediction', effect: 'Restores HP to party', level: 1 }
+    ]
+  },
+  {
+    name: 'Black Mage',
+    proficiencies: { hp: 'F', mp: 'B', str: 'F', dex: 'C', vit: 'F', agi: 'C', int: 'A', mnd: 'E', chr: 'D' },
+    traits: [
+      { name: 'Magic Attack Bonus', effect: 'Boosts magic damage', level: 20 }
+    ],
+    abilities: [
+      { name: 'Elemental Seal', effect: 'Improves spell accuracy', level: 15 }
+    ]
+  },
+  {
+    name: 'Red Mage',
+    proficiencies: { hp: 'D', mp: 'D', str: 'D', dex: 'D', vit: 'E', agi: 'E', int: 'C', mnd: 'C', chr: 'D' },
+    traits: [
+      { name: 'Fast Cast', effect: 'Shortens casting time', level: 15 }
+    ],
+    abilities: [
+      { name: 'Convert', effect: 'Swaps HP and MP', level: 40 }
+    ]
+  },
+  {
+    name: 'Thief',
+    proficiencies: { hp: 'D', mp: 'X', str: 'D', dex: 'A', vit: 'D', agi: 'B', int: 'C', mnd: 'G', chr: 'G' },
+    traits: [
+      { name: 'Treasure Hunter', effect: 'Improves drop rates', level: 5 }
+    ],
+    abilities: [
+      { name: 'Steal', effect: 'Attempts to steal an item', level: 5 }
+    ]
+  },
+  {
+    name: 'Paladin',
+    proficiencies: { hp: 'C', mp: 'F', str: 'B', dex: 'E', vit: 'A', agi: 'G', int: 'G', mnd: 'C', chr: 'C' },
+    traits: [
+      { name: 'Shield Mastery', effect: 'Blocks more often', level: 10 }
+    ],
+    abilities: [
+      { name: 'Cover', effect: 'Protects an ally', level: 35 }
+    ]
+  },
+  {
+    name: 'Dark Knight',
+    proficiencies: { hp: 'C', mp: 'F', str: 'A', dex: 'C', vit: 'C', agi: 'D', int: 'C', mnd: 'G', chr: 'G' },
+    traits: [
+      { name: 'Attack Bonus', effect: 'Increases attack', level: 10 }
+    ],
+    abilities: [
+      { name: 'Souleater', effect: 'Converts HP to damage', level: 30 }
+    ]
+  },
+  {
+    name: 'Beastmaster',
+    proficiencies: { hp: 'C', mp: 'X', str: 'D', dex: 'C', vit: 'D', agi: 'F', int: 'E', mnd: 'E', chr: 'A' },
+    traits: [
+      { name: 'Charm', effect: 'Tame beasts for a time', level: 1 }
+    ],
+    abilities: [
+      { name: 'Feral Howl', effect: 'Weakens a beast', level: 45 }
+    ]
+  },
+  {
+    name: 'Bard',
+    proficiencies: { hp: 'D', mp: 'X', str: 'D', dex: 'D', vit: 'D', agi: 'F', int: 'D', mnd: 'D', chr: 'B' },
+    traits: [
+      { name: 'Song Spellcasting Time', effect: 'Faster song casting', level: 20 }
+    ],
+    abilities: [
+      { name: "Mage's Ballad", effect: 'Restores MP over time', level: 25 }
+    ]
+  },
+  {
+    name: 'Ranger',
+    proficiencies: { hp: 'E', mp: 'X', str: 'E', dex: 'D', vit: 'D', agi: 'A', int: 'E', mnd: 'D', chr: 'E' },
+    traits: [
+      { name: 'Accuracy Bonus', effect: 'Increases ranged accuracy', level: 10 }
+    ],
+    abilities: [
+      { name: 'Barrage', effect: 'Fires multiple shots at once', level: 30 }
+    ]
+  },
+  {
+    name: 'Samurai',
+    proficiencies: { hp: 'B', mp: 'X', str: 'C', dex: 'C', vit: 'C', agi: 'D', int: 'E', mnd: 'E', chr: 'D' },
+    traits: [
+      { name: 'Store TP', effect: 'Gain extra TP per hit', level: 10 }
+    ],
+    abilities: [
+      { name: 'Meditate', effect: 'Instantly gains TP', level: 30 }
+    ]
+  },
+  {
+    name: 'Ninja',
+    proficiencies: { hp: 'D', mp: 'X', str: 'C', dex: 'B', vit: 'C', agi: 'B', int: 'D', mnd: 'G', chr: 'F' },
+    traits: [
+      { name: 'Dual Wield', effect: 'Allows wielding two weapons', level: 10 }
+    ],
+    abilities: [
+      { name: 'Mijin Gakure', effect: 'Deals damage at cost of HP', level: 25 }
+    ]
+  },
+  {
+    name: 'Dragoon',
+    proficiencies: { hp: 'C', mp: 'X', str: 'C', dex: 'E', vit: 'C', agi: 'E', int: 'F', mnd: 'E', chr: 'C' },
+    traits: [
+      { name: 'Accuracy Bonus', effect: 'Increases accuracy', level: 10 }
+    ],
+    abilities: [
+      { name: 'Jump', effect: 'Deals jumping attack', level: 1 }
+    ]
+  },
+  {
+    name: 'Summoner',
+    proficiencies: { hp: 'G', mp: 'A', str: 'G', dex: 'D', vit: 'G', agi: 'D', int: 'B', mnd: 'C', chr: 'C' },
+    traits: [
+      { name: 'Avatar Cost Down', effect: 'Lowers avatar upkeep', level: 25 }
+    ],
+    abilities: [
+      { name: 'Astral Flow', effect: 'Enables powerful avatar attack', level: 1 }
+    ]
+  },
+  {
+    name: 'Blue Mage',
+    proficiencies: { hp: 'C', mp: 'D', str: 'C', dex: 'C', vit: 'C', agi: 'D', int: 'D', mnd: 'D', chr: 'C' },
+    traits: [
+      { name: 'Blue Magic Attack Bonus', effect: 'Boosts blue magic', level: 30 }
+    ],
+    abilities: [
+      { name: 'Azure Lore', effect: 'Enhances blue magic', level: 1 }
+    ]
+  },
+  {
+    name: 'Corsair',
+    proficiencies: { hp: 'D', mp: 'E', str: 'E', dex: 'C', vit: 'D', agi: 'B', int: 'D', mnd: 'D', chr: 'B' },
+    traits: [
+      { name: 'Phantom Roll', effect: 'Provides party bonuses', level: 5 }
+    ],
+    abilities: [
+      { name: 'Wild Card', effect: 'Resets ability timers', level: 70 }
+    ]
+  },
+  {
+    name: 'Puppetmaster',
+    proficiencies: { hp: 'C', mp: 'E', str: 'D', dex: 'C', vit: 'D', agi: 'C', int: 'D', mnd: 'D', chr: 'C' },
+    traits: [
+      { name: 'Automaton Max HP Bonus', effect: 'Increases automaton HP', level: 10 }
+    ],
+    abilities: [
+      { name: 'Overdrive', effect: 'Enhances automaton abilities', level: 1 }
+    ]
+  },
+  {
+    name: 'Dancer',
+    proficiencies: { hp: 'D', mp: 'X', str: 'D', dex: 'A', vit: 'C', agi: 'C', int: 'C', mnd: 'G', chr: 'C' },
+    traits: [
+      { name: 'Sambas', effect: 'Adds healing or debuff effects', level: 5 }
+    ],
+    abilities: [
+      { name: 'Trance', effect: 'Unlimited step usage', level: 1 }
+    ]
+  },
+  {
+    name: 'Scholar',
+    proficiencies: { hp: 'E', mp: 'B', str: 'E', dex: 'D', vit: 'D', agi: 'D', int: 'B', mnd: 'A', chr: 'D' },
+    traits: [
+      { name: 'Grimoire', effect: 'Alters spellcasting modes', level: 1 }
+    ],
+    abilities: [
+      { name: 'Tabula Rasa', effect: 'Enhances grimoire', level: 1 }
+    ]
+  },
+  {
+    name: 'Geomancer',
+    proficiencies: { hp: 'E', mp: 'B', str: 'E', dex: 'D', vit: 'D', agi: 'D', int: 'C', mnd: 'A', chr: 'D' },
+    traits: [
+      { name: 'Indicolure Duration', effect: 'Extends geomancy spells', level: 40 }
+    ],
+    abilities: [
+      { name: 'Bolster', effect: 'Greatly strengthens geomancy', level: 1 }
+    ]
+  },
+  {
+    name: 'Rune Fencer',
+    proficiencies: { hp: 'B', mp: 'D', str: 'C', dex: 'C', vit: 'B', agi: 'D', int: 'C', mnd: 'D', chr: 'C' },
+    traits: [
+      { name: 'Magic Defense Bonus', effect: 'Increases magic defense', level: 10 }
+    ],
+    abilities: [
+      { name: 'Embolden', effect: 'Enhances enhancing magic', level: 96 }
+    ]
+  }
+];
+
+export const jobNames = jobs.map(j => j.name);

--- a/data/races.js
+++ b/data/races.js
@@ -1,0 +1,34 @@
+export const races = [
+  {
+    name: 'Hume',
+    proficiencies: {
+      hp: 'D', mp: 'D', str: 'D', dex: 'D', vit: 'D', agi: 'D', int: 'D', mnd: 'D', chr: 'D'
+    }
+  },
+  {
+    name: 'Elvaan',
+    proficiencies: {
+      hp: 'C', mp: 'E', str: 'B', dex: 'E', vit: 'C', agi: 'F', int: 'F', mnd: 'B', chr: 'D'
+    }
+  },
+  {
+    name: 'Tarutaru',
+    proficiencies: {
+      hp: 'G', mp: 'A', str: 'F', dex: 'D', vit: 'E', agi: 'C', int: 'A', mnd: 'E', chr: 'D'
+    }
+  },
+  {
+    name: 'Mithra',
+    proficiencies: {
+      hp: 'D', mp: 'D', str: 'E', dex: 'A', vit: 'E', agi: 'B', int: 'D', mnd: 'E', chr: 'F'
+    }
+  },
+  {
+    name: 'Galka',
+    proficiencies: {
+      hp: 'A', mp: 'G', str: 'C', dex: 'D', vit: 'A', agi: 'E', int: 'E', mnd: 'D', chr: 'F'
+    }
+  }
+];
+
+export const raceNames = races.map(r => r.name);

--- a/data/scales.js
+++ b/data/scales.js
@@ -1,0 +1,15 @@
+export const proficiencyScale = {
+  A: { hpScale: 9, hpBase: 19, hpScaleXXX: 1, mpScale: 6, mpBase: 16, statusScale: 0.5, statusBase: 5 },
+  B: { hpScale: 8, hpBase: 17, hpScaleXXX: 1, mpScale: 5, mpBase: 14, statusScale: 0.45, statusBase: 4 },
+  C: { hpScale: 7, hpBase: 16, hpScaleXXX: 1, mpScale: 4, mpBase: 12, statusScale: 0.4, statusBase: 4 },
+  D: { hpScale: 6, hpBase: 14, hpScaleXXX: 0, mpScale: 3, mpBase: 10, statusScale: 0.35, statusBase: 3 },
+  E: { hpScale: 5, hpBase: 13, hpScaleXXX: 0, mpScale: 2, mpBase: 8, statusScale: 0.3, statusBase: 3 },
+  F: { hpScale: 4, hpBase: 11, hpScaleXXX: 0, mpScale: 1, mpBase: 6, statusScale: 0.25, statusBase: 2 },
+  G: { hpScale: 3, hpBase: 10, hpScaleXXX: 0, mpScale: 0.5, mpBase: 4, statusScale: 0.2, statusBase: 2 },
+  X: { hpScale: 0, hpBase: 0, hpScaleXXX: 0, mpScale: 0, mpBase: 0, statusScale: 0, statusBase: 0 },
+  x: { hpScale: 0, hpBase: 0, hpScaleXXX: 0, mpScale: 0, mpBase: 0, statusScale: 0, statusBase: 0 }
+};
+
+export function getScale(grade) {
+  return proficiencyScale[grade] || proficiencyScale[grade?.toUpperCase()] || proficiencyScale.X;
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,4 +1,4 @@
-import { characters } from '../data/characters.js';
+import { characters, jobNames, raceNames, createNewCharacter } from '../data/index.js';
 
 export function renderMainMenu() {
     const container = document.createElement('div');
@@ -8,34 +8,54 @@ export function renderMainMenu() {
     const menu = document.createElement('div');
     menu.id = 'menu';
 
-    const charSelectBtn = document.createElement('button');
-    charSelectBtn.textContent = 'Character Select';
-    charSelectBtn.addEventListener('click', () => {
-        renderCharacterSelect(container);
+    const charactersBtn = document.createElement('button');
+    charactersBtn.textContent = 'Characters';
+    charactersBtn.addEventListener('click', () => {
+        renderCharacterMenu(container);
     });
 
-    menu.appendChild(charSelectBtn);
+    const randomBtn = document.createElement('button');
+    randomBtn.textContent = 'Random Race & Job';
+    randomBtn.addEventListener('click', () => {
+        const race = raceNames[Math.floor(Math.random() * raceNames.length)];
+        const job = jobNames[Math.floor(Math.random() * jobNames.length)];
+        displayRandomSelection(container, race, job);
+    });
+
+    menu.appendChild(charactersBtn);
+    menu.appendChild(randomBtn);
 
     container.appendChild(title);
     container.appendChild(menu);
 
+    const display = document.createElement('p');
+    display.id = 'random-display';
+    container.appendChild(display);
+
     return container;
 }
 
-export function renderCharacterSelect(root) {
+export function renderCharacterMenu(root) {
     root.innerHTML = '';
     const title = document.createElement('h2');
-    title.textContent = 'Choose Your Character';
+    title.textContent = 'Characters';
     root.appendChild(title);
 
+    const list = document.createElement('div');
     characters.forEach((ch) => {
-        const btn = document.createElement('button');
-        btn.textContent = ch.name;
-        btn.addEventListener('click', () => {
-            alert(`${ch.name} selected!`);
-        });
-        root.appendChild(btn);
+        const entry = document.createElement('div');
+        entry.textContent = `${ch.name} - ${ch.race} ${ch.job} Lv.${ch.level}`;
+        list.appendChild(entry);
     });
+    root.appendChild(list);
+
+    const newBtn = document.createElement('button');
+    newBtn.textContent = 'New Character';
+    newBtn.addEventListener('click', () => {
+        createNewCharacter();
+        renderCharacterMenu(root);
+    });
+    root.appendChild(newBtn);
 
     const back = document.createElement('button');
     back.textContent = 'Back';
@@ -46,4 +66,14 @@ export function renderCharacterSelect(root) {
 
     root.appendChild(document.createElement('br'));
     root.appendChild(back);
+}
+
+function displayRandomSelection(root, race, job) {
+    let display = root.querySelector('#random-display');
+    if (!display) {
+        display = document.createElement('p');
+        display.id = 'random-display';
+        root.appendChild(display);
+    }
+    display.textContent = `Race: ${race} | Job: ${job}`;
 }


### PR DESCRIPTION
## Summary
- define proficiency grades for jobs from the later expansions
- compute HP/MP/Status from race and job levels with `updateDerivedStats`
- expose `updateDerivedStats` through the data index
- mention new formula handling in README

## Testing
- `node -c data/characters.js`
- `node -c data/jobs.js`
- `node -c data/index.js`
- `node -c data/races.js`
- `node -c data/scales.js`
- `node -c js/ui.js`

------
https://chatgpt.com/codex/tasks/task_e_687ae76680cc8325a7f328c630cc8bcc