### PR TITLE
Improve randomize button and race descriptions

### DIFF
--- a/data/descriptions.js
+++ b/data/descriptions.js
@@ -1,49 +1,79 @@
 export const raceInfo = {
   Hume: {
-    description: 'Balanced humans able to excel in any job.',
+    description: 'The most balanced and adaptable race, Humes are similar to humans. They have average stats across the board and can excel in any job, making them the most versatile choice.',
     image: 'https://via.placeholder.com/150?text=Hume'
   },
   Elvaan: {
-    description: 'Proud, tall warriors from San d\'Oria.',
+    description: 'Tall, elegant, and noble, Elvaan hail from San d\u2019Oria. Known for their high Strength and Mind, they make excellent melee fighters or healers, but their lower Dexterity and Intelligence make them less suited for magic damage roles.',
     image: 'https://via.placeholder.com/150?text=Elvaan'
   },
   Tarutaru: {
-    description: 'Small folk with a natural talent for magic.',
+    description: 'Small, childlike beings from Windurst, Tarutaru possess great magical talent. They have high Intelligence and MP, making them ideal for mage jobs, but their low HP and Strength mean they are physically frail.',
     image: 'https://via.placeholder.com/150?text=Tarutaru'
   },
   Mithra: {
-    description: 'Agile feline hunters who favor dexterity.',
+    description: 'Agile and cat-like, Mithra are renowned for their quick reflexes and dexterity. They excel as Thieves, Rangers, and other jobs that benefit from high Agility, but their lower Vitality means less physical toughness.',
     image: 'https://via.placeholder.com/150?text=Mithra'
   },
   Galka: {
-    description: 'Huge and powerful beings of great stamina.',
+    description: 'Large, muscular, and beast-like, Galka have impressive Strength and Vitality. They are excellent tanks and damage dealers but have low MP and less aptitude for magic-based jobs.',
     image: 'https://via.placeholder.com/150?text=Galka'
   }
 };
 
 export const jobInfo = {
   'Warrior': {
-    description: 'Front-line fighter skilled with many weapons.',
+    description:
+      'Role: Frontline melee damage dealer and tank. ' +
+      'Skills: Proficient with many weapon types (axes, swords, great axes, great swords, polearms), moderate shield use. ' +
+      'Magic: None. ' +
+      'Gear: Heavy armor, shields, a wide variety of weapons. ' +
+      'History: Warriors are battle-hardened fighters, trained in both offense and defense. Historically, they serve as mercenaries, soldiers, and bodyguards across Vana\u2019diel. Their job abilities allow them to provoke enemies, enhance damage, and defend allies.',
     image: 'https://via.placeholder.com/150?text=Warrior'
   },
   'Monk': {
-    description: 'Master of martial arts and hand-to-hand combat.',
+    description:
+      'Role: Melee damage dealer specializing in hand-to-hand combat. ' +
+      'Skills: Hand-to-hand weapons, some staff use, high evasion and counterattack skills. ' +
+      'Magic: None. ' +
+      'Gear: Light armor, knuckles, claws, cesti. ' +
+      'History: Monks devote themselves to physical training and spiritual discipline. Drawing from ancient martial arts, they rely on raw power, relentless strikes, and endurance to overcome foes, making them formidable close-range fighters.',
     image: 'https://via.placeholder.com/150?text=Monk'
   },
   'White Mage': {
-    description: 'Expert in restorative and protective magic.',
+    description:
+      'Role: Primary healer and support. ' +
+      'Skills: Clubs and staves, healing magic, some enfeebling and enhancing spells. ' +
+      'Magic: Extensive White Magic, including powerful heals, status removal, buffs, and defensive spells. ' +
+      'Gear: Light armor (robes), staves, clubs. ' +
+      'History: White Mages serve as clerics and priests, channeling divine magic to heal and protect. Historically found in temples and among traveling healers, they are invaluable to any party for keeping allies alive and mitigating danger.',
     image: 'https://via.placeholder.com/150?text=White+Mage'
   },
   'Black Mage': {
-    description: 'Caster of destructive elemental magic.',
+    description:
+      'Role: Offensive caster specializing in elemental magic. ' +
+      'Skills: Staves and clubs, destructive black magic. ' +
+      'Magic: Extensive Black Magic, including elemental nukes, debuffs, and status effects. ' +
+      'Gear: Light armor (robes), staves, clubs. ' +
+      'History: Black Mages study the arcane arts to unleash fire, ice, lightning, and more upon their foes. Revered and feared for their destructive power, they come from traditions of ancient scholars and secretive magical orders.',
     image: 'https://via.placeholder.com/150?text=Black+Mage'
   },
   'Red Mage': {
-    description: 'Combines white and black magic with swordplay.',
+    description:
+      'Role: Versatile support, hybrid damage, and magic. ' +
+      'Skills: Swords, daggers, staves, both white and black magic, enfeebling and enhancing spells. ' +
+      'Magic: Limited White and Black Magic, excels at enfeebling (debuffing enemies) and support. ' +
+      'Gear: Light armor, swords, daggers, staves, unique ability to dual wield some weapons. ' +
+      'History: Red Mages are duelists and scholars, blending swordplay and spellcraft. Historically, they\u2019re adaptable adventurers and diplomats who walk both magical and martial paths, excelling in versatility.',
     image: 'https://via.placeholder.com/150?text=Red+Mage'
   },
   'Thief': {
-    description: 'Quick rogue adept at stealing and evasion.',
+    description:
+      'Role: Stealthy melee damage dealer, treasure hunter, enmity manipulator. ' +
+      'Skills: Daggers, swords, archery, evasion. ' +
+      'Magic: None. ' +
+      'Gear: Light armor, daggers, swords, ranged weapons. ' +
+      'History: Thieves are experts in agility, subterfuge, and treasure acquisition. Often coming from less savory backgrounds, their skills in sneaking, stealing, and striking quickly make them invaluable scouts and looters in any party.',
     image: 'https://via.placeholder.com/150?text=Thief'
   }
 };

--- a/js/ui.js
+++ b/js/ui.js
@@ -153,14 +153,9 @@ function renderNewCharacterForm(root) {
     const nameInput = document.createElement('input');
     nameInput.type = 'text';
     nameInput.value = randomName(raceNames[0], 'Male');
+    let customName = false;
     nameField.appendChild(nameLabel);
     nameField.appendChild(nameInput);
-    const nameRand = document.createElement('button');
-    nameRand.textContent = 'Random Name';
-    nameRand.addEventListener('click', () => {
-        nameInput.value = randomName(raceSelect.value, sexSelect.value);
-    });
-    nameField.appendChild(nameRand);
     inputs.appendChild(nameField);
 
     const raceField = document.createElement('div');
@@ -183,12 +178,26 @@ function renderNewCharacterForm(root) {
     const sexLabel = document.createElement('label');
     sexLabel.textContent = 'Sex:';
     const sexSelect = document.createElement('select');
-    ['Male', 'Female'].forEach(s => {
-        const opt = document.createElement('option');
-        opt.value = s;
-        opt.textContent = s;
-        sexSelect.appendChild(opt);
-    });
+    function updateSexOptions() {
+        const race = raceSelect.value;
+        const options = race === 'Galka'
+            ? ['Male']
+            : race === 'Mithra'
+                ? ['Female']
+                : ['Male', 'Female'];
+        const current = sexSelect.value;
+        sexSelect.innerHTML = '';
+        options.forEach(s => {
+            const opt = document.createElement('option');
+            opt.value = s;
+            opt.textContent = s;
+            sexSelect.appendChild(opt);
+        });
+        if (options.includes(current)) {
+            sexSelect.value = current;
+        }
+    }
+    updateSexOptions();
     sexField.appendChild(sexLabel);
     sexField.appendChild(sexSelect);
     inputs.appendChild(sexField);
@@ -213,23 +222,29 @@ function renderNewCharacterForm(root) {
     randomBtn.addEventListener('click', () => {
         raceSelect.value = raceNames[Math.floor(Math.random() * raceNames.length)];
         jobSelect.value = baseJobNames[Math.floor(Math.random() * baseJobNames.length)];
-        sexSelect.value = ['Male', 'Female'][Math.floor(Math.random() * 2)];
-        nameInput.value = randomName(raceSelect.value, sexSelect.value);
+        updateSexOptions();
+        const options = Array.from(sexSelect.options).map(o => o.value);
+        sexSelect.value = options[Math.floor(Math.random() * options.length)];
+        if (!customName) {
+            nameInput.value = randomName(raceSelect.value, sexSelect.value);
+        }
+        customName = false;
         updateInfo();
     });
     inputs.appendChild(randomBtn);
+    const raceDesc = document.createElement('p');
+    raceDesc.className = 'race-desc';
+    inputs.appendChild(raceDesc);
 
     form.appendChild(inputs);
     // middle column: stats display
+
     const statsCol = document.createElement('div');
     statsCol.className = 'form-stats';
 
     const raceImg = document.createElement('img');
     raceImg.className = 'race-img';
     statsCol.appendChild(raceImg);
-    const raceDesc = document.createElement('p');
-    raceDesc.className = 'race-desc';
-    statsCol.appendChild(raceDesc);
 
     const statsList = document.createElement('ul');
     statsList.className = 'stats-list';
@@ -246,9 +261,10 @@ function renderNewCharacterForm(root) {
     const jobImg = document.createElement('img');
     jobImg.className = 'job-img';
     infoCol.appendChild(jobImg);
+
     const jobDesc = document.createElement('p');
     jobDesc.className = 'job-desc';
-    infoCol.appendChild(jobDesc);
+    inputs.appendChild(jobDesc);
 
     const traitsHeader = document.createElement('h4');
     traitsHeader.textContent = 'Traits';
@@ -346,8 +362,17 @@ function renderNewCharacterForm(root) {
         }
     }
 
-    nameInput.addEventListener('input', updateInfo);
-    raceSelect.addEventListener('change', updateInfo);
+    nameInput.addEventListener('input', () => {
+        customName = true;
+        updateInfo();
+    });
+    raceSelect.addEventListener('change', () => {
+        updateSexOptions();
+        if (!customName) {
+            nameInput.value = randomName(raceSelect.value, sexSelect.value);
+        }
+        updateInfo();
+    });
     sexSelect.addEventListener('change', updateInfo);
     jobSelect.addEventListener('change', updateInfo);
     updateInfo();


### PR DESCRIPTION
## Summary
- remove dedicated random name button
- randomize button now keeps a custom name if one was typed
- display race description under the randomize button
- update all race descriptions
- limit sex options by race and randomize appropriately
- show job description under race description and expand job details

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d10e737488325882e726f53a4fa8e