### PR TITLE
Implement per-stat proficiency scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Open `index.html` in a browser. No build step is required.
   job and level.
 - Character equipment now tracks left and right rings and earrings as well as main and off-hand weapons.
 - A utility function can calculate a character's current stats factoring in race, job and equipment.
-- `updateDerivedStats()` computes HP, MP and status values using level-based formulas derived from race and job proficiencies.
+- `updateDerivedStats()` computes HP, MP and per-stat values using level-based formulas derived from race and job proficiencies. Each attribute (STR, DEX, VIT, AGI, INT, MND and CHR) scales individually.
 - Characters now store numeric scaling values derived from their race and job
   proficiencies. The `proficiencyScale` table maps letter grades to HP, MP and
   status base/scale numbers. These values are kept separately for race and job


### PR DESCRIPTION
## Summary
- compute proficiency scale values for every attribute in `buildScaleFields`
- derive STR/DEX/VIT/AGI/INT/MND/CHR values in `updateDerivedStats`
- update README to mention per-stat calculations

## Testing
- `node -e "require('./data/index.js'); console.log('loaded')"`

------
https://chatgpt.com/codex/tasks/task_e_687bec15429c8325962e20a590424c9b