### PR TITLE
Implement random name generation and character descriptions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -139,3 +139,14 @@ button:hover {
     margin-top: 20px;
 }
 
+.race-img, .job-img {
+    width: 150px;
+    height: auto;
+    display: block;
+    margin: 0 auto 10px auto;
+}
+
+.race-desc, .job-desc {
+    margin-bottom: 10px;
+}
+

--- a/data/descriptions.js
+++ b/data/descriptions.js
@@ -1,0 +1,49 @@
+export const raceInfo = {
+  Hume: {
+    description: 'Balanced humans able to excel in any job.',
+    image: 'https://via.placeholder.com/150?text=Hume'
+  },
+  Elvaan: {
+    description: 'Proud, tall warriors from San d\'Oria.',
+    image: 'https://via.placeholder.com/150?text=Elvaan'
+  },
+  Tarutaru: {
+    description: 'Small folk with a natural talent for magic.',
+    image: 'https://via.placeholder.com/150?text=Tarutaru'
+  },
+  Mithra: {
+    description: 'Agile feline hunters who favor dexterity.',
+    image: 'https://via.placeholder.com/150?text=Mithra'
+  },
+  Galka: {
+    description: 'Huge and powerful beings of great stamina.',
+    image: 'https://via.placeholder.com/150?text=Galka'
+  }
+};
+
+export const jobInfo = {
+  'Warrior': {
+    description: 'Front-line fighter skilled with many weapons.',
+    image: 'https://via.placeholder.com/150?text=Warrior'
+  },
+  'Monk': {
+    description: 'Master of martial arts and hand-to-hand combat.',
+    image: 'https://via.placeholder.com/150?text=Monk'
+  },
+  'White Mage': {
+    description: 'Expert in restorative and protective magic.',
+    image: 'https://via.placeholder.com/150?text=White+Mage'
+  },
+  'Black Mage': {
+    description: 'Caster of destructive elemental magic.',
+    image: 'https://via.placeholder.com/150?text=Black+Mage'
+  },
+  'Red Mage': {
+    description: 'Combines white and black magic with swordplay.',
+    image: 'https://via.placeholder.com/150?text=Red+Mage'
+  },
+  'Thief': {
+    description: 'Quick rogue adept at stealing and evasion.',
+    image: 'https://via.placeholder.com/150?text=Thief'
+  }
+};

--- a/data/index.js
+++ b/data/index.js
@@ -14,3 +14,5 @@ export {
   deleteCharacterSlot
 } from './characters.js';
 export { proficiencyScale, getScale } from './scales.js';
+export { names, randomName } from './names.js';
+export { raceInfo, jobInfo } from './descriptions.js';

--- a/data/names.js
+++ b/data/names.js
@@ -1,0 +1,30 @@
+export const names = {
+  Hume: {
+    Male: ['Aldo', 'Volker', 'Lucius', 'Gryff', 'Zeid'],
+    Female: ['Cornelia', 'Iroha', 'Lilisette', 'Prishe', 'Ulmia']
+  },
+  Elvaan: {
+    Male: ['Trion', 'Rahal', 'Halver', 'Valaineral', 'Camlann'],
+    Female: ['Curilla', 'Hinaree', 'Excenmille', 'Nanaa', 'Lehane']
+  },
+  Tarutaru: {
+    Male: ['Ajido-Marujido', 'Koru-Moru', 'Kupipi', 'Kukki-Chebukki'],
+    Female: ['Shantotto', 'Apururu', 'Koru-Moru', 'Kukki-Chebukki']
+  },
+  Mithra: {
+    Male: ['Raimbroy', 'Rycharde', 'Geru Vela'],
+    Female: ['Semih Lafihna', 'Ayame', 'Perih Vashai', 'Lerene']
+  },
+  Galka: {
+    Male: ['Zied', 'Gumbah', 'Cid', 'Naji', 'Azette'],
+    Female: ['Rongo-Nango', 'Kupipi'] // Galka rarely female
+  }
+};
+
+export function randomName(race = 'Hume', sex = 'Male') {
+  const list = (names[race] && names[race][sex]) || [];
+  if (list.length === 0) {
+    return `Adventurer`;
+  }
+  return list[Math.floor(Math.random() * list.length)];
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -11,6 +11,7 @@ import {
     loadCharacterSlot,
     deleteCharacterSlot
 } from '../data/index.js';
+import { randomName, raceInfo, jobInfo } from '../data/index.js';
 
 export function renderMainMenu() {
     const container = document.createElement('div');
@@ -151,9 +152,15 @@ function renderNewCharacterForm(root) {
     nameLabel.textContent = 'Name:';
     const nameInput = document.createElement('input');
     nameInput.type = 'text';
-    nameInput.value = `Adventurer ${characters.length + 1}`;
+    nameInput.value = randomName(raceNames[0], 'Male');
     nameField.appendChild(nameLabel);
     nameField.appendChild(nameInput);
+    const nameRand = document.createElement('button');
+    nameRand.textContent = 'Random Name';
+    nameRand.addEventListener('click', () => {
+        nameInput.value = randomName(raceSelect.value, sexSelect.value);
+    });
+    nameField.appendChild(nameRand);
     inputs.appendChild(nameField);
 
     const raceField = document.createElement('div');
@@ -207,6 +214,7 @@ function renderNewCharacterForm(root) {
         raceSelect.value = raceNames[Math.floor(Math.random() * raceNames.length)];
         jobSelect.value = baseJobNames[Math.floor(Math.random() * baseJobNames.length)];
         sexSelect.value = ['Male', 'Female'][Math.floor(Math.random() * 2)];
+        nameInput.value = randomName(raceSelect.value, sexSelect.value);
         updateInfo();
     });
     inputs.appendChild(randomBtn);
@@ -215,6 +223,14 @@ function renderNewCharacterForm(root) {
     // middle column: stats display
     const statsCol = document.createElement('div');
     statsCol.className = 'form-stats';
+
+    const raceImg = document.createElement('img');
+    raceImg.className = 'race-img';
+    statsCol.appendChild(raceImg);
+    const raceDesc = document.createElement('p');
+    raceDesc.className = 'race-desc';
+    statsCol.appendChild(raceDesc);
+
     const statsList = document.createElement('ul');
     statsList.className = 'stats-list';
     statsCol.appendChild(statsList);
@@ -226,6 +242,13 @@ function renderNewCharacterForm(root) {
     // right column: traits and abilities
     const infoCol = document.createElement('div');
     infoCol.className = 'form-traits';
+
+    const jobImg = document.createElement('img');
+    jobImg.className = 'job-img';
+    infoCol.appendChild(jobImg);
+    const jobDesc = document.createElement('p');
+    jobDesc.className = 'job-desc';
+    infoCol.appendChild(jobDesc);
 
     const traitsHeader = document.createElement('h4');
     traitsHeader.textContent = 'Traits';
@@ -254,6 +277,11 @@ function renderNewCharacterForm(root) {
             sexSelect.value
         );
         statsList.innerHTML = '';
+        raceImg.src = raceInfo[raceSelect.value]?.image || '';
+        raceDesc.textContent = raceInfo[raceSelect.value]?.description || '';
+        jobImg.src = jobInfo[jobSelect.value]?.image || '';
+        jobDesc.textContent = jobInfo[jobSelect.value]?.description || '';
+
         const statEntries = [
             ['HP', preview.hp],
             ['MP', preview.mp],


### PR DESCRIPTION
## Summary
- add lists of race-based names and a `randomName` helper
- include race and job descriptions with placeholder images
- expose new helpers through the data index
- display descriptions and images in the character creation form
- style character preview images

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687c6b6ddb508325bba3653d92d07f84