### PR TITLE
Add missing shop inventories

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Open `index.html` in a browser. No build step is required.
 - City vendors now sell basic weapons, armor, scrolls and consumables at
   canonical prices. Stackable items include a quantity selector when purchasing.
 - Vendor inventories have been expanded with additional early-game gear and
-  consumables.
+  consumables. Previously empty shops and guilds now stock basic items.
+- Map vendors now offer maps of the starting regions.
 - Weapon and armor entries include damage or defense values based on
   early-game FFXI stats and now list level requirements.
 - A new Explore button on area screens always triggers a battle without

--- a/data/locations.js
+++ b/data/locations.js
@@ -26,7 +26,7 @@ export const zonesByCity = {
       distance: 0,
       subAreas: [],
       connectedAreas: ['Bastok Markets', 'Bastok Residential Area'],
-      pointsOfInterest: ['Airship Dock', 'Chocobo Stables', 'Fishing Shop', 'Ferry to Selbina', 'Home Point Crystal'],
+      pointsOfInterest: ['Airship Dock', 'Chocobo Stables', 'Fishing Shop', 'Ferry to Selbina', 'Home Point Crystal', 'Map Vendor'],
       importantNPCs: ['Gate Guard', 'Regional Merchant']
     },
     {
@@ -127,7 +127,7 @@ export const zonesByCity = {
       distance: 0,
       subAreas: [],
       connectedAreas: ["Northern San d'Oria", "San d'Oria Residential Area"],
-      pointsOfInterest: ['Airship Dock', 'Chocobo Stables', 'Fishing Guild', 'Item Shop', 'Home Point Crystal', 'Ferry to Mhaura'],
+      pointsOfInterest: ['Airship Dock', 'Chocobo Stables', 'Fishing Guild', 'Item Shop', 'Home Point Crystal', 'Ferry to Mhaura', 'Map Vendor'],
       importantNPCs: ['Gate Guard', 'Ferry Ticket Seller', 'Regional Merchant']
     },
     {
@@ -210,7 +210,7 @@ export const zonesByCity = {
       distance: 0,
       subAreas: [],
       connectedAreas: ['Windurst Waters', 'West Sarutabaruta', 'Windurst Woods', 'Windurst Residential Area'],
-      pointsOfInterest: ['Ferry to Mhaura', 'Chocobo Stables', 'Fishing Supplies Shop', 'Item Shop', 'Airship Dock', 'Home Point Crystal'],
+      pointsOfInterest: ['Ferry to Mhaura', 'Chocobo Stables', 'Fishing Supplies Shop', 'Item Shop', 'Airship Dock', 'Home Point Crystal', 'Map Vendor'],
       importantNPCs: ['Regional Merchant', 'Ferry Ticket Seller']
     },
     {
@@ -284,7 +284,7 @@ export const zonesByCity = {
       distance: 0,
       subAreas: [],
       connectedAreas: ['Upper Jeuno', 'Port Jeuno', 'Qufim Island', 'Rolanberry Fields', 'Jeuno Residential Area'],
-      pointsOfInterest: ['Auction House', 'Mog House', 'Rental House', 'Chocobo Stables', 'General Goods Shop', 'Armor Shop', 'Weapon Shop', 'Home Point Crystal'],
+      pointsOfInterest: ['Auction House', 'Mog House', 'Rental House', 'Chocobo Stables', 'General Goods Shop', 'Armor Shop', 'Weapon Shop', 'Home Point Crystal', 'Map Vendor'],
       importantNPCs: ['Fame/Mission/Quest NPCs', 'Outpost Warper', 'Regional Merchant']
     },
     {

--- a/data/vendors.js
+++ b/data/vendors.js
@@ -118,6 +118,156 @@ export const items = {
     stack: 12,
     description: 'A sweet pie that restores MP over time.',
     levelRequirement: 0
+  },
+  leatherCap: {
+    name: 'Leather Cap',
+    price: 150,
+    stack: 1,
+    description: 'A basic leather cap.',
+    defense: 2,
+    levelRequirement: 1
+  },
+  leatherBoots: {
+    name: 'Leather Boots',
+    price: 176,
+    stack: 1,
+    description: 'Sturdy leather boots.',
+    defense: 3,
+    levelRequirement: 1
+  },
+  bronzeAxe: {
+    name: 'Bronze Axe',
+    price: 360,
+    stack: 1,
+    description: 'A crude axe forged from bronze.',
+    damage: 7,
+    delay: 276,
+    levelRequirement: 1
+  },
+  bronzeSpear: {
+    name: 'Bronze Spear',
+    price: 520,
+    stack: 1,
+    description: 'A simple bronze spear.',
+    damage: 8,
+    delay: 303,
+    levelRequirement: 1
+  },
+  bronzeKnife: {
+    name: 'Bronze Knife',
+    price: 100,
+    stack: 1,
+    description: 'A small bronze knife.',
+    damage: 2,
+    delay: 186,
+    levelRequirement: 1
+  },
+  willowStaff: {
+    name: 'Willow Staff',
+    price: 200,
+    stack: 1,
+    description: 'A basic wooden staff.',
+    damage: 4,
+    delay: 366,
+    levelRequirement: 1
+  },
+  woodenArrow: {
+    name: 'Wooden Arrow',
+    price: 3,
+    stack: 99,
+    description: 'Simple arrows made of wood.',
+    levelRequirement: 0
+  },
+  bambooFishingRod: {
+    name: 'Bamboo Fishing Rod',
+    price: 500,
+    stack: 1,
+    description: 'A basic bamboo fishing rod.',
+    levelRequirement: 0
+  },
+  pickaxe: {
+    name: 'Pickaxe',
+    price: 200,
+    stack: 1,
+    description: 'Used for mining ore from deposits.',
+    levelRequirement: 0
+  },
+  copperOre: {
+    name: 'Copper Ore',
+    price: 50,
+    stack: 12,
+    description: 'Ore used in smithing.',
+    levelRequirement: 0
+  },
+  copperIngot: {
+    name: 'Copper Ingot',
+    price: 150,
+    stack: 12,
+    description: 'A bar of refined copper.',
+    levelRequirement: 0
+  },
+  cottonThread: {
+    name: 'Cotton Thread',
+    price: 60,
+    stack: 12,
+    description: 'Thread spun from cotton.',
+    levelRequirement: 0
+  },
+  boneChip: {
+    name: 'Bone Chip',
+    price: 20,
+    stack: 12,
+    description: 'Small fragments of bone.',
+    levelRequirement: 0
+  },
+  arrowwoodLog: {
+    name: 'Arrowwood Log',
+    price: 100,
+    stack: 12,
+    description: 'A log of arrowwood.',
+    levelRequirement: 0
+  },
+  honey: {
+    name: 'Honey',
+    price: 40,
+    stack: 12,
+    description: 'Sweet honey used in cooking.',
+    levelRequirement: 0
+  },
+  bastokMap: {
+    name: 'Map of Bastok',
+    price: 200,
+    stack: 1,
+    description: 'A detailed map of Bastok and surrounding areas.',
+    levelRequirement: 0
+  },
+  sandoriaMap: {
+    name: "Map of San d'Oria",
+    price: 200,
+    stack: 1,
+    description: "A detailed map of San d'Oria and surrounding areas.",
+    levelRequirement: 0
+  },
+  windurstMap: {
+    name: 'Map of Windurst',
+    price: 200,
+    stack: 1,
+    description: 'A detailed map of Windurst and surrounding areas.',
+    levelRequirement: 0
+  },
+  jeunoMap: {
+    name: 'Map of Jeuno',
+    price: 200,
+    stack: 1,
+    description: 'A detailed map of Jeuno and surrounding areas.',
+    levelRequirement: 0
+  },
+  valkurmMap: {
+    name: 'Map of Valkurm Dunes',
+    price: 200,
+    stack: 1,
+    description: 'A map guiding travelers through the Valkurm Dunes.',
+    levelRequirement: 0
   }
 };
 
@@ -131,5 +281,25 @@ export const vendorInventories = {
   'Scroll Shop': ['scrollCure', 'scrollFire'],
   'Magic Shop': ['scrollCure', 'scrollFire', 'ether'],
   'Fishing Supplies Shop': ['insectPaste', 'distilledWater'],
-  'Guild Shop': ['bronzeIngot']
+  'Guild Shop': ['bronzeIngot'],
+  'Map Vendor': ['bastokMap', 'sandoriaMap', 'windurstMap', 'jeunoMap', 'valkurmMap'],
+  'Armor Shop': ['leatherVest', 'leatherGloves', 'clothHeadband', 'bronzeShield', 'leatherCap', 'leatherBoots'],
+  'Weapon Shop': ['bronzeSword', 'bronzeDagger', 'bronzeAxe', 'bronzeSpear', 'willowStaff'],
+  'Consumable Shop': ['potion', 'antidote', 'meatJerky', 'applePie', 'distilledWater', 'ether', 'honey'],
+  'Arrow Shop': ['woodenArrow'],
+  'Potion Shop': ['potion', 'antidote', 'ether'],
+  'Sword Shop': ['bronzeSword'],
+  'Dagger Shop': ['bronzeDagger', 'bronzeKnife'],
+  'Staff Shop': ['willowStaff'],
+  'Fishing Shop': ['bambooFishingRod', 'insectPaste', 'distilledWater'],
+  'Fishing Guild': ['bambooFishingRod', 'insectPaste', 'distilledWater'],
+  "Fisherman's Guild": ['bambooFishingRod', 'insectPaste', 'distilledWater'],
+  'Cooking Guild': ['meatJerky', 'applePie', 'honey'],
+  "Carpenter's Guild": ['arrowwoodLog'],
+  'Clothcraft Guild': ['cottonThread'],
+  "Boneworker's Guild": ['boneChip'],
+  "Goldsmiths' Guild": ['copperIngot'],
+  "Blacksmith's Guild": ['bronzeIngot', 'copperOre', 'pickaxe'],
+  "Blacksmiths' Guild": ['bronzeIngot', 'copperOre', 'pickaxe'],
+  'Mining Guild': ['pickaxe', 'copperOre']
 };


### PR DESCRIPTION
## Summary
- expand vendor data with starter materials and gear
- give each shop and guild a basic inventory
- document the shop expansion in README

## Testing
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_687f05a679ac8325847df7d1dd823b06