### PR TITLE
Add Bastok Markets vendors with shop submenus

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -28,7 +28,7 @@ export { raceInfo, jobInfo, cityImages } from './descriptions.js';
 export { cityList, zonesByCity, locations, zoneNames } from './locations.js';
 export { bestiaryByZone, allMonsters } from './bestiary.js';
 export { experienceTable, experienceForKill } from './experience.js';
-export { items, vendorInventories } from './vendors.js';
+export { items, vendorInventories, shopNpcs } from './vendors.js';
 export {
   parseLevel,
   conLevel,

--- a/data/locations.js
+++ b/data/locations.js
@@ -17,7 +17,23 @@ export const zonesByCity = {
       distance: 0,
       subAreas: [],
       connectedAreas: ['Bastok Mines', 'Port Bastok', 'South Gustaberg', 'Bastok Residential Area'],
-      pointsOfInterest: ['Auction House', 'Mog House', 'Rental House', "Goldsmiths' Guild", "Blacksmiths' Guild", 'Arms & Armor Shop', 'General Goods Shop', 'Item Shop', 'Tenshodo Entrance', 'Chocobo Stables', 'Home Point Crystal'],
+      pointsOfInterest: [
+        'Auction House',
+        'Mog House',
+        'Rental House',
+        "Goldsmiths' Guild",
+        "Blacksmiths' Guild",
+        "Brunhilde's Armourer",
+        "Dragon's Claw Weaponry",
+        "Carmelide's Jewelry Store",
+        "Mjoll's General Goods",
+        "Olwyn's General Goods",
+        "Harmodios's Music Shop",
+        'Scribe & Notary',
+        'Tenshodo Entrance',
+        'Chocobo Stables',
+        'Home Point Crystal'
+      ],
       importantNPCs: ['Gate Guard', 'Regional Merchant']
     },
     {

--- a/data/vendors.js
+++ b/data/vendors.js
@@ -260,6 +260,524 @@ export const items = {
     description: 'Sweet honey used in cooking.',
     levelRequirement: 0
   },
+  mythrilSallet: {
+    name: 'Mythril Sallet',
+    price: 51152,
+    stack: 1,
+    description: 'Heavy headgear forged of mythril.',
+    defense: 15,
+    levelRequirement: 20,
+    slot: 'head',
+    jobs: baseJobNames
+  },
+  breastplate: {
+    name: 'Breastplate',
+    price: 44226,
+    stack: 1,
+    description: 'A sturdy metal breastplate.',
+    defense: 27,
+    levelRequirement: 18,
+    slot: 'body',
+    jobs: baseJobNames
+  },
+  gauntlets: {
+    name: 'Gauntlets',
+    price: 23328,
+    stack: 1,
+    description: 'Heavy metal gauntlets.',
+    defense: 12,
+    levelRequirement: 16,
+    slot: 'hands',
+    jobs: baseJobNames
+  },
+  brassMask: {
+    name: 'Brass Mask',
+    price: 11520,
+    stack: 1,
+    description: 'Face armor forged from brass.',
+    defense: 8,
+    levelRequirement: 14,
+    slot: 'head',
+    jobs: baseJobNames
+  },
+  sallet: {
+    name: 'Sallet',
+    price: 28674,
+    stack: 1,
+    description: 'A sturdy metal helm.',
+    defense: 12,
+    levelRequirement: 16,
+    slot: 'head',
+    jobs: baseJobNames
+  },
+  brassScaleMail: {
+    name: 'Brass Scale Mail',
+    price: 17539,
+    stack: 1,
+    description: 'Scale armor made of brass.',
+    defense: 17,
+    levelRequirement: 14,
+    slot: 'body',
+    jobs: baseJobNames
+  },
+  brassFingerGauntlets: {
+    name: 'Brass Finger Gauntlets',
+    price: 9273,
+    stack: 1,
+    description: 'Fingered gauntlets of brass.',
+    defense: 8,
+    levelRequirement: 14,
+    slot: 'hands',
+    jobs: baseJobNames
+  },
+  bronzeCap: {
+    name: 'Bronze Cap',
+    price: 151,
+    stack: 1,
+    description: 'A simple bronze cap.',
+    defense: 1,
+    levelRequirement: 1,
+    slot: 'head',
+    jobs: baseJobNames
+  },
+  faceguard: {
+    name: 'Faceguard',
+    price: 1305,
+    stack: 1,
+    description: 'Protective face armor.',
+    defense: 4,
+    levelRequirement: 10,
+    slot: 'head',
+    jobs: baseJobNames
+  },
+  bronzeHarness: {
+    name: 'Bronze Harness',
+    price: 230,
+    stack: 1,
+    description: 'A light bronze cuirass.',
+    defense: 4,
+    levelRequirement: 1,
+    slot: 'body',
+    jobs: baseJobNames
+  },
+  scaleMail: {
+    name: 'Scale Mail',
+    price: 2007,
+    stack: 1,
+    description: 'Light armor of overlapping scales.',
+    defense: 14,
+    levelRequirement: 10,
+    slot: 'body',
+    jobs: baseJobNames
+  },
+  bronzeMittens: {
+    name: 'Bronze Mittens',
+    price: 126,
+    stack: 1,
+    description: 'Simple bronze mittens.',
+    defense: 1,
+    levelRequirement: 1,
+    slot: 'hands',
+    jobs: baseJobNames
+  },
+  scaleFingerGauntlets: {
+    name: 'Scale Finger Gauntlets',
+    price: 1071,
+    stack: 1,
+    description: 'Finger gauntlets crafted from scales.',
+    defense: 5,
+    levelRequirement: 10,
+    slot: 'hands',
+    jobs: baseJobNames
+  },
+  bronzeKnuckles: {
+    name: 'Bronze Knuckles',
+    price: 224,
+    stack: 1,
+    description: 'Bronze fist weapons.',
+    damage: 4,
+    delay: 96,
+    levelRequirement: 1,
+    slot: 'mainHand',
+    jobs: baseJobNames
+  },
+  brassKnuckles: {
+    name: 'Brass Knuckles',
+    price: 828,
+    stack: 1,
+    description: 'Brass fist weapons.',
+    damage: 7,
+    delay: 96,
+    levelRequirement: 7,
+    slot: 'mainHand',
+    jobs: baseJobNames
+  },
+  metalKnuckles: {
+    name: 'Metal Knuckles',
+    price: 4818,
+    stack: 1,
+    description: 'Heavy metal knuckles.',
+    damage: 10,
+    delay: 96,
+    levelRequirement: 18,
+    slot: 'mainHand',
+    jobs: baseJobNames
+  },
+  bronzeHammer: {
+    name: 'Bronze Hammer',
+    price: 312,
+    stack: 1,
+    description: 'A basic bronze hammer.',
+    damage: 5,
+    delay: 288,
+    levelRequirement: 1,
+    slot: 'mainHand',
+    jobs: baseJobNames
+  },
+  brassHammer: {
+    name: 'Brass Hammer',
+    price: 2129,
+    stack: 1,
+    description: 'A sturdy brass hammer.',
+    damage: 11,
+    delay: 288,
+    levelRequirement: 13,
+    slot: 'mainHand',
+    jobs: baseJobNames
+  },
+  warhammer: {
+    name: 'Warhammer',
+    price: 6033,
+    stack: 1,
+    description: 'A heavy warhammer.',
+    damage: 18,
+    delay: 312,
+    levelRequirement: 20,
+    slot: 'mainHand',
+    jobs: baseJobNames
+  },
+  mapleWand: {
+    name: 'Maple Wand',
+    price: 47,
+    stack: 1,
+    description: 'A simple wand made of maple.',
+    damage: 3,
+    delay: 240,
+    levelRequirement: 1,
+    slot: 'mainHand',
+    jobs: baseJobNames
+  },
+  ironArrow: {
+    name: 'Iron Arrow',
+    price: 7,
+    stack: 99,
+    description: 'Sturdy iron arrows.',
+    levelRequirement: 1
+  },
+  silverArrow: {
+    name: 'Silver Arrow',
+    price: 16,
+    stack: 99,
+    description: 'High-quality silver arrows.',
+    levelRequirement: 1
+  },
+  crossbowBolt: {
+    name: 'Crossbow Bolt',
+    price: 5,
+    stack: 99,
+    description: 'Bolts used with crossbows.',
+    levelRequirement: 1
+  },
+  lightCrossbow: {
+    name: 'Light Crossbow',
+    price: 165,
+    stack: 1,
+    description: 'A lightweight crossbow.',
+    damage: 10,
+    delay: 288,
+    levelRequirement: 1,
+    slot: 'ranged',
+    jobs: baseJobNames
+  },
+  crossbow: {
+    name: 'Crossbow',
+    price: 2166,
+    stack: 1,
+    description: 'A standard crossbow.',
+    damage: 15,
+    delay: 300,
+    levelRequirement: 14,
+    slot: 'ranged',
+    jobs: baseJobNames
+  },
+  scrollDarkThrenody: {
+    name: 'Scroll of Dark Threnody',
+    price: 199,
+    stack: 1,
+    description: 'Teaches the song Dark Threnody.',
+    levelRequirement: 15
+  },
+  scrollIceThrenody: {
+    name: 'Scroll of Ice Threnody',
+    price: 1000,
+    stack: 1,
+    description: 'Teaches the song Ice Threnody.',
+    levelRequirement: 45
+  },
+  scrollFoeRequiemI: {
+    name: 'Scroll of Foe Requiem I',
+    price: 64,
+    stack: 1,
+    description: 'Teaches Foe Requiem I.',
+    levelRequirement: 7
+  },
+  scrollFoeRequiemII: {
+    name: 'Scroll of Foe Requiem II',
+    price: 441,
+    stack: 1,
+    description: 'Teaches Foe Requiem II.',
+    levelRequirement: 17
+  },
+  scrollFoeRequiemIII: {
+    name: 'Scroll of Foe Requiem III',
+    price: 3960,
+    stack: 1,
+    description: 'Teaches Foe Requiem III.',
+    levelRequirement: 37
+  },
+  scrollFoeRequiemIV: {
+    name: 'Scroll of Foe Requiem IV',
+    price: 6912,
+    stack: 1,
+    description: 'Teaches Foe Requiem IV.',
+    levelRequirement: 47
+  },
+  scrollArmysPaeon: {
+    name: "Scroll of Army's Paeon", 
+    price: 37,
+    stack: 1,
+    description: "Teaches Army's Paeon.",
+    levelRequirement: 5
+  },
+  scrollArmysPaeonII: {
+    name: "Scroll of Army's Paeon II",
+    price: 321,
+    stack: 1,
+    description: "Teaches Army's Paeon II.",
+    levelRequirement: 15
+  },
+  scrollArmysPaeonIII: {
+    name: "Scroll of Army's Paeon III",
+    price: 3240,
+    stack: 1,
+    description: "Teaches Army's Paeon III.",
+    levelRequirement: 35
+  },
+  scrollArmysPaeonIV: {
+    name: "Scroll of Army's Paeon IV",
+    price: 5940,
+    stack: 1,
+    description: "Teaches Army's Paeon IV.",
+    levelRequirement: 45
+  },
+  scrollValorMinuet: {
+    name: 'Scroll of Valor Minuet',
+    price: 21,
+    stack: 1,
+    description: 'Teaches Valor Minuet.',
+    levelRequirement: 3
+  },
+  scrollValorMinuetII: {
+    name: 'Scroll of Valor Minuet II',
+    price: 1101,
+    stack: 1,
+    description: 'Teaches Valor Minuet II.',
+    levelRequirement: 23
+  },
+  scrollValorMinuetIII: {
+    name: 'Scroll of Valor Minuet III',
+    price: 5544,
+    stack: 1,
+    description: 'Teaches Valor Minuet III.',
+    levelRequirement: 43
+  },
+  scrollCureII: {
+    name: 'Scroll of Cure II',
+    price: 585,
+    stack: 1,
+    description: 'Teaches the white magic Cure II.',
+    levelRequirement: 11
+  },
+  scrollCuraga: {
+    name: 'Scroll of Curaga',
+    price: 1363,
+    stack: 1,
+    description: 'Teaches the white magic Curaga.',
+    levelRequirement: 43
+  },
+  scrollPoisona: {
+    name: 'Scroll of Poisona',
+    price: 180,
+    stack: 1,
+    description: 'Teaches the white magic Poisona.',
+    levelRequirement: 15
+  },
+  scrollParalyna: {
+    name: 'Scroll of Paralyna',
+    price: 324,
+    stack: 1,
+    description: 'Teaches the white magic Paralyna.',
+    levelRequirement: 21
+  },
+  scrollBlindna: {
+    name: 'Scroll of Blindna',
+    price: 990,
+    stack: 1,
+    description: 'Teaches the white magic Blindna.',
+    levelRequirement: 47
+  },
+  scrollDia: {
+    name: 'Scroll of Dia',
+    price: 82,
+    stack: 1,
+    description: 'Teaches the white magic Dia.',
+    levelRequirement: 27
+  },
+  scrollDiaga: {
+    name: 'Scroll of Diaga',
+    price: 1165,
+    stack: 1,
+    description: 'Teaches the white magic Diaga.',
+    levelRequirement: 73
+  },
+  scrollBanish: {
+    name: 'Scroll of Banish',
+    price: 140,
+    stack: 1,
+    description: 'Teaches Banish.',
+    levelRequirement: 1
+  },
+  scrollBanishga: {
+    name: 'Scroll of Banishga',
+    price: 1165,
+    stack: 1,
+    description: 'Teaches Banishga.',
+    levelRequirement: 35
+  },
+  scrollBlink: {
+    name: 'Scroll of Blink',
+    price: 2097,
+    stack: 1,
+    description: 'Teaches Blink.',
+    levelRequirement: 15
+  },
+  scrollProtect: {
+    name: 'Scroll of Protect',
+    price: 219,
+    stack: 1,
+    description: 'Teaches Protect.',
+    levelRequirement: 20
+  },
+  scrollShell: {
+    name: 'Scroll of Shell',
+    price: 1584,
+    stack: 1,
+    description: 'Teaches Shell.',
+    levelRequirement: 35
+  },
+  scrollStoneskin: {
+    name: 'Scroll of Stoneskin',
+    price: 7025,
+    stack: 1,
+    description: 'Teaches Stoneskin.',
+    levelRequirement: 49
+  },
+  scrollSlow: {
+    name: 'Scroll of Slow',
+    price: 837,
+    stack: 1,
+    description: 'Teaches Slow.',
+    levelRequirement: 13
+  },
+  echoDrops: {
+    name: 'Echo Drops',
+    price: 736,
+    stack: 12,
+    description: 'Cures silence.',
+    levelRequirement: 0
+  },
+  eyeDrops: {
+    name: 'Eye Drops',
+    price: 2387,
+    stack: 12,
+    description: 'Cures blindness.',
+    levelRequirement: 0
+  },
+  tourmaline: {
+    name: 'Tourmaline',
+    price: 1676,
+    stack: 1,
+    description: 'A pink gemstone.',
+    levelRequirement: 0
+  },
+  sardonyx: {
+    name: 'Sardonyx',
+    price: 1676,
+    stack: 1,
+    description: 'A striped gemstone.',
+    levelRequirement: 0
+  },
+  amethyst: {
+    name: 'Amethyst',
+    price: 1676,
+    stack: 1,
+    description: 'A purple gemstone.',
+    levelRequirement: 0
+  },
+  amber: {
+    name: 'Amber',
+    price: 1676,
+    stack: 1,
+    description: 'A golden gemstone.',
+    levelRequirement: 0
+  },
+  lapisLazuli: {
+    name: 'Lapis Lazuli',
+    price: 1676,
+    stack: 1,
+    description: 'A blue gemstone.',
+    levelRequirement: 0
+  },
+  clearTopaz: {
+    name: 'Clear Topaz',
+    price: 1676,
+    stack: 1,
+    description: 'A transparent gem.',
+    levelRequirement: 0
+  },
+  onyx: {
+    name: 'Onyx',
+    price: 1676,
+    stack: 1,
+    description: 'A jet-black gem.',
+    levelRequirement: 0
+  },
+  lightOpal: {
+    name: 'Light Opal',
+    price: 1676,
+    stack: 1,
+    description: 'A brilliant opal.',
+    levelRequirement: 0
+  },
+  copperRing: {
+    name: 'Copper Ring',
+    price: 68,
+    stack: 1,
+    description: 'A simple copper ring.',
+    levelRequirement: 0,
+    slot: 'leftRing',
+    jobs: baseJobNames
+  },
   bastokMap: {
     name: 'Map of Bastok',
     price: 200,
@@ -327,5 +845,20 @@ export const vendorInventories = {
   "Goldsmiths' Guild": ['copperIngot'],
   "Blacksmith's Guild": ['bronzeIngot', 'copperOre', 'pickaxe'],
   "Blacksmiths' Guild": ['bronzeIngot', 'copperOre', 'pickaxe'],
-  'Mining Guild': ['pickaxe', 'copperOre']
+  'Mining Guild': ['pickaxe', 'copperOre'],
+  'Brunhilde the Armourer': ['mythrilSallet', 'breastplate', 'gauntlets', 'brassMask', 'sallet', 'brassScaleMail', 'brassFingerGauntlets', 'bronzeCap', 'faceguard', 'bronzeHarness', 'scaleMail', 'bronzeMittens', 'scaleFingerGauntlets'],
+  'Ciqala': ['bronzeKnuckles', 'brassKnuckles', 'metalKnuckles', 'bronzeHammer', 'brassHammer', 'warhammer', 'mapleWand'],
+  'Carmelide': ['tourmaline', 'sardonyx', 'amethyst', 'amber', 'lapisLazuli', 'clearTopaz', 'onyx', 'lightOpal', 'copperRing'],
+  "Mjoll's General Goods": ['woodenArrow', 'ironArrow', 'silverArrow', 'crossbowBolt', 'lightCrossbow', 'crossbow', 'scrollDarkThrenody', 'scrollIceThrenody'],
+  "Olwyn's General Goods": ['potion', 'ether', 'echoDrops', 'eyeDrops', 'antidote'],
+  'Hortense': ['scrollFoeRequiemI', 'scrollFoeRequiemII', 'scrollFoeRequiemIII', 'scrollFoeRequiemIV', 'scrollArmysPaeon', 'scrollArmysPaeonII', 'scrollArmysPaeonIII', 'scrollArmysPaeonIV', 'scrollValorMinuet', 'scrollValorMinuetII', 'scrollValorMinuetIII'],
+  'Sororo': ['scrollCure', 'scrollCureII', 'scrollCuraga', 'scrollPoisona', 'scrollParalyna', 'scrollBlindna', 'scrollDia', 'scrollDiaga', 'scrollBanish', 'scrollBanishga', 'scrollBlink', 'scrollProtect', 'scrollShell', 'scrollStoneskin', 'scrollSlow']
+};
+
+export const shopNpcs = {
+  'Brunhilde\'s Armourer': ['Brunhilde the Armourer'],
+  "Dragon's Claw Weaponry": ['Ciqala'],
+  "Carmelide's Jewelry Store": ['Carmelide'],
+  "Harmodios's Music Shop": ['Hortense'],
+  'Scribe & Notary': ['Sororo']
 };

--- a/js/ui.js
+++ b/js/ui.js
@@ -14,6 +14,7 @@ import {
     setActiveCharacter,
     locations,
     vendorInventories,
+    shopNpcs,
     items,
     updateDerivedStats,
     loadUsers,
@@ -1158,7 +1159,7 @@ function buyItem(id, qty = 1) {
     alert(`Purchased ${qty} x ${item.name}.`);
 }
 
-export function renderVendorScreen(root, vendor) {
+export function renderVendorScreen(root, vendor, backFn = null) {
     root.innerHTML = '';
     const title = document.createElement('h2');
     title.textContent = vendor;
@@ -1225,7 +1226,8 @@ export function renderVendorScreen(root, vendor) {
         list.appendChild(row);
     });
     root.appendChild(list);
-    showBackButton(() => renderAreaScreen(root));
+    const handler = backFn || (() => renderAreaScreen(root));
+    showBackButton(handler);
 }
 
 export function renderEquipmentScreen(root) {
@@ -1394,10 +1396,27 @@ export function renderInventoryScreen(root) {
     });
 }
 
-function openMenu(name) {
+function openMenu(name, backFn) {
     const root = document.getElementById('app');
-    if (vendorInventories[name]) {
-        renderVendorScreen(root, name);
+    const backHandler = backFn || (() => renderAreaScreen(root));
+    if (shopNpcs[name]) {
+        root.innerHTML = '';
+        const title = document.createElement('h2');
+        title.textContent = name;
+        root.appendChild(title);
+        const list = document.createElement('ul');
+        shopNpcs[name].forEach(npc => {
+            const li = document.createElement('li');
+            const btn = document.createElement('button');
+            btn.textContent = npc;
+            btn.addEventListener('click', () => openMenu(npc, () => openMenu(name, backFn)));
+            li.appendChild(btn);
+            list.appendChild(li);
+        });
+        root.appendChild(list);
+        showBackButton(backHandler);
+    } else if (vendorInventories[name]) {
+        renderVendorScreen(root, name, backHandler);
     } else {
         alert(`Opening menu for ${name}`);
     }


### PR DESCRIPTION
## Summary
- expand vendor inventories with Bastok Markets merchants
- add gemstone and armor items
- enable nested shop menus for NPCs inside stores
- update Bastok Markets points of interest

## Testing
- `node --check js/ui.js`
- `node --check data/vendors.js`

------
https://chatgpt.com/codex/tasks/task_e_6880251adea88325bf64cb0f95f1b8ad