### PR TITLE
Add equipment damage stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ Open `index.html` in a browser. No build step is required.
   details with an initiative roll to decide who acts first.
 - City vendors now sell basic weapons, armor, scrolls and consumables at
   canonical prices. Stackable items include a quantity selector when purchasing.
+- Weapon and armor entries include damage or defense values based on
+  early-game FFXI stats.
+- The main menu now includes an Equipment button that lists currently
+  equipped items along with empty slots.

--- a/css/style.css
+++ b/css/style.css
@@ -277,3 +277,14 @@ body.portrait .character-form {
     width: 60px;
 }
 
+.equipment-list {
+    list-style: none;
+    padding: 0;
+    margin-top: 20px;
+}
+
+.equipment-list li {
+    margin-top: 4px;
+    text-align: left;
+}
+

--- a/data/vendors.js
+++ b/data/vendors.js
@@ -1,7 +1,27 @@
 export const items = {
-  bronzeDagger: { name: 'Bronze Dagger', price: 140, stack: 1, description: 'A small dagger forged from bronze.' },
-  bronzeSword: { name: 'Bronze Sword', price: 240, stack: 1, description: 'A simple bronze sword.' },
-  leatherVest: { name: 'Leather Vest', price: 604, stack: 1, description: 'Basic leather armor for the body.' },
+  bronzeDagger: {
+    name: 'Bronze Dagger',
+    price: 140,
+    stack: 1,
+    description: 'A small dagger forged from bronze.',
+    damage: 3,
+    delay: 183
+  },
+  bronzeSword: {
+    name: 'Bronze Sword',
+    price: 240,
+    stack: 1,
+    description: 'A simple bronze sword.',
+    damage: 6,
+    delay: 231
+  },
+  leatherVest: {
+    name: 'Leather Vest',
+    price: 604,
+    stack: 1,
+    description: 'Basic leather armor for the body.',
+    defense: 7
+  },
   bronzeIngot: { name: 'Bronze Ingot', price: 120, stack: 12, description: 'A bar of bronze used in crafting.' },
   potion: { name: 'Potion', price: 300, stack: 12, description: 'Restores a small amount of HP.' },
   antidote: { name: 'Antidote', price: 60, stack: 12, description: 'Cures poison.' },

--- a/js/ui.js
+++ b/js/ui.js
@@ -43,8 +43,14 @@ export function renderMainMenu() {
         const menu = renderMainMenu();
         container.replaceWith(menu);
     });
+    const equipBtn = document.createElement('button');
+    equipBtn.textContent = 'Equipment';
+    equipBtn.addEventListener('click', () => {
+        renderEquipmentScreen(container);
+    });
     menu.appendChild(areaBtn);
     menu.appendChild(restBtn);
+    menu.appendChild(equipBtn);
 
     container.appendChild(title);
     container.appendChild(menu);
@@ -921,6 +927,43 @@ export function renderVendorScreen(root, vendor) {
     const back = document.createElement('button');
     back.textContent = 'Back';
     back.addEventListener('click', () => renderAreaScreen(root));
+    root.appendChild(back);
+}
+
+export function renderEquipmentScreen(root) {
+    root.innerHTML = '';
+    const title = document.createElement('h2');
+    title.textContent = 'Equipment';
+    root.appendChild(title);
+    if (!activeCharacter) {
+        const p = document.createElement('p');
+        p.textContent = 'No active character';
+        root.appendChild(p);
+    } else {
+        const list = document.createElement('ul');
+        list.className = 'equipment-list';
+        const slots = {
+            head: 'Head', body: 'Body', hands: 'Hands', legs: 'Legs', feet: 'Feet',
+            mainHand: 'Main Hand', offHand: 'Off Hand', ranged: 'Ranged', ammo: 'Ammo',
+            back: 'Back', waist: 'Waist', neck: 'Neck',
+            leftEar: 'Left Ear', rightEar: 'Right Ear',
+            leftRing: 'Left Ring', rightRing: 'Right Ring'
+        };
+        for (const key of Object.keys(slots)) {
+            const li = document.createElement('li');
+            const itemId = activeCharacter.equipment?.[key];
+            const item = items[itemId];
+            li.textContent = `${slots[key]}: ${item ? item.name : 'Empty'}`;
+            list.appendChild(li);
+        }
+        root.appendChild(list);
+    }
+    const back = document.createElement('button');
+    back.textContent = 'Back';
+    back.addEventListener('click', () => {
+        const menu = renderMainMenu();
+        root.replaceWith(menu);
+    });
     root.appendChild(back);
 }
 


### PR DESCRIPTION
## Summary
- add damage and delay to bronze weapons
- add defense value to leather vest
- document that equipment now includes basic stats

## Testing
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_687eec1cce8c8325a9681a4be2603130