### PR TITLE
Consolidate travel into area screen

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -70,6 +70,12 @@ button:hover {
     margin-top: 20px;
 }
 
+.area-column {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
 .area-column ul {
     list-style: none;
     padding: 0;

--- a/data/locations.js
+++ b/data/locations.js
@@ -41,6 +41,30 @@ export const zonesByCity = {
       connectedAreas: ['Bastok Mines', 'Bastok Markets', 'Port Bastok'],
       pointsOfInterest: ['Mog House'],
       importantNPCs: []
+    },
+    {
+      name: 'Zeruhn Mines',
+      city: 'Bastok',
+      subAreas: [],
+      connectedAreas: ['Bastok Mines', 'North Gustaberg'],
+      pointsOfInterest: ['Training Grounds', 'Mine Shafts', 'Home Point Crystal'],
+      importantNPCs: []
+    },
+    {
+      name: 'North Gustaberg',
+      city: 'Bastok',
+      subAreas: [],
+      connectedAreas: ['Bastok Mines', 'South Gustaberg', 'Konschtat Highlands', 'Zeruhn Mines'],
+      pointsOfInterest: ['Outpost', 'Dangruf Wadi Entrance', 'Home Point Crystal'],
+      importantNPCs: []
+    },
+    {
+      name: 'South Gustaberg',
+      city: 'Bastok',
+      subAreas: [],
+      connectedAreas: ['Bastok Markets', 'North Gustaberg', 'Konschtat Highlands'],
+      pointsOfInterest: ['Outpost', 'Selt Steel Mines', 'Home Point Crystal'],
+      importantNPCs: []
     }
   ],
   "San d'Oria": [
@@ -83,6 +107,22 @@ export const zonesByCity = {
       connectedAreas: ["Northern San d'Oria", "Southern San d'Oria", "Port San d'Oria"],
       pointsOfInterest: ['Mog House'],
       importantNPCs: []
+    },
+    {
+      name: 'West Ronfaure',
+      city: "San d'Oria",
+      subAreas: [],
+      connectedAreas: ["Northern San d'Oria", 'East Ronfaure', 'La Theine Plateau'],
+      pointsOfInterest: ['Outpost', 'Canyon', 'Home Point Crystal'],
+      importantNPCs: []
+    },
+    {
+      name: 'East Ronfaure',
+      city: "San d'Oria",
+      subAreas: [],
+      connectedAreas: ["Southern San d'Oria", 'West Ronfaure', 'La Theine Plateau'],
+      pointsOfInterest: ['Outpost', 'Orc Camps', 'Home Point Crystal'],
+      importantNPCs: []
     }
   ],
   Windurst: [
@@ -114,7 +154,7 @@ export const zonesByCity = {
       name: 'Port Windurst',
       city: 'Windurst',
       subAreas: [],
-      connectedAreas: ['Windurst Waters'],
+      connectedAreas: ['Windurst Waters', 'West Sarutabaruta'],
       pointsOfInterest: ['Ferry to Mhaura', 'Chocobo Stables', 'Fishing Supplies Shop', 'Item Shop', 'Airship Dock', 'Home Point Crystal'],
       importantNPCs: ['Regional Merchant', 'Ferry Ticket Seller']
     },
@@ -133,6 +173,22 @@ export const zonesByCity = {
       connectedAreas: ['Windurst Waters', 'Windurst Woods', 'Port Windurst'],
       pointsOfInterest: ['Mog House'],
       importantNPCs: []
+    },
+    {
+      name: 'East Sarutabaruta',
+      city: 'Windurst',
+      subAreas: [],
+      connectedAreas: ['Windurst Waters', 'Windurst Woods', 'Tahrongi Canyon'],
+      pointsOfInterest: ['Outpost', 'Crag of Mea', 'Home Point Crystal'],
+      importantNPCs: []
+    },
+    {
+      name: 'West Sarutabaruta',
+      city: 'Windurst',
+      subAreas: [],
+      connectedAreas: ['Port Windurst', 'Tahrongi Canyon'],
+      pointsOfInterest: ['Outpost', 'Giddeus Entrance', 'Home Point Crystal'],
+      importantNPCs: []
     }
   ],
   Jeuno: [
@@ -140,7 +196,7 @@ export const zonesByCity = {
       name: 'Lower Jeuno',
       city: 'Jeuno',
       subAreas: [],
-      connectedAreas: ['Upper Jeuno', 'Port Jeuno', 'Qufim Island'],
+      connectedAreas: ['Upper Jeuno', 'Port Jeuno', 'Qufim Island', 'Rolanberry Fields'],
       pointsOfInterest: ['Auction House', 'Mog House', 'Rental House', 'Chocobo Stables', 'General Goods Shop', 'Armor Shop', 'Weapon Shop', 'Home Point Crystal'],
       importantNPCs: ['Fame/Mission/Quest NPCs', 'Outpost Warper', 'Regional Merchant']
     },
@@ -148,7 +204,7 @@ export const zonesByCity = {
       name: 'Upper Jeuno',
       city: 'Jeuno',
       subAreas: [],
-      connectedAreas: ['Lower Jeuno', "Ru'Lude Gardens"],
+      connectedAreas: ['Lower Jeuno', "Ru'Lude Gardens", 'Battalia Downs'],
       pointsOfInterest: ['Airship Dock', 'Magic Shop', 'Item Shop', 'Armor Shop', 'Weapon Shop', 'Consumable Shop', 'Home Point Crystal'],
       importantNPCs: ['Mission/Quest/Event NPCs', 'Regional Merchant']
     },
@@ -156,7 +212,7 @@ export const zonesByCity = {
       name: 'Port Jeuno',
       city: 'Jeuno',
       subAreas: [],
-      connectedAreas: ['Lower Jeuno'],
+      connectedAreas: ['Lower Jeuno', 'Sauromugue Champaign'],
       pointsOfInterest: ['Ferry to Selbina', 'Ferry to Mhaura', 'Auction House', 'Fishing Shop', 'Item Shop', 'Armor Shop', 'Weapon Shop', 'Home Point Crystal'],
       importantNPCs: ['Outpost Warper', 'Regional Merchant']
     },
@@ -174,6 +230,38 @@ export const zonesByCity = {
       subAreas: [],
       connectedAreas: ['Lower Jeuno', 'Upper Jeuno', 'Port Jeuno', "Ru'Lude Gardens"],
       pointsOfInterest: ['Mog House'],
+      importantNPCs: []
+    },
+    {
+      name: 'Qufim Island',
+      city: 'Jeuno',
+      subAreas: [],
+      connectedAreas: ['Lower Jeuno'],
+      pointsOfInterest: ['Outpost', "Delkfutt's Tower", 'Home Point Crystal'],
+      importantNPCs: []
+    },
+    {
+      name: 'Rolanberry Fields',
+      city: 'Jeuno',
+      subAreas: [],
+      connectedAreas: ['Lower Jeuno', 'Sauromugue Champaign', 'Battalia Downs'],
+      pointsOfInterest: ['Outpost', 'Crag of Mea', 'Home Point Crystal'],
+      importantNPCs: []
+    },
+    {
+      name: 'Sauromugue Champaign',
+      city: 'Jeuno',
+      subAreas: [],
+      connectedAreas: ['Port Jeuno', 'Rolanberry Fields'],
+      pointsOfInterest: ['Outpost', 'Crag of Dem', 'Home Point Crystal'],
+      importantNPCs: []
+    },
+    {
+      name: 'Battalia Downs',
+      city: 'Jeuno',
+      subAreas: [],
+      connectedAreas: ['Upper Jeuno', 'Rolanberry Fields'],
+      pointsOfInterest: ['Outpost', 'Crag of Holla', 'Home Point Crystal'],
       importantNPCs: []
     }
   ]

--- a/js/ui.js
+++ b/js/ui.js
@@ -37,15 +37,8 @@ export function renderMainMenu() {
         renderAreaScreen(container);
     });
 
-    const travelMainBtn = document.createElement('button');
-    travelMainBtn.textContent = 'Travel';
-    travelMainBtn.addEventListener('click', () => {
-        renderTravelScreen(container);
-    });
-
     menu.appendChild(charactersBtn);
     menu.appendChild(areaBtn);
-    menu.appendChild(travelMainBtn);
 
     container.appendChild(title);
     container.appendChild(menu);
@@ -509,40 +502,87 @@ export function renderAreaScreen(root) {
         const grid = document.createElement('div');
         grid.id = 'area-grid';
 
-        const poiCol = document.createElement('div');
-        poiCol.className = 'area-column';
-        const poiHeader = document.createElement('h3');
-        poiHeader.textContent = 'Points of Interest';
-        poiCol.appendChild(poiHeader);
-        const poiList = document.createElement('ul');
-        loc.pointsOfInterest.forEach(p => {
+        const travelCol = document.createElement('div');
+        travelCol.className = 'area-column';
+        const travelHeader = document.createElement('h3');
+        travelHeader.textContent = 'Travel';
+        travelCol.appendChild(travelHeader);
+        const travelList = document.createElement('ul');
+
+        const travelKeywords = /(airship|ferry|chocobo|home point|gate|dock|boat)/i;
+        const travelPOIs = loc.pointsOfInterest.filter(p => travelKeywords.test(p));
+
+        loc.connectedAreas.forEach(area => {
+            const li = document.createElement('li');
+            const btn = document.createElement('button');
+            btn.textContent = area;
+            btn.addEventListener('click', () => {
+                activeCharacter.currentLocation = area;
+                renderAreaScreen(root);
+            });
+            li.appendChild(btn);
+            travelList.appendChild(li);
+        });
+
+        travelPOIs.forEach(p => {
             const li = document.createElement('li');
             const btn = document.createElement('button');
             btn.textContent = p;
             btn.addEventListener('click', () => openMenu(p));
             li.appendChild(btn);
-            poiList.appendChild(li);
+            travelList.appendChild(li);
         });
-        poiCol.appendChild(poiList);
+        travelCol.appendChild(travelList);
 
-        const npcCol = document.createElement('div');
-        npcCol.className = 'area-column';
-        const npcHeader = document.createElement('h3');
-        npcHeader.textContent = 'NPCs';
-        npcCol.appendChild(npcHeader);
-        const npcList = document.createElement('ul');
+        const marketCol = document.createElement('div');
+        marketCol.className = 'area-column';
+        const marketHeader = document.createElement('h3');
+        marketHeader.textContent = 'Marketplace';
+        marketCol.appendChild(marketHeader);
+        const marketList = document.createElement('ul');
+
+        const marketKeywords = /(shop|store|auction|guild|merchant|market)/i;
+        const marketPOIs = loc.pointsOfInterest.filter(p => marketKeywords.test(p) && !travelPOIs.includes(p));
+
+        marketPOIs.forEach(p => {
+            const li = document.createElement('li');
+            const btn = document.createElement('button');
+            btn.textContent = p;
+            btn.addEventListener('click', () => openMenu(p));
+            li.appendChild(btn);
+            marketList.appendChild(li);
+        });
+        marketCol.appendChild(marketList);
+
+        const otherCol = document.createElement('div');
+        otherCol.className = 'area-column';
+        const otherHeader = document.createElement('h3');
+        otherHeader.textContent = 'Other';
+        otherCol.appendChild(otherHeader);
+        const otherList = document.createElement('ul');
+
+        loc.pointsOfInterest.forEach(p => {
+            if (travelPOIs.includes(p) || marketPOIs.includes(p)) return;
+            const li = document.createElement('li');
+            const btn = document.createElement('button');
+            btn.textContent = p;
+            btn.addEventListener('click', () => openMenu(p));
+            li.appendChild(btn);
+            otherList.appendChild(li);
+        });
         loc.importantNPCs.forEach(n => {
             const li = document.createElement('li');
             const btn = document.createElement('button');
             btn.textContent = n;
             btn.addEventListener('click', () => openMenu(n));
             li.appendChild(btn);
-            npcList.appendChild(li);
+            otherList.appendChild(li);
         });
-        npcCol.appendChild(npcList);
+        otherCol.appendChild(otherList);
 
-        grid.appendChild(poiCol);
-        grid.appendChild(npcCol);
+        grid.appendChild(travelCol);
+        grid.appendChild(marketCol);
+        grid.appendChild(otherCol);
         root.appendChild(grid);
     }
 


### PR DESCRIPTION
## Summary
- remove Travel button from main menu
- support three columns in area view
- add Travel, Marketplace, and Other sections
- keep buttons vertically aligned
- add adjacent zone data for areas around starting cities and Jeuno
- add Rolanberry Fields, Sauromugue Champaign, and Battalia Downs connected to Jeuno
- fix Sauromugue Champaign link to Port Jeuno

## Testing
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_687dba1038848325960dfa6e8d0daa87