### PR TITLE
Add multi-user save system

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -14,7 +14,13 @@ export {
   deleteCharacterSlot,
   saveCharacterToFile,
   loadCharacterFromFile,
-  setActiveCharacter
+  setActiveCharacter,
+  loadUsers,
+  saveUsers,
+  addUser,
+  initCurrentUser,
+  setCurrentUser,
+  currentUser
 } from './characters.js';
 export { proficiencyScale, getScale } from './scales.js';
 export { names, randomName } from './names.js';

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,5 @@
 import { renderMainMenu, renderCharacterMenu, setupBackButton } from './ui.js';
-import { loadCharacters } from '../data/index.js';
+import { loadCharacters, initCurrentUser } from '../data/index.js';
 
 // Entry point: initialize application
 let uiScale = 1;
@@ -16,6 +16,7 @@ function updateScale(delta) {
 }
 
 function init() {
+    initCurrentUser();
     loadCharacters();
     const app = document.getElementById('app');
     app.innerHTML = '';

--- a/js/ui.js
+++ b/js/ui.js
@@ -15,7 +15,11 @@ import {
     locations,
     vendorInventories,
     items,
-    updateDerivedStats
+    updateDerivedStats,
+    loadUsers,
+    addUser,
+    setCurrentUser,
+    currentUser
 } from '../data/index.js';
 import { randomName, raceInfo, jobInfo, cityImages, getZoneTravelTurns, rollForEncounter, exploreEncounter, parseLevel } from '../data/index.js';
 
@@ -190,11 +194,45 @@ export function renderCharacterMenu(root) {
     title.textContent = 'Characters';
     root.appendChild(title);
 
+    const userDiv = document.createElement('div');
+    userDiv.className = 'user-select';
+    const userSelect = document.createElement('select');
+    loadUsers().forEach(u => {
+        const opt = document.createElement('option');
+        opt.value = u;
+        opt.textContent = u;
+        userSelect.appendChild(opt);
+    });
+    userSelect.value = currentUser || '';
+    userSelect.addEventListener('change', () => {
+        setCurrentUser(userSelect.value);
+        renderCharacterMenu(root);
+    });
+    const newUserBtn = document.createElement('button');
+    newUserBtn.textContent = 'New User';
+    newUserBtn.addEventListener('click', () => {
+        const name = prompt('Enter new username');
+        if (name) {
+            addUser(name);
+            setCurrentUser(name);
+            renderCharacterMenu(root);
+        }
+    });
+    userDiv.appendChild(userSelect);
+    userDiv.appendChild(newUserBtn);
+    root.appendChild(userDiv);
+    if (!currentUser) {
+        const msg = document.createElement('div');
+        msg.textContent = 'Create a user to start saving characters.';
+        root.appendChild(msg);
+    }
+
     const newBtn = document.createElement('button');
     newBtn.textContent = 'New Character';
     newBtn.addEventListener('click', () => {
         renderNewCharacterForm(root);
     });
+    if (!currentUser) newBtn.disabled = true;
     root.appendChild(newBtn);
 
     const list = document.createElement('div');


### PR DESCRIPTION
## Summary
- track users in localStorage and store save files per user
- allow selecting or creating a user from the character screen
- persist the last active character for each user

## Testing
- `node --check js/main.js`
- `node --check js/ui.js`
- `node --check data/characters.js`


------
https://chatgpt.com/codex/tasks/task_e_687fc91113888325b1ef1bb0182c2b90