### PR TITLE
Update character load workflow and layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -68,8 +68,10 @@ button:hover {
 .slot-entry {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    justify-content: flex-start;
     padding: 0 10px;
+    gap: 5px;
+    text-align: left;
 }
 
 .slot-label {
@@ -79,6 +81,16 @@ button:hover {
 
 .slot-entry button {
     margin-left: 5px;
+}
+
+#slot-container {
+    display: grid;
+    grid-template-columns: auto auto;
+    column-gap: 50px;
+    row-gap: 10px;
+    width: fit-content;
+    margin: 20px auto;
+    text-align: left;
 }
 
 /* Character creation layout */

--- a/data/characters.js
+++ b/data/characters.js
@@ -457,3 +457,7 @@ export async function loadCharacterFromFile() {
     return null;
   }
 }
+
+export function setActiveCharacter(character) {
+  activeCharacter = character;
+}

--- a/data/index.js
+++ b/data/index.js
@@ -13,7 +13,8 @@ export {
   loadCharacterSlot,
   deleteCharacterSlot,
   saveCharacterToFile,
-  loadCharacterFromFile
+  loadCharacterFromFile,
+  setActiveCharacter
 } from './characters.js';
 export { proficiencyScale, getScale } from './scales.js';
 export { names, randomName } from './names.js';

--- a/js/ui.js
+++ b/js/ui.js
@@ -9,7 +9,9 @@ import {
     createNewCharacter,
     deleteCharacterSlot,
     saveCharacterToFile,
-    loadCharacterFromFile
+    loadCharacterFromFile,
+    loadCharacterSlot,
+    setActiveCharacter
 } from '../data/index.js';
 import { randomName, raceInfo, jobInfo, cityImages } from '../data/index.js';
 
@@ -97,6 +99,7 @@ export function renderCharacterMenu(root) {
     root.appendChild(newBtn);
 
     const list = document.createElement('div');
+    list.id = 'slot-container';
     const maxSlots = 8;
     const slotCount = Math.min(Math.max(characters.length, 3), maxSlots);
     for (let i = 0; i < slotCount; i++) {
@@ -109,11 +112,19 @@ export function renderCharacterMenu(root) {
         entry.appendChild(label);
 
         const loadBtn = document.createElement('button');
-        loadBtn.textContent = 'Load';
-        loadBtn.addEventListener('click', async () => {
-            await loadCharacterFromFile();
-            renderCharacterMenu(root);
-        });
+        if (ch) {
+            loadBtn.textContent = 'Load';
+            loadBtn.addEventListener('click', () => {
+                setActiveCharacter(ch);
+                renderCharacterMenu(root);
+            });
+        } else {
+            loadBtn.textContent = 'Import';
+            loadBtn.addEventListener('click', async () => {
+                await loadCharacterFromFile();
+                renderCharacterMenu(root);
+            });
+        }
         entry.appendChild(loadBtn);
 
         const saveBtn = document.createElement('button');


### PR DESCRIPTION
## Summary
- tweak slot layout styles
- add `setActiveCharacter` helper
- support loading a save slot without invoking the file picker
- center save slot layout with two columns

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d342a1cd4832596baed40f658f04d