### PR TITLE
Improve character creation UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,12 +5,13 @@ body {
     text-align: center;
     margin: 0;
     padding: 0;
+    font-size: clamp(14px, 2vw, 20px);
 }
 
 button {
-    padding: 10px 20px;
+    padding: clamp(8px, 1vw, 12px) clamp(12px, 2vw, 24px);
     margin: 5px;
-    font-size: 16px;
+    font-size: clamp(14px, 1.5vw, 18px);
     background-color: #333;
     color: #fff;
     border: 1px solid #555;
@@ -45,8 +46,16 @@ button:hover {
 .character-form {
     display: flex;
     justify-content: space-between;
+    flex-wrap: wrap;
     margin-top: 20px;
     gap: 20px;
+    padding: 2vw;
+}
+
+@media (max-width: 600px) {
+    .character-form {
+        flex-direction: column;
+    }
 }
 
 .form-inputs {
@@ -58,14 +67,36 @@ button:hover {
     margin-bottom: 10px;
 }
 
-.form-info {
+.form-stats {
+    flex: 1;
+    text-align: left;
+}
+
+.form-traits {
     flex: 1;
     text-align: center;
 }
 
-#info-hpmp {
-    margin-bottom: 10px;
+.stats-list,
+.trait-list,
+.ability-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
 }
+
+.trait-list li,
+.ability-list li {
+    display: flex;
+    justify-content: center;
+    gap: 4px;
+}
+
+.start-city {
+    margin-top: 10px;
+    text-align: left;
+}
+
 
 /* Active character profile */
 #active-profile {
@@ -76,16 +107,20 @@ button:hover {
     display: flex;
     justify-content: center;
     align-items: flex-start;
-    gap: 20px;
+    gap: clamp(10px, 2vw, 30px);
     margin-top: 10px;
+    padding: 2vw;
 }
 
 .info-buttons {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
+    gap: 5px;
+    margin-right: clamp(10px, 2vw, 30px);
 }
 
 .info-display {
     text-align: right;
+    margin-left: clamp(10px, 2vw, 30px);
 }

--- a/data/characters.js
+++ b/data/characters.js
@@ -1,5 +1,5 @@
 import { jobs, jobNames } from './jobs.js';
-import { races, raceNames } from './races.js';
+import { races, raceNames, startingCities } from './races.js';
 import { getScale, proficiencyScale } from './scales.js';
 
 const aldoScale = buildScaleFields('Hume', 'Thief');
@@ -43,6 +43,7 @@ export const characters = [
     race: 'Hume',
     sex: 'Male',
     job: 'Thief',
+    startingCity: startingCities['Hume'],
     level: 99,
     stats: { str: 70, dex: 90, vit: 70, agi: 80, int: 60, mnd: 60, chr: 70 },
     hp: 1200,
@@ -90,6 +91,7 @@ export const characters = [
     race: 'Tarutaru',
     sex: 'Female',
     job: 'Black Mage',
+    startingCity: startingCities['Tarutaru'],
     level: 99,
     stats: { str: 40, dex: 60, vit: 50, agi: 60, int: 95, mnd: 80, chr: 70 },
     hp: 1000,
@@ -144,6 +146,7 @@ export function createCharacterObject(name, job, race, sex = 'Male') {
     race: selectedRace,
     sex,
     job: selectedJob,
+    startingCity: startingCities[selectedRace],
     level: 1,
     stats: { str: 10, dex: 10, vit: 10, agi: 10, int: 10, mnd: 10, chr: 10 },
     hp: 50,

--- a/data/index.js
+++ b/data/index.js
@@ -1,5 +1,5 @@
 export { jobs, jobNames, baseJobNames } from './jobs.js';
-export { races, raceNames } from './races.js';
+export { races, raceNames, startingCities } from './races.js';
 export {
   characters,
   activeCharacter,

--- a/data/races.js
+++ b/data/races.js
@@ -1,30 +1,35 @@
 export const races = [
   {
     name: 'Hume',
+    startingCity: 'Bastok',
     proficiencies: {
       hp: 'D', mp: 'D', str: 'D', dex: 'D', vit: 'D', agi: 'D', int: 'D', mnd: 'D', chr: 'D'
     }
   },
   {
     name: 'Elvaan',
+    startingCity: "San d'Oria",
     proficiencies: {
       hp: 'C', mp: 'E', str: 'B', dex: 'E', vit: 'C', agi: 'F', int: 'F', mnd: 'B', chr: 'D'
     }
   },
   {
     name: 'Tarutaru',
+    startingCity: 'Windurst',
     proficiencies: {
       hp: 'G', mp: 'A', str: 'F', dex: 'D', vit: 'E', agi: 'C', int: 'A', mnd: 'E', chr: 'D'
     }
   },
   {
     name: 'Mithra',
+    startingCity: 'Windurst',
     proficiencies: {
       hp: 'D', mp: 'D', str: 'E', dex: 'A', vit: 'E', agi: 'B', int: 'D', mnd: 'E', chr: 'F'
     }
   },
   {
     name: 'Galka',
+    startingCity: 'Bastok',
     proficiencies: {
       hp: 'A', mp: 'G', str: 'C', dex: 'D', vit: 'A', agi: 'E', int: 'E', mnd: 'D', chr: 'F'
     }
@@ -32,3 +37,6 @@ export const races = [
 ];
 
 export const raceNames = races.map(r => r.name);
+export const startingCities = Object.fromEntries(
+  races.map(r => [r.name, r.startingCity])
+);

--- a/js/ui.js
+++ b/js/ui.js
@@ -4,6 +4,7 @@ import {
     raceNames,
     baseJobNames,
     jobs,
+    startingCities,
     createCharacterObject,
     createNewCharacter,
     saveCharacterSlot,
@@ -173,7 +174,7 @@ function renderNewCharacterForm(root) {
     title.textContent = 'Create Character';
     root.appendChild(title);
 
-    // container for two-column layout
+    // container for three-column layout
     const form = document.createElement('div');
     form.className = 'character-form';
 
@@ -237,18 +238,46 @@ function renderNewCharacterForm(root) {
     jobField.appendChild(jobSelect);
     inputs.appendChild(jobField);
 
+    const randomBtn = document.createElement('button');
+    randomBtn.textContent = 'Randomize';
+    randomBtn.addEventListener('click', () => {
+        raceSelect.value = raceNames[Math.floor(Math.random() * raceNames.length)];
+        jobSelect.value = baseJobNames[Math.floor(Math.random() * baseJobNames.length)];
+        sexSelect.value = ['Male', 'Female'][Math.floor(Math.random() * 2)];
+        updateInfo();
+    });
+    inputs.appendChild(randomBtn);
+
     form.appendChild(inputs);
+    // middle column: stats display
+    const statsCol = document.createElement('div');
+    statsCol.className = 'form-stats';
+    const statsList = document.createElement('ul');
+    statsList.className = 'stats-list';
+    statsCol.appendChild(statsList);
+    const cityDiv = document.createElement('div');
+    cityDiv.className = 'start-city';
+    statsCol.appendChild(cityDiv);
+    form.appendChild(statsCol);
 
-    // right column: info display
+    // right column: traits and abilities
     const infoCol = document.createElement('div');
-    infoCol.className = 'form-info';
+    infoCol.className = 'form-traits';
 
-    const hpmpDiv = document.createElement('div');
-    hpmpDiv.id = 'info-hpmp';
-    infoCol.appendChild(hpmpDiv);
+    const traitsHeader = document.createElement('h4');
+    traitsHeader.textContent = 'Traits';
+    infoCol.appendChild(traitsHeader);
+    const traitsList = document.createElement('ul');
+    traitsList.className = 'trait-list';
+    infoCol.appendChild(traitsList);
 
-    const detailsDiv = document.createElement('div');
-    infoCol.appendChild(detailsDiv);
+    const abilitiesHeader = document.createElement('h4');
+    abilitiesHeader.textContent = 'Abilities';
+    abilitiesHeader.style.marginTop = '20px';
+    infoCol.appendChild(abilitiesHeader);
+    const abilitiesList = document.createElement('ul');
+    abilitiesList.className = 'ability-list';
+    infoCol.appendChild(abilitiesList);
 
     form.appendChild(infoCol);
 
@@ -261,14 +290,39 @@ function renderNewCharacterForm(root) {
             raceSelect.value,
             sexSelect.value
         );
-        hpmpDiv.textContent = `HP: ${preview.hp} | MP: ${preview.mp}`;
-        detailsDiv.innerHTML = '';
+        statsList.innerHTML = '';
+        const statEntries = [
+            ['HP', preview.hp],
+            ['MP', preview.mp],
+            ['STR', preview.stats.str],
+            ['DEX', preview.stats.dex],
+            ['VIT', preview.stats.vit],
+            ['AGI', preview.stats.agi],
+            ['INT', preview.stats.int],
+            ['MND', preview.stats.mnd],
+            ['CHR', preview.stats.chr]
+        ];
+        statEntries.forEach(([label, val]) => {
+            const li = document.createElement('li');
+            li.textContent = `${label}: ${val}`;
+            statsList.appendChild(li);
+        });
+        cityDiv.textContent = `Starting City: ${startingCities[raceSelect.value]}`;
+
+        traitsList.innerHTML = '';
+        abilitiesList.innerHTML = '';
         const job = jobs.find(j => j.name === jobSelect.value);
         if (job) {
-            const trait = job.traits[0];
-            const ability = job.abilities[0];
-            if (trait) detailsDiv.innerHTML += `Trait: ${trait.name} - ${trait.effect}<br>`;
-            if (ability) detailsDiv.innerHTML += `Ability: ${ability.name} - ${ability.effect}`;
+            (job.traits || []).forEach(t => {
+                const li = document.createElement('li');
+                li.innerHTML = `<span>${t.name}</span><span>-</span><span>${t.effect}</span>`;
+                traitsList.appendChild(li);
+            });
+            (job.abilities || []).forEach(a => {
+                const li = document.createElement('li');
+                li.innerHTML = `<span>${a.name}</span><span>-</span><span>${a.effect}</span>`;
+                abilitiesList.appendChild(li);
+            });
         }
     }
 


### PR DESCRIPTION
## Summary
- adjust fonts and button sizing responsively
- rework character creation layout to three columns
- add randomize button and display starting stats
- show job traits and abilities in creation screen
- space character profile sections better
- show recommended starting city when creating a character

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687be3927018832589a8600b15070052