### PR TITLE
Add save/load and job selection

### DIFF
--- a/data/characters.js
+++ b/data/characters.js
@@ -132,13 +132,13 @@ export const characters = [
 
 characters.forEach(ch => updateDerivedStats(ch));
 
-export function createNewCharacter() {
-  const race = raceNames[Math.floor(Math.random() * raceNames.length)];
-  const job = jobNames[Math.floor(Math.random() * jobNames.length)];
+export function createNewCharacter(name = `Adventurer ${characters.length + 1}`, job, race) {
+  const selectedRace = race || raceNames[Math.floor(Math.random() * raceNames.length)];
+  const selectedJob = job || jobNames[Math.floor(Math.random() * jobNames.length)];
   const character = {
-    name: `Adventurer ${characters.length + 1}`,
-    race,
-    job,
+    name,
+    race: selectedRace,
+    job: selectedJob,
     level: 1,
     stats: { str: 10, dex: 10, vit: 10, agi: 10, int: 10, mnd: 10, chr: 10 },
     hp: 50,
@@ -147,12 +147,12 @@ export function createNewCharacter() {
     skills: [],
     traits: [],
     abilities: [],
-    jobs: { [job]: 1 },
+    jobs: { [selectedJob]: 1 },
     gil: 0,
     combatSkills: {},
     magicSkills: {},
     crafting: {},
-    ...buildScaleFields(race, job),
+    ...buildScaleFields(selectedRace, selectedJob),
     mLvX: 0,
     mLvXXX: 0,
     sLvX: 0,
@@ -294,4 +294,27 @@ function applyProficiencies(stats, profs) {
 function gradeToValue(grade) {
   const mapping = { A: 6, B: 5, C: 4, D: 3, E: 2, F: 1, G: 0, X: 0 };
   return mapping[grade] ?? 0;
+}
+
+export function saveCharacters() {
+  try {
+    localStorage.setItem('ffxiCharacters', JSON.stringify(characters));
+  } catch (e) {
+    console.error('Failed to save characters', e);
+  }
+}
+
+export function loadCharacters() {
+  try {
+    const data = localStorage.getItem('ffxiCharacters');
+    if (!data) return;
+    const loaded = JSON.parse(data);
+    characters.length = 0;
+    loaded.forEach(c => {
+      characters.push(c);
+      updateDerivedStats(c);
+    });
+  } catch (e) {
+    console.error('Failed to load characters', e);
+  }
 }

--- a/data/index.js
+++ b/data/index.js
@@ -1,4 +1,4 @@
-export { jobs, jobNames } from './jobs.js';
+export { jobs, jobNames, baseJobNames } from './jobs.js';
 export { races, raceNames } from './races.js';
-export { characters, createNewCharacter, calculateCharacterStats, updateDerivedStats } from './characters.js';
+export { characters, createNewCharacter, calculateCharacterStats, updateDerivedStats, saveCharacters, loadCharacters } from './characters.js';
 export { proficiencyScale, getScale } from './scales.js';

--- a/data/jobs.js
+++ b/data/jobs.js
@@ -605,3 +605,14 @@ export const jobs = [
 ];
 
 export const jobNames = jobs.map(j => j.name);
+// Jobs available when creating a brand new character without completing any
+// unlock quests. These correspond to the six starter jobs from the original
+// Final Fantasy XI release.
+export const baseJobNames = [
+  'Warrior',
+  'Monk',
+  'White Mage',
+  'Black Mage',
+  'Red Mage',
+  'Thief'
+];

--- a/js/main.js
+++ b/js/main.js
@@ -1,7 +1,9 @@
 import { renderMainMenu } from './ui.js';
+import { loadCharacters } from '../data/index.js';
 
 // Entry point: initialize application
 function init() {
+    loadCharacters();
     const app = document.getElementById('app');
     app.innerHTML = '';
     const menu = renderMainMenu();

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,4 +1,4 @@
-import { characters, jobNames, raceNames, createNewCharacter } from '../data/index.js';
+import { characters, jobNames, raceNames, baseJobNames, createNewCharacter, saveCharacters, loadCharacters } from '../data/index.js';
 
 export function renderMainMenu() {
     const container = document.createElement('div');
@@ -52,10 +52,24 @@ export function renderCharacterMenu(root) {
     const newBtn = document.createElement('button');
     newBtn.textContent = 'New Character';
     newBtn.addEventListener('click', () => {
-        createNewCharacter();
-        renderCharacterMenu(root);
+        renderNewCharacterForm(root);
     });
     root.appendChild(newBtn);
+
+    const saveBtn = document.createElement('button');
+    saveBtn.textContent = 'Save';
+    saveBtn.addEventListener('click', () => {
+        saveCharacters();
+    });
+    root.appendChild(saveBtn);
+
+    const loadBtn = document.createElement('button');
+    loadBtn.textContent = 'Load';
+    loadBtn.addEventListener('click', () => {
+        loadCharacters();
+        renderCharacterMenu(root);
+    });
+    root.appendChild(loadBtn);
 
     const back = document.createElement('button');
     back.textContent = 'Back';
@@ -66,6 +80,50 @@ export function renderCharacterMenu(root) {
 
     root.appendChild(document.createElement('br'));
     root.appendChild(back);
+}
+
+function renderNewCharacterForm(root) {
+    root.innerHTML = '';
+    const title = document.createElement('h3');
+    title.textContent = 'Create Character';
+    root.appendChild(title);
+
+    const nameLabel = document.createElement('label');
+    nameLabel.textContent = 'Name:';
+    const nameInput = document.createElement('input');
+    nameInput.type = 'text';
+    nameInput.value = `Adventurer ${characters.length + 1}`;
+    root.appendChild(nameLabel);
+    root.appendChild(nameInput);
+    root.appendChild(document.createElement('br'));
+
+    const jobLabel = document.createElement('label');
+    jobLabel.textContent = 'Job:';
+    const jobSelect = document.createElement('select');
+    baseJobNames.forEach(j => {
+        const opt = document.createElement('option');
+        opt.value = j;
+        opt.textContent = j;
+        jobSelect.appendChild(opt);
+    });
+    root.appendChild(jobLabel);
+    root.appendChild(jobSelect);
+    root.appendChild(document.createElement('br'));
+
+    const createBtn = document.createElement('button');
+    createBtn.textContent = 'Create';
+    createBtn.addEventListener('click', () => {
+        createNewCharacter(nameInput.value.trim() || undefined, jobSelect.value);
+        renderCharacterMenu(root);
+    });
+    root.appendChild(createBtn);
+
+    const cancelBtn = document.createElement('button');
+    cancelBtn.textContent = 'Cancel';
+    cancelBtn.addEventListener('click', () => {
+        renderCharacterMenu(root);
+    });
+    root.appendChild(cancelBtn);
 }
 
 function displayRandomSelection(root, race, job) {


### PR DESCRIPTION
## Summary
- add starter job list
- enable saving and loading characters using localStorage
- allow setting character name and job when creating characters
- load saved characters when the app boots

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687bae04eb1883258f5e3438848c20f3