### PR TITLE
Add separated North Gustaberg zones

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -48,6 +48,13 @@ button {
     margin: 0 2px;
 }
 
+#back-button {
+    padding: 2px 6px;
+    font-size: 14px;
+    margin: 0 2px;
+    display: none;
+}
+
 #scale-controls button {
     padding: 2px 6px;
     font-size: 14px;
@@ -295,5 +302,16 @@ body.portrait .character-form {
 .equipment-list li {
     margin-top: 4px;
     text-align: left;
+}
+
+.inventory-list {
+    list-style: none;
+    padding: 0;
+    text-align: left;
+    margin-bottom: 10px;
+}
+
+.inventory-list li {
+    margin-top: 4px;
 }
 

--- a/data/bestiary.js
+++ b/data/bestiary.js
@@ -81,7 +81,48 @@ export const bestiaryByZone = {
       resistances: []
     }
   ],
-  'North Gustaberg': [
+  'North Gustaberg (East)': [
+    {
+      name: 'Huge Wasp',
+      level: '1-3',
+      drops: ['Insect Wing', 'Beeswax', 'Honey'],
+      aggressive: false,
+      linking: false,
+      detection: 'Sight',
+      attacks: ['Attack'],
+      skills: ['Sting'],
+      magic: [],
+      weaknesses: ['Ice'],
+      resistances: []
+    },
+    {
+      name: 'Tunnel Worm',
+      level: '1-3',
+      drops: ['Worm Thread', 'Pebble'],
+      aggressive: false,
+      linking: false,
+      detection: 'Sound',
+      attacks: ['Attack'],
+      skills: ['Sandpit'],
+      magic: [],
+      weaknesses: ['Ice'],
+      resistances: ['Earth']
+    },
+    {
+      name: 'Carrion Crow',
+      level: '2-4',
+      drops: ['Bird Feather', 'Bird Egg'],
+      aggressive: true,
+      linking: true,
+      detection: 'Sight',
+      attacks: ['Attack'],
+      skills: ['Poison Peck'],
+      magic: [],
+      weaknesses: ['Lightning'],
+      resistances: []
+    }
+  ],
+  'North Gustaberg (West)': [
     {
       name: 'Huge Wasp',
       level: '1-3',

--- a/data/bestiary.js
+++ b/data/bestiary.js
@@ -2,7 +2,9 @@ export const bestiaryByZone = {
   'West Ronfaure': [
     {
       name: 'Forest Hare',
-      level: '1-3',
+      level: '1-5',
+      str: 6,
+      vit: 5,
       drops: ['Rabbit Hide', 'Rabbit Meat'],
       aggressive: false,
       linking: false,
@@ -15,7 +17,9 @@ export const bestiaryByZone = {
     },
     {
       name: 'Tiny Bee',
-      level: '1-2',
+      level: '1-3',
+      str: 5,
+      vit: 3,
       drops: ['Insect Wing', 'Beeswax', 'Honey'],
       aggressive: false,
       linking: false,
@@ -28,7 +32,9 @@ export const bestiaryByZone = {
     },
     {
       name: 'Orcish Fodder',
-      level: '2-4',
+      level: '3-8',
+      str: 10,
+      vit: 8,
       drops: ['Orcish Axe', 'Bronze Axe', 'Stone'],
       aggressive: true,
       linking: true,
@@ -43,7 +49,9 @@ export const bestiaryByZone = {
   'East Ronfaure': [
     {
       name: 'Forest Hare',
-      level: '1-3',
+      level: '1-5',
+      str: 6,
+      vit: 5,
       drops: ['Rabbit Hide', 'Rabbit Meat'],
       aggressive: false,
       linking: false,
@@ -56,7 +64,9 @@ export const bestiaryByZone = {
     },
     {
       name: 'Tiny Bee',
-      level: '1-2',
+      level: '1-3',
+      str: 5,
+      vit: 3,
       drops: ['Insect Wing', 'Beeswax', 'Honey'],
       aggressive: false,
       linking: false,
@@ -69,7 +79,9 @@ export const bestiaryByZone = {
     },
     {
       name: 'Orcish Fodder',
-      level: '2-4',
+      level: '3-8',
+      str: 10,
+      vit: 8,
       drops: ['Orcish Axe', 'Bronze Axe', 'Stone'],
       aggressive: true,
       linking: true,
@@ -84,7 +96,9 @@ export const bestiaryByZone = {
   'North Gustaberg (East)': [
     {
       name: 'Huge Wasp',
-      level: '1-3',
+      level: '1-2',
+      str: 4,
+      vit: 3,
       drops: ['Insect Wing', 'Beeswax', 'Honey'],
       aggressive: false,
       linking: false,
@@ -98,6 +112,8 @@ export const bestiaryByZone = {
     {
       name: 'Tunnel Worm',
       level: '1-3',
+      str: 5,
+      vit: 3,
       drops: ['Worm Thread', 'Pebble'],
       aggressive: false,
       linking: false,
@@ -109,8 +125,10 @@ export const bestiaryByZone = {
       resistances: ['Earth']
     },
     {
-      name: 'Carrion Crow',
-      level: '2-4',
+      name: 'Vulture',
+      level: '2-6',
+      str: 8,
+      vit: 6,
       drops: ['Bird Feather', 'Bird Egg'],
       aggressive: true,
       linking: true,
@@ -125,7 +143,9 @@ export const bestiaryByZone = {
   'North Gustaberg (West)': [
     {
       name: 'Huge Wasp',
-      level: '1-3',
+      level: '1-2',
+      str: 4,
+      vit: 3,
       drops: ['Insect Wing', 'Beeswax', 'Honey'],
       aggressive: false,
       linking: false,
@@ -139,6 +159,8 @@ export const bestiaryByZone = {
     {
       name: 'Tunnel Worm',
       level: '1-3',
+      str: 5,
+      vit: 3,
       drops: ['Worm Thread', 'Pebble'],
       aggressive: false,
       linking: false,
@@ -150,8 +172,10 @@ export const bestiaryByZone = {
       resistances: ['Earth']
     },
     {
-      name: 'Carrion Crow',
-      level: '2-4',
+      name: 'Vulture',
+      level: '2-6',
+      str: 8,
+      vit: 6,
       drops: ['Bird Feather', 'Bird Egg'],
       aggressive: true,
       linking: true,
@@ -166,7 +190,9 @@ export const bestiaryByZone = {
   'South Gustaberg': [
     {
       name: 'Huge Wasp',
-      level: '1-3',
+      level: '1-2',
+      str: 4,
+      vit: 3,
       drops: ['Insect Wing', 'Beeswax', 'Honey'],
       aggressive: false,
       linking: false,
@@ -180,6 +206,8 @@ export const bestiaryByZone = {
     {
       name: 'Tunnel Worm',
       level: '1-3',
+      str: 5,
+      vit: 3,
       drops: ['Worm Thread', 'Pebble'],
       aggressive: false,
       linking: false,
@@ -193,6 +221,8 @@ export const bestiaryByZone = {
     {
       name: 'Mad Sheep',
       level: '2-3',
+      str: 5,
+      vit: 4,
       drops: ['Sheepskin', 'Sheep Meat', 'Wool'],
       aggressive: true,
       linking: true,
@@ -207,7 +237,9 @@ export const bestiaryByZone = {
   'West Sarutabaruta': [
     {
       name: 'Savanna Rarab',
-      level: '1-3',
+      level: '1-6',
+      str: 7,
+      vit: 5,
       drops: ['Rabbit Hide', 'Rabbit Meat'],
       aggressive: false,
       linking: false,
@@ -220,7 +252,9 @@ export const bestiaryByZone = {
     },
     {
       name: 'Tiny Mandragora',
-      level: '1-3',
+      level: '1',
+      str: 3,
+      vit: 2,
       drops: ['Mandragora Flower', 'La Theine Cabbage'],
       aggressive: false,
       linking: false,
@@ -233,7 +267,9 @@ export const bestiaryByZone = {
     },
     {
       name: 'Yagudo Initiate',
-      level: '2-5',
+      level: '1-8',
+      str: 8,
+      vit: 7,
       drops: ['Yagudo Feather', 'Bird Egg'],
       aggressive: true,
       linking: true,
@@ -248,7 +284,9 @@ export const bestiaryByZone = {
   'East Sarutabaruta': [
     {
       name: 'Savanna Rarab',
-      level: '1-3',
+      level: '1-6',
+      str: 7,
+      vit: 5,
       drops: ['Rabbit Hide', 'Rabbit Meat'],
       aggressive: false,
       linking: false,
@@ -261,7 +299,9 @@ export const bestiaryByZone = {
     },
     {
       name: 'Tiny Mandragora',
-      level: '1-3',
+      level: '1',
+      str: 3,
+      vit: 2,
       drops: ['Mandragora Flower', 'La Theine Cabbage'],
       aggressive: false,
       linking: false,
@@ -274,7 +314,9 @@ export const bestiaryByZone = {
     },
     {
       name: 'Yagudo Initiate',
-      level: '2-5',
+      level: '1-8',
+      str: 8,
+      vit: 7,
       drops: ['Yagudo Feather', 'Bird Egg'],
       aggressive: true,
       linking: true,

--- a/data/locations.js
+++ b/data/locations.js
@@ -7,7 +7,7 @@ export const zonesByCity = {
       city: 'Bastok',
       distance: 0,
       subAreas: [],
-      connectedAreas: ['Bastok Markets', 'Metalworks', 'Zeruhn Mines', 'North Gustaberg', 'Bastok Residential Area'],
+      connectedAreas: ['Bastok Markets', 'Metalworks', 'Zeruhn Mines', 'North Gustaberg (East)', 'Bastok Residential Area'],
       pointsOfInterest: ['Mog House', 'Mining Guild', 'Swordsmith Shop', 'General Goods Shop', 'Food Shop', 'Home Point Crystal'],
       importantNPCs: ['Gate Guard']
     },
@@ -25,7 +25,7 @@ export const zonesByCity = {
       city: 'Bastok',
       distance: 0,
       subAreas: [],
-      connectedAreas: ['Bastok Markets', 'Bastok Residential Area'],
+      connectedAreas: ['Bastok Markets', 'Bastok Residential Area', 'North Gustaberg (East)'],
       pointsOfInterest: ['Airship Dock', 'Chocobo Stables', 'Fishing Shop', 'Ferry to Selbina', 'Home Point Crystal', 'Map Vendor'],
       importantNPCs: ['Gate Guard', 'Regional Merchant']
     },
@@ -52,17 +52,26 @@ export const zonesByCity = {
       city: 'Bastok',
       distance: 1,
       subAreas: [],
-      connectedAreas: ['Bastok Mines', 'North Gustaberg'],
+      connectedAreas: ['Bastok Mines', 'North Gustaberg (East)'],
       pointsOfInterest: ['Training Grounds', 'Mine Shafts'],
       importantNPCs: []
     },
     {
-      name: 'North Gustaberg',
+      name: 'North Gustaberg (East)',
       city: 'Bastok',
       distance: 1,
       subAreas: [],
-      connectedAreas: ['Bastok Mines', 'South Gustaberg', 'Konschtat Highlands', 'Zeruhn Mines', 'Dangruf Wadi'],
-      pointsOfInterest: ['Outpost', 'Dangruf Wadi Entrance'],
+      connectedAreas: ['South Gustaberg', 'Port Bastok', 'Oldton Movalpolos', 'Palborough Mines'],
+      pointsOfInterest: ['Outpost'],
+      importantNPCs: []
+    },
+    {
+      name: 'North Gustaberg (West)',
+      city: 'Bastok',
+      distance: 1,
+      subAreas: [],
+      connectedAreas: ['South Gustaberg', 'Konschtat Highlands'],
+      pointsOfInterest: ['Outpost'],
       importantNPCs: []
     },
     {
@@ -70,7 +79,7 @@ export const zonesByCity = {
       city: 'Bastok',
       distance: 1,
       subAreas: [],
-      connectedAreas: ['Bastok Markets', 'North Gustaberg', 'Konschtat Highlands', 'Dangruf Wadi'],
+      connectedAreas: ['Bastok Markets', 'North Gustaberg (East)', 'North Gustaberg (West)', 'Konschtat Highlands', 'Dangruf Wadi'],
       pointsOfInterest: ['Outpost', 'Selt Steel Mines'],
       importantNPCs: []
     },
@@ -79,7 +88,7 @@ export const zonesByCity = {
       city: 'Bastok',
       distance: 2,
       subAreas: [],
-      connectedAreas: ['North Gustaberg', 'South Gustaberg', 'Valkurm Dunes', 'Gusgen Mines', 'Pashhow Marshlands'],
+      connectedAreas: ['North Gustaberg (West)', 'South Gustaberg', 'Valkurm Dunes', 'Gusgen Mines', 'Pashhow Marshlands'],
       pointsOfInterest: ['Outpost', 'Crag of Dem'],
       importantNPCs: []
     },
@@ -93,11 +102,29 @@ export const zonesByCity = {
       importantNPCs: []
     },
     {
+      name: 'Palborough Mines',
+      city: 'Bastok',
+      distance: 2,
+      subAreas: [],
+      connectedAreas: ['North Gustaberg (East)'],
+      pointsOfInterest: [],
+      importantNPCs: []
+    },
+    {
+      name: 'Oldton Movalpolos',
+      city: 'Bastok',
+      distance: 2,
+      subAreas: [],
+      connectedAreas: ['North Gustaberg (East)'],
+      pointsOfInterest: [],
+      importantNPCs: []
+    },
+    {
       name: 'Dangruf Wadi',
       city: 'Bastok',
       distance: 2,
       subAreas: [],
-      connectedAreas: ['North Gustaberg', 'South Gustaberg'],
+      connectedAreas: ['North Gustaberg (East)', 'South Gustaberg'],
       pointsOfInterest: ['Outpost'],
       importantNPCs: []
     }

--- a/data/vendors.js
+++ b/data/vendors.js
@@ -6,7 +6,8 @@ export const items = {
     description: 'A small dagger forged from bronze.',
     damage: 3,
     delay: 183,
-    levelRequirement: 1
+    levelRequirement: 1,
+    slot: 'mainHand'
   },
   bronzeSword: {
     name: 'Bronze Sword',
@@ -15,7 +16,8 @@ export const items = {
     description: 'A simple bronze sword.',
     damage: 6,
     delay: 231,
-    levelRequirement: 1
+    levelRequirement: 1,
+    slot: 'mainHand'
   },
   leatherVest: {
     name: 'Leather Vest',
@@ -23,7 +25,8 @@ export const items = {
     stack: 1,
     description: 'Basic leather armor for the body.',
     defense: 7,
-    levelRequirement: 1
+    levelRequirement: 1,
+    slot: 'body'
   },
   bronzeIngot: {
     name: 'Bronze Ingot',
@@ -80,7 +83,8 @@ export const items = {
     stack: 1,
     description: 'A small bronze buckler.',
     defense: 2,
-    levelRequirement: 1
+    levelRequirement: 1,
+    slot: 'offHand'
   },
   leatherGloves: {
     name: 'Leather Gloves',
@@ -88,7 +92,8 @@ export const items = {
     stack: 1,
     description: 'Basic leather armor for the hands.',
     defense: 4,
-    levelRequirement: 1
+    levelRequirement: 1,
+    slot: 'hands'
   },
   clothHeadband: {
     name: 'Cloth Headband',
@@ -96,7 +101,8 @@ export const items = {
     stack: 1,
     description: 'A simple cloth headband.',
     defense: 1,
-    levelRequirement: 1
+    levelRequirement: 1,
+    slot: 'head'
   },
   scrollFire: {
     name: 'Scroll of Fire',
@@ -125,7 +131,8 @@ export const items = {
     stack: 1,
     description: 'A basic leather cap.',
     defense: 2,
-    levelRequirement: 1
+    levelRequirement: 1,
+    slot: 'head'
   },
   leatherBoots: {
     name: 'Leather Boots',
@@ -133,7 +140,8 @@ export const items = {
     stack: 1,
     description: 'Sturdy leather boots.',
     defense: 3,
-    levelRequirement: 1
+    levelRequirement: 1,
+    slot: 'feet'
   },
   bronzeAxe: {
     name: 'Bronze Axe',
@@ -142,7 +150,8 @@ export const items = {
     description: 'A crude axe forged from bronze.',
     damage: 7,
     delay: 276,
-    levelRequirement: 1
+    levelRequirement: 1,
+    slot: 'mainHand'
   },
   bronzeSpear: {
     name: 'Bronze Spear',
@@ -151,7 +160,8 @@ export const items = {
     description: 'A simple bronze spear.',
     damage: 8,
     delay: 303,
-    levelRequirement: 1
+    levelRequirement: 1,
+    slot: 'mainHand'
   },
   bronzeKnife: {
     name: 'Bronze Knife',
@@ -160,7 +170,8 @@ export const items = {
     description: 'A small bronze knife.',
     damage: 2,
     delay: 186,
-    levelRequirement: 1
+    levelRequirement: 1,
+    slot: 'mainHand'
   },
   willowStaff: {
     name: 'Willow Staff',
@@ -169,7 +180,8 @@ export const items = {
     description: 'A basic wooden staff.',
     damage: 4,
     delay: 366,
-    levelRequirement: 1
+    levelRequirement: 1,
+    slot: 'mainHand'
   },
   woodenArrow: {
     name: 'Wooden Arrow',

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <body>
     <div id="scale-controls">
         <button id="character-select">Character Select</button>
+        <button id="back-button">Back</button>
         <button class="scale-btn" id="scale-dec">-</button>
         <button class="scale-btn" id="scale-inc">+</button>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-import { renderMainMenu, renderCharacterMenu } from './ui.js';
+import { renderMainMenu, renderCharacterMenu, setupBackButton } from './ui.js';
 import { loadCharacters } from '../data/index.js';
 
 // Entry point: initialize application
@@ -21,6 +21,9 @@ function init() {
     app.innerHTML = '';
     const menu = renderMainMenu();
     app.appendChild(menu);
+
+    const backBtn = document.getElementById('back-button');
+    if (backBtn) setupBackButton(backBtn);
 
     applyOrientation();
     window.addEventListener('resize', applyOrientation);


### PR DESCRIPTION
## Summary
- connect Port Bastok to North Gustaberg
- split North Gustaberg into East and West halves
- add Oldton Movalpolos and Palborough Mines
- update bestiary to include both halves
- fix all zone links
- add inventory page and top navigation back button

## Testing
- `node scripts/validateZones.js`

------
https://chatgpt.com/codex/tasks/task_e_687f0dd61b308325818787d4a74a2274