### PR TITLE
Add home point and signet features

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8,7 +8,7 @@ body {
     color: #eee;
     text-align: center;
     margin: 0;
-    padding: 0;
+    padding: 60px 0 0 0;
     font-size: clamp(14px, 2vw, 20px);
 }
 
@@ -362,5 +362,18 @@ body.portrait .character-form {
 .character-summary {
     margin-top: 10px;
     text-align: left;
+}
+
+#status-effects {
+    margin: 10px 0;
+}
+
+#status-effects .buffs {
+    color: lightgreen;
+    margin-right: 10px;
+}
+
+#status-effects .debuffs {
+    color: salmon;
 }
 

--- a/data/bestiary.js
+++ b/data/bestiary.js
@@ -330,4 +330,13 @@ export const bestiaryByZone = {
   ]
 };
 
+// Increase base monster stats by 1 for better balance
+for (const zone of Object.values(bestiaryByZone)) {
+  for (const mob of zone) {
+    ['str','vit','dex','agi','int','mnd','chr'].forEach(a => {
+      if (typeof mob[a] === 'number') mob[a] += 1;
+    });
+  }
+}
+
 export const allMonsters = Object.values(bestiaryByZone).flat();

--- a/data/characters.js
+++ b/data/characters.js
@@ -66,6 +66,18 @@ export function setCurrentUser(name) {
   loadCharacters();
 }
 
+export function grantSignet(character) {
+  const now = new Date();
+  const nextMid = new Date(now.getFullYear(), now.getMonth(), now.getDate() + 1);
+  character.signetUntil = nextMid.getTime();
+  if (!character.buffs) character.buffs = [];
+  if (!character.buffs.includes('Signet')) character.buffs.push('Signet');
+}
+
+export function hasSignet(character) {
+  return character.signetUntil && character.signetUntil > Date.now();
+}
+
 function buildScaleFields(raceName, jobName) {
   const raceInfo = races.find(r => r.name === raceName);
   const jobInfo = jobs.find(j => j.name === jobName);
@@ -156,7 +168,12 @@ export const characters = [
       rightEar: null,
       leftRing: null,
       rightRing: null
-    }
+    },
+    buffs: [],
+    debuffs: [],
+    homePoints: [zonesByCity[startingCities['Hume']][0].name],
+    currentHomePoint: zonesByCity[startingCities['Hume']][0].name,
+    signetUntil: 0
   },
   {
     name: 'Shantotto',
@@ -211,7 +228,12 @@ export const characters = [
       rightEar: null,
       leftRing: null,
       rightRing: null
-    }
+    },
+    buffs: [],
+    debuffs: [],
+    homePoints: [zonesByCity[startingCities['Tarutaru']][0].name],
+    currentHomePoint: zonesByCity[startingCities['Tarutaru']][0].name,
+    signetUntil: 0
   }
 ];
 
@@ -274,7 +296,12 @@ export function createCharacterObject(name, job, race, sex = 'Male') {
       rightEar: null,
       leftRing: null,
       rightRing: null
-    }
+    },
+    buffs: [],
+    debuffs: [],
+    homePoints: [zonesByCity[startingCities[selectedRace]][0].name],
+    currentHomePoint: zonesByCity[startingCities[selectedRace]][0].name,
+    signetUntil: 0
   };
   updateDerivedStats(character);
   return character;

--- a/data/index.js
+++ b/data/index.js
@@ -20,7 +20,9 @@ export {
   addUser,
   initCurrentUser,
   setCurrentUser,
-  currentUser
+  currentUser,
+  grantSignet,
+  hasSignet
 } from './characters.js';
 export { proficiencyScale, getScale } from './scales.js';
 export { names, randomName } from './names.js';


### PR DESCRIPTION
## Summary
- add padding to body and show buff/debuff display
- implement persistent home point system and signet buff
- show status effects in exploration and combat UI
- categorize merchant NPCs in marketplace section
- slightly boost monster attributes for balance

## Testing
- `node scripts/validateZones.js`
- `node scripts/testTaruBlm.js | head -n 20`
- `node scripts/testBalance.js | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68803baad2c8832589091088ffda62da