### PR TITLE
Add encounter rate system

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ Open `index.html` in a browser. No build step is required.
 - Paladin and Bard data has been confirmed, with `verified.traits = true` and `verified.abilities = true` for both jobs.
 - Initial bestiary data lists low-level monsters for zones adjacent to the three starting cities.
 - `experienceForKill(level, targetLevel)` replicates FFXI's EXP table including level difference adjustments.
+- Basic encounter simulation using `walkAcrossZone()` and `rollForEncounter()` with level-based aggro rates.

--- a/data/characters.js
+++ b/data/characters.js
@@ -76,6 +76,7 @@ export const characters = [
     raceMP: 0,
     jobMP: 0,
     sJobMP: 0,
+    travel: null,
     equipment: {
       head: null,
       body: null,
@@ -125,6 +126,7 @@ export const characters = [
     raceMP: 0,
     jobMP: 0,
     sJobMP: 0,
+    travel: null,
     equipment: {
       head: null,
       body: null,
@@ -181,6 +183,7 @@ export function createCharacterObject(name, job, race, sex = 'Male') {
     raceMP: 0,
     jobMP: 0,
     sJobMP: 0,
+    travel: null,
     equipment: {
       head: null,
       body: null,

--- a/data/index.js
+++ b/data/index.js
@@ -22,3 +22,13 @@ export { raceInfo, jobInfo, cityImages } from './descriptions.js';
 export { cityList, zonesByCity, locations, zoneNames } from './locations.js';
 export { bestiaryByZone, allMonsters } from './bestiary.js';
 export { experienceTable, experienceForKill } from './experience.js';
+export {
+  parseLevel,
+  conLevel,
+  encounterChance,
+  getAggressiveMonsters,
+  baseEncounterChanceForZone,
+  getZoneTravelTurns,
+  rollForEncounter,
+  walkAcrossZone
+} from '../js/encounter.js';

--- a/data/locations.js
+++ b/data/locations.js
@@ -6,7 +6,7 @@ export const zonesByCity = {
       name: 'Bastok Mines',
       city: 'Bastok',
       subAreas: [],
-      connectedAreas: ['Bastok Markets', 'Metalworks', 'Zeruhn Mines', 'North Gustaberg', 'Residential Area'],
+      connectedAreas: ['Bastok Markets', 'Metalworks', 'Zeruhn Mines', 'North Gustaberg', 'Bastok Residential Area'],
       pointsOfInterest: ['Mog House', 'Mining Guild', 'Swordsmith Shop', 'General Goods Shop', 'Food Shop', 'Home Point Crystal'],
       importantNPCs: ['Gate Guard']
     },
@@ -14,7 +14,7 @@ export const zonesByCity = {
       name: 'Bastok Markets',
       city: 'Bastok',
       subAreas: [],
-      connectedAreas: ['Bastok Mines', 'Port Bastok', 'South Gustaberg', 'Residential Area'],
+      connectedAreas: ['Bastok Mines', 'Port Bastok', 'South Gustaberg', 'Bastok Residential Area'],
       pointsOfInterest: ['Auction House', 'Mog House', 'Rental House', "Goldsmiths' Guild", "Blacksmiths' Guild", 'Arms & Armor Shop', 'General Goods Shop', 'Item Shop', 'Tenshodo Entrance', 'Chocobo Stables', 'Home Point Crystal'],
       importantNPCs: ['Gate Guard', 'Regional Merchant']
     },
@@ -22,7 +22,7 @@ export const zonesByCity = {
       name: 'Port Bastok',
       city: 'Bastok',
       subAreas: [],
-      connectedAreas: ['Bastok Markets', 'Residential Area'],
+      connectedAreas: ['Bastok Markets', 'Bastok Residential Area'],
       pointsOfInterest: ['Airship Dock', 'Chocobo Stables', 'Fishing Shop', 'Ferry to Selbina', 'Home Point Crystal'],
       importantNPCs: ['Gate Guard', 'Regional Merchant']
     },
@@ -35,7 +35,7 @@ export const zonesByCity = {
       importantNPCs: []
     },
     {
-      name: 'Residential Area',
+      name: 'Bastok Residential Area',
       city: 'Bastok',
       subAreas: [],
       connectedAreas: ['Bastok Mines', 'Bastok Markets', 'Port Bastok'],
@@ -96,7 +96,7 @@ export const zonesByCity = {
       name: "Northern San d'Oria",
       city: "San d'Oria",
       subAreas: [],
-      connectedAreas: ["Southern San d'Oria", "Port San d'Oria", "Château d'Oraguille", 'West Ronfaure', 'Residential Area'],
+      connectedAreas: ["Southern San d'Oria", "Port San d'Oria", "Château d'Oraguille", 'West Ronfaure', "San d'Oria Residential Area"],
       pointsOfInterest: ['Auction House', 'Mog House', 'Rental House', 'Armor Shop', 'Weapon Shop', 'Consumable Shop', 'Item Shop', 'Chocobo Stables', 'Home Point Crystal'],
       importantNPCs: ['Gate Guard', 'Mission/Fame NPCs', 'Outpost Warper', 'Regional Merchant']
     },
@@ -104,7 +104,7 @@ export const zonesByCity = {
       name: "Southern San d'Oria",
       city: "San d'Oria",
       subAreas: [],
-      connectedAreas: ["Northern San d'Oria", 'East Ronfaure', 'Residential Area'],
+      connectedAreas: ["Northern San d'Oria", 'East Ronfaure', "San d'Oria Residential Area"],
       pointsOfInterest: ["Carpenter's Guild", "Blacksmith's Guild", 'Food Shop', 'Arrow Shop', 'Potion Shop', 'Armor Shop', 'Sword Shop', 'Home Point Crystal'],
       importantNPCs: ['Gate Guard', 'Quest Giver NPCs', 'Regional Merchant']
     },
@@ -112,7 +112,7 @@ export const zonesByCity = {
       name: "Port San d'Oria",
       city: "San d'Oria",
       subAreas: [],
-      connectedAreas: ["Northern San d'Oria", 'Residential Area'],
+      connectedAreas: ["Northern San d'Oria", "San d'Oria Residential Area"],
       pointsOfInterest: ['Airship Dock', 'Chocobo Stables', 'Fishing Guild', 'Item Shop', 'Home Point Crystal', 'Ferry to Mhaura'],
       importantNPCs: ['Gate Guard', 'Ferry Ticket Seller', 'Regional Merchant']
     },
@@ -125,7 +125,7 @@ export const zonesByCity = {
       importantNPCs: []
     },
     {
-      name: 'Residential Area',
+      name: "San d'Oria Residential Area",
       city: "San d'Oria",
       subAreas: [],
       connectedAreas: ["Northern San d'Oria", "Southern San d'Oria", "Port San d'Oria"],
@@ -162,7 +162,7 @@ export const zonesByCity = {
       name: 'Windurst Waters',
       city: 'Windurst',
       subAreas: [],
-      connectedAreas: ['Windurst Walls', 'Windurst Woods', 'Port Windurst', 'East Sarutabaruta', 'Residential Area'],
+      connectedAreas: ['Windurst Walls', 'Windurst Woods', 'Port Windurst', 'East Sarutabaruta', 'Windurst Residential Area'],
       pointsOfInterest: ['Auction House', 'Mog House', 'Rental House', 'Cooking Guild', "Fisherman's Guild", 'General Store', 'Food Shop', 'Scroll Shop', 'Item Shop', 'Chocobo Stables', 'Home Point Crystal'],
       importantNPCs: ['Gate Guard', 'Mission/Quest NPCs', 'Outpost Warper', 'Regional Merchant']
     },
@@ -170,7 +170,7 @@ export const zonesByCity = {
       name: 'Windurst Woods',
       city: 'Windurst',
       subAreas: [],
-      connectedAreas: ['Windurst Waters', 'Port Windurst', 'East Sarutabaruta', 'Residential Area'],
+      connectedAreas: ['Windurst Waters', 'Port Windurst', 'East Sarutabaruta', 'Windurst Residential Area'],
       pointsOfInterest: ['Clothcraft Guild', "Boneworker's Guild", 'Dagger Shop', 'Staff Shop', 'Magic Shop', 'Guild Shop', 'Alchemy Shop', 'Consumable Shop', 'Home Point Crystal'],
       importantNPCs: ['Gate Guard', 'Fame/Quest/Event NPCs', 'Regional Merchant']
     },
@@ -186,7 +186,7 @@ export const zonesByCity = {
       name: 'Port Windurst',
       city: 'Windurst',
       subAreas: [],
-      connectedAreas: ['Windurst Waters', 'West Sarutabaruta', 'Windurst Woods', 'Residential Area'],
+      connectedAreas: ['Windurst Waters', 'West Sarutabaruta', 'Windurst Woods', 'Windurst Residential Area'],
       pointsOfInterest: ['Ferry to Mhaura', 'Chocobo Stables', 'Fishing Supplies Shop', 'Item Shop', 'Airship Dock', 'Home Point Crystal'],
       importantNPCs: ['Regional Merchant', 'Ferry Ticket Seller']
     },
@@ -199,7 +199,7 @@ export const zonesByCity = {
       importantNPCs: []
     },
     {
-      name: 'Residential Area',
+      name: 'Windurst Residential Area',
       city: 'Windurst',
       subAreas: [],
       connectedAreas: ['Windurst Waters', 'Windurst Woods', 'Port Windurst'],
@@ -252,7 +252,7 @@ export const zonesByCity = {
       name: 'Lower Jeuno',
       city: 'Jeuno',
       subAreas: [],
-      connectedAreas: ['Upper Jeuno', 'Port Jeuno', 'Qufim Island', 'Rolanberry Fields', 'Residential Area'],
+      connectedAreas: ['Upper Jeuno', 'Port Jeuno', 'Qufim Island', 'Rolanberry Fields', 'Jeuno Residential Area'],
       pointsOfInterest: ['Auction House', 'Mog House', 'Rental House', 'Chocobo Stables', 'General Goods Shop', 'Armor Shop', 'Weapon Shop', 'Home Point Crystal'],
       importantNPCs: ['Fame/Mission/Quest NPCs', 'Outpost Warper', 'Regional Merchant']
     },
@@ -260,7 +260,7 @@ export const zonesByCity = {
       name: 'Upper Jeuno',
       city: 'Jeuno',
       subAreas: [],
-      connectedAreas: ['Lower Jeuno', "Ru'Lude Gardens", 'Battalia Downs', 'Residential Area'],
+      connectedAreas: ['Lower Jeuno', "Ru'Lude Gardens", 'Battalia Downs', 'Jeuno Residential Area'],
       pointsOfInterest: ['Airship Dock', 'Magic Shop', 'Item Shop', 'Armor Shop', 'Weapon Shop', 'Consumable Shop', 'Home Point Crystal'],
       importantNPCs: ['Mission/Quest/Event NPCs', 'Regional Merchant']
     },
@@ -268,7 +268,7 @@ export const zonesByCity = {
       name: 'Port Jeuno',
       city: 'Jeuno',
       subAreas: [],
-      connectedAreas: ['Lower Jeuno', 'Sauromugue Champaign', 'Residential Area'],
+      connectedAreas: ['Lower Jeuno', 'Sauromugue Champaign', 'Jeuno Residential Area'],
       pointsOfInterest: ['Ferry to Selbina', 'Ferry to Mhaura', 'Auction House', 'Fishing Shop', 'Item Shop', 'Armor Shop', 'Weapon Shop', 'Home Point Crystal'],
       importantNPCs: ['Outpost Warper', 'Regional Merchant']
     },
@@ -276,12 +276,12 @@ export const zonesByCity = {
       name: "Ru'Lude Gardens",
       city: 'Jeuno',
       subAreas: [],
-      connectedAreas: ['Upper Jeuno', 'Residential Area'],
+      connectedAreas: ['Upper Jeuno', 'Jeuno Residential Area'],
       pointsOfInterest: ['Home Point Crystal'],
       importantNPCs: ['Embassy/Mission NPCs', 'Event/High-Rank/Quest NPCs']
     },
     {
-      name: 'Residential Area',
+      name: 'Jeuno Residential Area',
       city: 'Jeuno',
       subAreas: [],
       connectedAreas: ['Lower Jeuno', 'Upper Jeuno', 'Port Jeuno', "Ru'Lude Gardens"],

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -1,0 +1,86 @@
+export function parseLevel(level) {
+  if (typeof level === 'number') return level;
+  if (!level) return 1;
+  if (level.includes('-')) {
+    const [min, max] = level.split('-').map(Number);
+    return (min + max) / 2;
+  }
+  return Number(level);
+}
+
+export function conLevel(playerLevel, monsterLevel) {
+  const diff = monsterLevel - playerLevel;
+  if (diff <= -6) return 'Too Weak';
+  if (diff <= -4) return 'Easy Prey';
+  if (diff <= -1) return 'Decent Challenge';
+  if (diff === 0) return 'Even Match';
+  if (diff === 1) return 'Tough';
+  if (diff === 2) return 'Very Tough';
+  return 'Incredibly Tough';
+}
+
+export function encounterChance(playerLevel, monsterLevel) {
+  const diff = monsterLevel - playerLevel;
+  if (diff <= -6) return 0; // too weak
+  if (diff <= -1) return 0.2; // easy prey / decent challenge
+  if (diff === 0) return 0.5; // even match
+  if (diff === 1) return 0.7; // tough
+  if (diff === 2) return 0.9; // very tough
+  return 1; // incredibly tough
+}
+
+import { bestiaryByZone } from '../data/bestiary.js';
+import { locations } from '../data/locations.js';
+
+export function getAggressiveMonsters(zone) {
+  const list = bestiaryByZone[zone] || [];
+  return list.filter(m => m.aggressive);
+}
+
+export function baseEncounterChanceForZone(playerLevel, zone) {
+  const aggressive = getAggressiveMonsters(zone);
+  let maxChance = 0;
+  for (const m of aggressive) {
+    const lvl = parseLevel(m.level);
+    const chance = encounterChance(playerLevel, lvl);
+    if (chance > maxChance) maxChance = chance;
+  }
+  return maxChance;
+}
+
+export function getZoneTravelTurns(zone) {
+  const info = locations.find(l => l.name === zone);
+  return info && info.travelTurns ? info.travelTurns : 10;
+}
+
+export function rollForEncounter(character, zone, options = {}) {
+  const usingMount = !!options.mount;
+  const baseChance = baseEncounterChanceForZone(character.level, zone);
+  const chance = Math.max(0, baseChance - (usingMount ? 0.2 : 0));
+  if (Math.random() < chance) {
+    const mobs = getAggressiveMonsters(zone);
+    if (mobs.length) {
+      const mob = mobs[Math.floor(Math.random() * mobs.length)];
+      return mob;
+    }
+  }
+  return null;
+}
+
+export function walkAcrossZone(character, zone, options = {}) {
+  const usingMount = !!options.mount;
+  const turns = Math.ceil(getZoneTravelTurns(zone) / (usingMount ? 2 : 1));
+  const baseChance = baseEncounterChanceForZone(character.level, zone);
+  const chance = Math.max(0, baseChance - (usingMount ? 0.2 : 0));
+  const encounters = [];
+  for (let t = 1; t <= turns; t++) {
+    if (Math.random() < chance) {
+      const mobs = getAggressiveMonsters(zone);
+      if (mobs.length) {
+        const mob = mobs[Math.floor(Math.random() * mobs.length)];
+        encounters.push({ turn: t, monster: mob.name });
+      }
+    }
+  }
+  return { turns, encounters };
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -14,7 +14,7 @@ import {
     setActiveCharacter,
     locations
 } from '../data/index.js';
-import { randomName, raceInfo, jobInfo, cityImages } from '../data/index.js';
+import { randomName, raceInfo, jobInfo, cityImages, getZoneTravelTurns, rollForEncounter } from '../data/index.js';
 
 export function renderMainMenu() {
     const container = document.createElement('div');
@@ -515,9 +515,24 @@ export function renderAreaScreen(root) {
         loc.connectedAreas.forEach(area => {
             const li = document.createElement('li');
             const btn = document.createElement('button');
-            btn.textContent = area;
+            const total = getZoneTravelTurns(area);
+            const travel = activeCharacter.travel &&
+                activeCharacter.travel.start === loc.name &&
+                activeCharacter.travel.destination === area
+                ? activeCharacter.travel.remaining
+                : total;
+            btn.textContent = `${area} (${travel}/${total})`;
             btn.addEventListener('click', () => {
-                activeCharacter.currentLocation = area;
+                if (!activeCharacter.travel || activeCharacter.travel.start !== loc.name || activeCharacter.travel.destination !== area) {
+                    activeCharacter.travel = { start: loc.name, destination: area, remaining: total, total };
+                }
+                const mob = rollForEncounter(activeCharacter, loc.name);
+                if (mob) alert(`A wild ${mob.name} appears!`);
+                activeCharacter.travel.remaining -= 1;
+                if (activeCharacter.travel.remaining <= 0) {
+                    activeCharacter.currentLocation = area;
+                    activeCharacter.travel = null;
+                }
                 renderAreaScreen(root);
             });
             li.appendChild(btn);


### PR DESCRIPTION
## Summary
- implement base encounter calculations and zone travel helper
- export new helpers
- document basic encounter simulation in README
- Implement travel turns with encounter checks

## Testing
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_687e3db69bcc832592eb9109957439a1