### PR TITLE
Add Bastok Mines merchant data

### DIFF
--- a/data/locations.js
+++ b/data/locations.js
@@ -8,7 +8,20 @@ export const zonesByCity = {
       distance: 0,
       subAreas: [],
       connectedAreas: ['Bastok Markets', 'Metalworks', 'Zeruhn Mines', 'North Gustaberg (East)', 'Bastok Residential Area'],
-      pointsOfInterest: ['Mog House', 'Mining Guild', 'Swordsmith Shop', 'General Goods Shop', 'Food Shop', 'Home Point Crystal'],
+      pointsOfInterest: [
+        'Mog House',
+        'Mining Guild',
+        "Boytz's Knickknacks",
+        "Gelzerio's Stall",
+        "Deegis's Armour",
+        'Zemedars',
+        'Proud Beard',
+        "Neigepance's Chocobo Stables",
+        "Griselda's Tavern",
+        "Alchemists' Guild",
+        "Rodellieux's Stall",
+        'Home Point Crystal'
+      ],
       importantNPCs: ['Gate Guard']
     },
     {
@@ -42,8 +55,21 @@ export const zonesByCity = {
       distance: 0,
       subAreas: [],
       connectedAreas: ['Bastok Markets', 'Bastok Residential Area', 'North Gustaberg (East)'],
-      pointsOfInterest: ['Airship Dock', 'Chocobo Stables', 'Fishing Shop', 'Ferry to Selbina', 'Home Point Crystal', 'Map Vendor'],
-      importantNPCs: ['Gate Guard', 'Regional Merchant']
+      pointsOfInterest: [
+        'Airship Dock',
+        'Chocobo Stables',
+        'Fishing Shop',
+        'Ferry to Selbina',
+        "Galvin's Travel Gear",
+        'Denvihr',
+        'Blabbivix',
+        'Steaming Sheep Restaurant',
+        'Sugandhi',
+        'World Pass Merchant',
+        'Map Vendor',
+        'Home Point Crystal'
+      ],
+      importantNPCs: ['Gate Guard', 'Regional Merchant', 'Rex']
     },
     {
       name: 'Metalworks',

--- a/data/vendors.js
+++ b/data/vendors.js
@@ -812,6 +812,1247 @@ export const items = {
     stack: 1,
     description: 'A map guiding travelers through the Valkurm Dunes.',
     levelRequirement: 0
+  },
+  ashLog: {
+    name: 'Ash Log',
+    price: 88,
+    stack: 99,
+    description: 'A log cut from an ash tree.',
+    levelRequirement: 0
+  },
+  chestnutLog: {
+    name: 'Chestnut Log',
+    price: 2599,
+    stack: 99,
+    description: 'Wood from a chestnut tree.',
+    levelRequirement: 0
+  },
+  oakLog: {
+    name: 'Oak Log',
+    price: 5814,
+    stack: 99,
+    description: 'A sturdy oak log.',
+    levelRequirement: 0
+  },
+  ironOre: {
+    name: 'Iron Ore',
+    price: 828,
+    stack: 99,
+    description: 'Ore containing iron.',
+    levelRequirement: 0
+  },
+  mythrilOre: {
+    name: 'Mythril Ore',
+    price: 1840,
+    stack: 99,
+    description: 'Ore containing mythril.',
+    levelRequirement: 0
+  },
+  mokoGrass: {
+    name: 'Moko Grass',
+    price: 18,
+    stack: 99,
+    description: 'A clump of moko grass used in clothcraft.',
+    levelRequirement: 0
+  },
+  birdEgg: {
+    name: 'Bird Egg',
+    price: 51,
+    stack: 12,
+    description: 'A fresh bird egg.',
+    levelRequirement: 0
+  },
+  flaxFlower: {
+    name: 'Flax Flower',
+    price: 230,
+    stack: 99,
+    description: 'A delicate flax blossom.',
+    levelRequirement: 0
+  },
+  kaiserinCosmetics: {
+    name: 'Kaiserin Cosmetics',
+    price: 1840,
+    stack: 99,
+    description: 'Cosmetics from the Empire of Aht Urhgan.',
+    levelRequirement: 0
+  },
+  blackChip: {
+    name: 'Black Chip',
+    price: 21000,
+    stack: 1,
+    description: 'A black strange apparatus chip.',
+    levelRequirement: 0
+  },
+  blueChip: {
+    name: 'Blue Chip',
+    price: 21000,
+    stack: 1,
+    description: 'A blue strange apparatus chip.',
+    levelRequirement: 0
+  },
+  clearChip: {
+    name: 'Clear Chip',
+    price: 21000,
+    stack: 1,
+    description: 'A clear strange apparatus chip.',
+    levelRequirement: 0
+  },
+  greenChip: {
+    name: 'Green Chip',
+    price: 21000,
+    stack: 1,
+    description: 'A green strange apparatus chip.',
+    levelRequirement: 0
+  },
+  purpleChip: {
+    name: 'Purple Chip',
+    price: 21000,
+    stack: 1,
+    description: 'A purple strange apparatus chip.',
+    levelRequirement: 0
+  },
+  redChip: {
+    name: 'Red Chip',
+    price: 21000,
+    stack: 1,
+    description: 'A red strange apparatus chip.',
+    levelRequirement: 0
+  },
+  whiteChip: {
+    name: 'White Chip',
+    price: 21000,
+    stack: 1,
+    description: 'A white strange apparatus chip.',
+    levelRequirement: 0
+  },
+  yellowChip: {
+    name: 'Yellow Chip',
+    price: 21000,
+    stack: 1,
+    description: 'A yellow strange apparatus chip.',
+    levelRequirement: 0
+  },
+  linkshell: {
+    name: 'Linkshell',
+    price: 6000,
+    stack: 1,
+    description: 'Creates a social linkshell.',
+    levelRequirement: 0
+  },
+  pendantCompass: {
+    name: 'Pendant Compass',
+    price: 375,
+    stack: 1,
+    description: 'A simple compass pendant.',
+    levelRequirement: 0
+  },
+  cottonHachimaki: {
+    name: 'Cotton Hachimaki',
+    price: 5079,
+    stack: 99,
+    description: 'Headgear woven from cotton.',
+    defense: 4,
+    levelRequirement: 14,
+    slot: 'head',
+    jobs: baseJobNames
+  },
+  cottonDogi: {
+    name: 'Cotton Dogi',
+    price: 7654,
+    stack: 99,
+    description: 'A cotton martial arts tunic.',
+    defense: 10,
+    levelRequirement: 14,
+    slot: 'body',
+    jobs: baseJobNames
+  },
+  cottonTekko: {
+    name: 'Cotton Tekko',
+    price: 4212,
+    stack: 99,
+    description: 'Cotton handguards.',
+    defense: 6,
+    levelRequirement: 14,
+    slot: 'hands',
+    jobs: baseJobNames
+  },
+  cottonSitabaki: {
+    name: 'Cotton Sitabaki',
+    price: 6133,
+    stack: 99,
+    description: 'Cotton shinobi trousers.',
+    defense: 8,
+    levelRequirement: 14,
+    slot: 'legs',
+    jobs: baseJobNames
+  },
+  cottonKyahan: {
+    name: 'Cotton Kyahan',
+    price: 3924,
+    stack: 99,
+    description: 'Cotton boots favored by monks.',
+    defense: 5,
+    levelRequirement: 14,
+    slot: 'feet',
+    jobs: baseJobNames
+  },
+  silverObi: {
+    name: 'Silver Obi',
+    price: 3825,
+    stack: 99,
+    description: 'A belt adorned with silver.',
+    defense: 1,
+    levelRequirement: 14,
+    slot: 'waist',
+    jobs: baseJobNames
+  },
+  hachimaki: {
+    name: 'Hachimaki',
+    price: 742,
+    stack: 99,
+    description: 'Simple cloth headgear.',
+    defense: 2,
+    levelRequirement: 7,
+    slot: 'head',
+    jobs: baseJobNames
+  },
+  kenpogi: {
+    name: 'Kenpogi',
+    price: 1120,
+    stack: 99,
+    description: 'A light practice gi.',
+    defense: 6,
+    levelRequirement: 7,
+    slot: 'body',
+    jobs: baseJobNames
+  },
+  tekko: {
+    name: 'Tekko',
+    price: 616,
+    stack: 99,
+    description: 'Training gloves for monks.',
+    defense: 3,
+    levelRequirement: 7,
+    slot: 'hands',
+    jobs: baseJobNames
+  },
+  sitabaki: {
+    name: 'Sitabaki',
+    price: 895,
+    stack: 99,
+    description: 'Loose martial arts pants.',
+    defense: 4,
+    levelRequirement: 7,
+    slot: 'legs',
+    jobs: baseJobNames
+  },
+  kyahan: {
+    name: 'Kyahan',
+    price: 571,
+    stack: 99,
+    description: 'Simple cloth footwear.',
+    defense: 2,
+    levelRequirement: 7,
+    slot: 'feet',
+    jobs: baseJobNames
+  },
+  bambooStick: {
+    name: 'Bamboo Stick',
+    price: 132,
+    stack: 99,
+    description: 'A basic bamboo pole.',
+    damage: 5,
+    delay: 240,
+    levelRequirement: 1,
+    slot: 'mainHand',
+    jobs: baseJobNames
+  },
+  toolbagIno: {
+    name: 'Toolbag (Ino)',
+    price: 13500,
+    stack: 99,
+    description: 'Bundle of Ino tools for ninjutsu.',
+    levelRequirement: 0
+  },
+  toolbagShika: {
+    name: 'Toolbag (Shika)',
+    price: 18000,
+    stack: 99,
+    description: 'Bundle of Shika tools for ninjutsu.',
+    levelRequirement: 0
+  },
+  toolbagCho: {
+    name: 'Toolbag (Cho)',
+    price: 18000,
+    stack: 99,
+    description: 'Bundle of Cho tools for ninjutsu.',
+    levelRequirement: 0
+  },
+  ironBread: {
+    name: 'Iron Bread',
+    price: 92,
+    stack: 99,
+    description: 'Bread that slightly boosts vitality when eaten.',
+    levelRequirement: 0
+  },
+  bretzel: {
+    name: 'Bretzel',
+    price: 22,
+    stack: 99,
+    description: 'A soft pretzel popular in Bastok.',
+    levelRequirement: 0
+  },
+  pumpernickel: {
+    name: 'Pumpernickel',
+    price: 147,
+    stack: 99,
+    description: 'Dark rye bread with a mild effect.',
+    levelRequirement: 0
+  },
+  sausage: {
+    name: 'Sausage',
+    price: 143,
+    stack: 99,
+    description: 'A grilled sausage that restores a little HP.',
+    levelRequirement: 0
+  },
+  bakedPopoto: {
+    name: 'Baked Popoto',
+    price: 294,
+    stack: 99,
+    description: 'A baked popoto that recovers HP.',
+    levelRequirement: 0
+  },
+  pebbleSoup: {
+    name: 'Pebble Soup',
+    price: 184,
+    stack: 99,
+    description: 'Soup with tiny pebbles for texture.',
+    levelRequirement: 0
+  },
+  pineappleJuice: {
+    name: 'Pineapple Juice',
+    price: 368,
+    stack: 99,
+    description: 'A sweet juice that gradually restores MP.',
+    levelRequirement: 0
+  },
+  melonJuice: {
+    name: 'Melon Juice',
+    price: 1012,
+    stack: 99,
+    description: 'A refreshing melon juice that restores MP over time.',
+    levelRequirement: 0
+  },
+  roastMutton: {
+    name: 'Roast Mutton',
+    price: 662,
+    stack: 99,
+    description: 'A hearty roast of mutton.',
+    levelRequirement: 0
+  },
+  eggSoup: {
+    name: 'Egg Soup',
+    price: 3036,
+    stack: 99,
+    description: 'A soup made from eggs.',
+    levelRequirement: 0
+  },
+  derflandPear: {
+    name: 'Derfland Pear',
+    price: 128,
+    stack: 99,
+    description: 'A sweet pear from the Derfland region.',
+    levelRequirement: 0
+  },
+  ginger: {
+    name: 'Ginger',
+    price: 142,
+    stack: 99,
+    description: 'A fragrant root used in cooking.',
+    levelRequirement: 0
+  },
+  gysahlGreens: {
+    name: 'Gysahl Greens',
+    price: 62,
+    stack: 99,
+    description: 'Favorite food of chocobos.',
+    levelRequirement: 0
+  },
+  oliveFlower: {
+    name: 'Olive Flower',
+    price: 1656,
+    stack: 99,
+    description: 'A delicate olive blossom.',
+    levelRequirement: 0
+  },
+  oliveOil: {
+    name: 'Olive Oil',
+    price: 14,
+    stack: 99,
+    description: 'Oil pressed from olives.',
+    levelRequirement: 0
+  },
+  wijnruit: {
+    name: 'Wijnruit',
+    price: 110,
+    stack: 99,
+    description: 'A pungent herb used in alchemy.',
+    levelRequirement: 0
+  },
+  kazhamPeppers: {
+    name: 'Kazham Peppers',
+    price: 55,
+    stack: 99,
+    description: 'Spicy peppers from Kazham.',
+    levelRequirement: 0
+  },
+  kazhamPineapple: {
+    name: 'Kazham Pineapple',
+    price: 55,
+    stack: 99,
+    description: 'A tropical pineapple.',
+    levelRequirement: 0
+  },
+  mithranTomato: {
+    name: 'Mithran Tomato',
+    price: 36,
+    stack: 99,
+    description: 'A juicy tomato cultivated by Mithra.',
+    levelRequirement: 0
+  },
+  blackPepper: {
+    name: 'Black Pepper',
+    price: 234,
+    stack: 99,
+    description: 'A common spice used in cooking.',
+    levelRequirement: 0
+  },
+  ogrePumpkin: {
+    name: 'Ogre Pumpkin',
+    price: 88,
+    stack: 99,
+    description: 'A large pumpkin.',
+    levelRequirement: 0
+  },
+  kukuruBean: {
+    name: 'Kukuru Bean',
+    price: 110,
+    stack: 99,
+    description: 'A flavorful bean used in sweets.',
+    levelRequirement: 0
+  },
+  phalaenopsis: {
+    name: 'Phalaenopsis',
+    price: 1656,
+    stack: 99,
+    description: 'A rare orchid.',
+    levelRequirement: 0
+  },
+  cattleya: {
+    name: 'Cattleya',
+    price: 1656,
+    stack: 99,
+    description: 'An exotic flower from the uplands.',
+    levelRequirement: 0
+  },
+  cinnamon: {
+    name: 'Cinnamon',
+    price: 239,
+    stack: 99,
+    description: 'Fragrant cinnamon bark.',
+    levelRequirement: 0
+  },
+  pamamas: {
+    name: 'Pamamas',
+    price: 73,
+    stack: 99,
+    description: 'Small sweet bananas.',
+    levelRequirement: 0
+  },
+  rattanLumber: {
+    name: 'Rattan Lumber',
+    price: 147,
+    stack: 99,
+    description: 'Lumber cut from rattan.',
+    levelRequirement: 0
+  },
+  sulfur: {
+    name: 'Sulfur',
+    price: 703,
+    stack: 99,
+    description: 'Yellow sulfur used in alchemy.',
+    levelRequirement: 0
+  },
+  popoto: {
+    name: 'Popoto',
+    price: 43,
+    stack: 99,
+    description: 'A starchy vegetable.',
+    levelRequirement: 0
+  },
+  ryeFlour: {
+    name: 'Rye Flour',
+    price: 36,
+    stack: 99,
+    description: 'Finely milled rye flour.',
+    levelRequirement: 0
+  },
+  eggplant: {
+    name: 'Eggplant',
+    price: 40,
+    stack: 99,
+    description: 'A glossy purple vegetable.',
+    levelRequirement: 0
+  },
+  cactuarNeedle: {
+    name: 'Cactuar Needle',
+    price: 855,
+    stack: 99,
+    description: 'A sharp needle from a cactuar.',
+    levelRequirement: 0
+  },
+  thundermelon: {
+    name: 'Thundermelon',
+    price: 299,
+    stack: 99,
+    description: 'A melon crackling with energy.',
+    levelRequirement: 0
+  },
+  watermelon: {
+    name: 'Watermelon',
+    price: 184,
+    stack: 99,
+    description: 'A juicy watermelon.',
+    levelRequirement: 0
+  },
+  giantSheepMeat: {
+    name: 'Giant Sheep Meat',
+    price: 44,
+    stack: 99,
+    description: 'Meat from a giant sheep.',
+    levelRequirement: 0
+  },
+  driedMarjoram: {
+    name: 'Dried Marjoram',
+    price: 44,
+    stack: 99,
+    description: 'A bundle of dried marjoram.',
+    levelRequirement: 0
+  },
+  sanDoriaFlour: {
+    name: "San d'Oria Flour",
+    price: 55,
+    stack: 99,
+    description: 'Flour milled in San d\'Oria.',
+    levelRequirement: 0
+  },
+  semolina: {
+    name: 'Semolina',
+    price: 1840,
+    stack: 99,
+    description: 'High-quality wheat flour.',
+    levelRequirement: 0
+  },
+  laTheineCabbage: {
+    name: 'La Theine Cabbage',
+    price: 22,
+    stack: 99,
+    description: 'A crisp cabbage from La Theine.',
+    levelRequirement: 0
+  },
+  selbinaMilk: {
+    name: 'Selbina Milk',
+    price: 55,
+    stack: 99,
+    description: 'Fresh milk from Selbina.',
+    levelRequirement: 0
+  },
+  movalpolosWater: {
+    name: 'Movalpolos Water',
+    price: 736,
+    stack: 99,
+    description: 'Water from the depth of Movalpolos.',
+    levelRequirement: 0
+  },
+  danceshroom: {
+    name: 'Danceshroom',
+    price: 4121,
+    stack: 99,
+    description: 'A rare dancing mushroom.',
+    levelRequirement: 0
+  },
+  coralFungus: {
+    name: 'Coral Fungus',
+    price: 694,
+    stack: 99,
+    description: 'A fungus resembling coral.',
+    levelRequirement: 0
+  },
+  kopparnickel: {
+    name: 'Kopparnickel',
+    price: 736,
+    stack: 99,
+    description: 'Ore rich in copper and nickel.',
+    levelRequirement: 0
+  },
+  degen: {
+    name: 'Degen',
+    price: 9406,
+    stack: 1,
+    description: 'A well-balanced broadsword.',
+    damage: 20,
+    delay: 240,
+    levelRequirement: 20,
+    slot: 'mainHand',
+    jobs: ['Warrior','Monk','Red Mage','Paladin','Bard','Dragoon','Corsair','Dancer']
+  },
+  worldPass: {
+    name: 'World Pass',
+    price: 1000,
+    stack: 1,
+    description: 'Allows inviting new players to your world.',
+    levelRequirement: 0
+  },
+  goldWorldPass: {
+    name: 'Gold World Pass',
+    price: 1000,
+    stack: 1,
+    description: 'A gold pass for new characters.',
+    levelRequirement: 0
+  },
+  brassFlowerpot: {
+    name: 'Brass Flowerpot',
+    price: 920,
+    stack: 1,
+    description: 'A small brass pot for gardening.',
+    levelRequirement: 0
+  },
+  republicWaystone: {
+    name: 'Republic Waystone',
+    price: 9200,
+    stack: 1,
+    description: 'Teleports the user to a Bastok location.',
+    levelRequirement: 0
+  },
+  thievesTools: {
+    name: "Thief's Tools",
+    price: 3643,
+    stack: 1,
+    description: 'Used to pick simple locks.',
+    levelRequirement: 0
+  },
+  livingKey: {
+    name: 'Living Key',
+    price: 5520,
+    stack: 1,
+    description: 'Opens locked doors and chests.',
+    levelRequirement: 0
+  },
+  lugworm: {
+    name: 'Lugworm',
+    price: 11,
+    stack: 99,
+    description: 'Common fishing bait.',
+    levelRequirement: 0
+  },
+  littleWorm: {
+    name: 'Little Worm',
+    price: 3,
+    stack: 99,
+    description: 'Small bait for beginner fishers.',
+    levelRequirement: 0
+  },
+  yewFishingRod: {
+    name: 'Yew Fishing Rod',
+    price: 217,
+    stack: 1,
+    description: 'A sturdy fishing rod made of yew.',
+    levelRequirement: 0
+  },
+  willowFishingRod: {
+    name: 'Willow Fishing Rod',
+    price: 66,
+    stack: 1,
+    description: 'A light fishing rod crafted from willow.',
+    levelRequirement: 0
+  },
+  robe: {
+    name: 'Robe',
+    price: 220,
+    stack: 1,
+    description: 'Simple robe for novice adventurers.',
+    defense: 3,
+    levelRequirement: 1,
+    slot: 'body',
+    jobs: baseJobNames
+  },
+  cuffs: {
+    name: 'Cuffs',
+    price: 121,
+    stack: 1,
+    description: 'Basic arm cuffs.',
+    defense: 1,
+    levelRequirement: 1,
+    slot: 'hands',
+    jobs: baseJobNames
+  },
+  slops: {
+    name: 'Slops',
+    price: 176,
+    stack: 1,
+    description: 'Loose legwear for all jobs.',
+    defense: 1,
+    levelRequirement: 1,
+    slot: 'legs',
+    jobs: baseJobNames
+  },
+  ashClogs: {
+    name: 'Ash Clogs',
+    price: 114,
+    stack: 1,
+    description: 'Wooden clogs fashioned from ash.',
+    defense: 1,
+    levelRequirement: 1,
+    slot: 'feet',
+    jobs: baseJobNames
+  },
+  headgear: {
+    name: 'Headgear',
+    price: 1781,
+    stack: 1,
+    description: 'Protective headgear.',
+    defense: 5,
+    levelRequirement: 5,
+    slot: 'head',
+    jobs: ['Warrior','Monk','Thief','Ranger','Paladin','Dark Knight','Beastmaster','Bard','Samurai','Ninja','Dragoon','Blue Mage','Corsair','Dancer','Rune Fencer']
+  },
+  doublet: {
+    name: 'Doublet',
+    price: 2525,
+    stack: 1,
+    description: 'A simple doublet.',
+    defense: 6,
+    levelRequirement: 5,
+    slot: 'body',
+    jobs: ['Warrior','Monk','Red Mage']
+  },
+  gloves: {
+    name: 'Gloves',
+    price: 1393,
+    stack: 1,
+    description: 'Light gloves for adventurers.',
+    defense: 3,
+    levelRequirement: 5,
+    slot: 'hands',
+    jobs: baseJobNames
+  },
+  brais: {
+    name: 'Brais',
+    price: 1941,
+    stack: 1,
+    description: 'Light leg armor.',
+    defense: 5,
+    levelRequirement: 5,
+    slot: 'legs',
+    jobs: ['Warrior','Monk','Dragoon']
+  },
+  gaiters: {
+    name: 'Gaiters',
+    price: 1297,
+    stack: 1,
+    description: 'Protective footwear.',
+    defense: 4,
+    levelRequirement: 5,
+    slot: 'feet',
+    jobs: baseJobNames
+  },
+  paddedCap: {
+    name: 'Padded Cap',
+    price: 18360,
+    stack: 1,
+    description: 'A padded iron cap.',
+    defense: 12,
+    levelRequirement: 35,
+    slot: 'head',
+    jobs: ['Warrior','Monk','Red Mage','Thief','Paladin','Dark Knight','Beastmaster','Bard','Samurai','Ninja','Dragoon','Blue Mage','Corsair','Dancer','Rune Fencer']
+  },
+  ironMask: {
+    name: 'Iron Mask',
+    price: 9234,
+    stack: 1,
+    description: 'A heavy iron mask.',
+    defense: 7,
+    levelRequirement: 15,
+    slot: 'head',
+    jobs: ['Warrior','Paladin','Dark Knight']
+  },
+  paddedArmor: {
+    name: 'Padded Armor',
+    price: 28339,
+    stack: 1,
+    description: 'Body armor lined with padding.',
+    defense: 24,
+    levelRequirement: 35,
+    slot: 'body',
+    jobs: ['Warrior','Monk','Red Mage']
+  },
+  ironMittens: {
+    name: 'Iron Mittens',
+    price: 15552,
+    stack: 1,
+    description: 'Iron gauntlets.',
+    defense: 11,
+    levelRequirement: 15,
+    slot: 'hands',
+    jobs: ['Warrior','Dark Knight']
+  },
+  brassCap: {
+    name: 'Brass Cap',
+    price: 1471,
+    stack: 1,
+    description: 'A cap made of brass.',
+    defense: 4,
+    levelRequirement: 9,
+    slot: 'head',
+    jobs: ['Monk','Thief','Ranger']
+  },
+  leatherBandana: {
+    name: 'Leather Bandana',
+    price: 396,
+    stack: 1,
+    description: 'A rugged leather bandana.',
+    defense: 1,
+    levelRequirement: 10,
+    slot: 'head',
+    jobs: ['Monk','Thief','Ranger']
+  },
+  brassHarness: {
+    name: 'Brass Harness',
+    price: 2236,
+    stack: 1,
+    description: 'Chest armor of polished brass.',
+    defense: 6,
+    levelRequirement: 9,
+    slot: 'body',
+    jobs: ['Monk','Thief']
+  },
+  brassMittens: {
+    name: 'Brass Mittens',
+    price: 1228,
+    stack: 1,
+    description: 'Mittens crafted from brass.',
+    defense: 3,
+    levelRequirement: 9,
+    slot: 'hands',
+    jobs: ['Monk','Thief']
+  },
+  ironSubligar: {
+    name: 'Iron Subligar',
+    price: 23316,
+    stack: 1,
+    description: 'Iron leg protection.',
+    defense: 10,
+    levelRequirement: 20,
+    slot: 'legs',
+    jobs: baseJobNames
+  },
+  lizardTrousers: {
+    name: 'Lizard Trousers',
+    price: 5003,
+    stack: 1,
+    description: 'Trousers made from lizard skin.',
+    defense: 3,
+    levelRequirement: 10,
+    slot: 'legs',
+    jobs: baseJobNames
+  },
+  leggings: {
+    name: 'Leggings',
+    price: 14484,
+    stack: 1,
+    description: 'Sturdy protective leggings.',
+    defense: 11,
+    levelRequirement: 30,
+    slot: 'legs',
+    jobs: baseJobNames
+  },
+  lizardLedelsens: {
+    name: 'Lizard Ledelsens',
+    price: 3162,
+    stack: 1,
+    description: 'Footwear made from lizard skin.',
+    defense: 4,
+    levelRequirement: 17,
+    slot: 'feet',
+    jobs: ['Warrior','Red Mage','Thief','Paladin','Dark Knight','Beastmaster','Bard','Ranger','Samurai','Ninja','Dragoon','Blue Mage','Corsair','Dancer','Rune Fencer']
+  },
+  buckler: {
+    name: 'Buckler',
+    price: 31544,
+    stack: 1,
+    description: 'A sturdy round shield.',
+    defense: 12,
+    levelRequirement: 40,
+    slot: 'offHand',
+    jobs: ['Warrior','Paladin','Black Mage','Red Mage','Thief','Dark Knight']
+  },
+  brassSubligar: {
+    name: 'Brass Subligar',
+    price: 1840,
+    stack: 1,
+    description: 'A subligar fashioned from brass.',
+    defense: 3,
+    levelRequirement: 9,
+    slot: 'legs',
+    jobs: baseJobNames
+  },
+  leatherTrousers: {
+    name: 'Leather Trousers',
+    price: 493,
+    stack: 1,
+    description: 'Simple leather trousers.',
+    defense: 2,
+    levelRequirement: 1,
+    slot: 'legs',
+    jobs: baseJobNames
+  },
+  brassLeggings: {
+    name: 'Brass Leggings',
+    price: 1140,
+    stack: 1,
+    description: 'Leg armor crafted from brass.',
+    defense: 4,
+    levelRequirement: 9,
+    slot: 'legs',
+    jobs: baseJobNames
+  },
+  leatherHighboots: {
+    name: 'Leather Highboots',
+    price: 309,
+    stack: 1,
+    description: 'High-cut leather boots.',
+    defense: 2,
+    levelRequirement: 1,
+    slot: 'feet',
+    jobs: baseJobNames
+  },
+  targe: {
+    name: 'Targe',
+    price: 11076,
+    stack: 1,
+    description: 'A small protective shield.',
+    defense: 8,
+    levelRequirement: 15,
+    slot: 'offHand',
+    jobs: baseJobNames
+  },
+  bronzeSubligar: {
+    name: 'Bronze Subligar',
+    price: 191,
+    stack: 1,
+    description: 'Bronze under-armor.',
+    defense: 1,
+    levelRequirement: 1,
+    slot: 'legs',
+    jobs: baseJobNames
+  },
+  chainHose: {
+    name: 'Chain Hose',
+    price: 11592,
+    stack: 1,
+    description: 'Leg armor of interlocked chain.',
+    defense: 12,
+    levelRequirement: 28,
+    slot: 'legs',
+    jobs: baseJobNames
+  },
+  bronzeLeggings: {
+    name: 'Bronze Leggings',
+    price: 117,
+    stack: 1,
+    description: 'Bronze greaves for beginners.',
+    defense: 2,
+    levelRequirement: 1,
+    slot: 'legs',
+    jobs: baseJobNames
+  },
+  greaves: {
+    name: 'Greaves',
+    price: 7120,
+    stack: 1,
+    description: 'Heavy metal greaves.',
+    defense: 9,
+    levelRequirement: 30,
+    slot: 'feet',
+    jobs: baseJobNames
+  },
+  lauanShield: {
+    name: 'Lauan Shield',
+    price: 110,
+    stack: 1,
+    description: 'A basic wooden shield.',
+    defense: 2,
+    levelRequirement: 1,
+    slot: 'offHand',
+    jobs: baseJobNames
+  },
+  humeTunic: {
+    name: 'Hume Tunic',
+    price: 276,
+    stack: 1,
+    description: 'Starting tunic for Hume males.',
+    defense: 6,
+    levelRequirement: 1,
+    slot: 'body',
+    jobs: ['Hume M']
+  },
+  humeVest: {
+    name: 'Hume Vest',
+    price: 276,
+    stack: 1,
+    description: 'Starting vest for Hume females.',
+    defense: 6,
+    levelRequirement: 1,
+    slot: 'body',
+    jobs: ['Hume F']
+  },
+  humeMGloves: {
+    name: 'Hume M Gloves',
+    price: 165,
+    stack: 1,
+    description: 'Gloves sized for Hume males.',
+    defense: 2,
+    levelRequirement: 1,
+    slot: 'hands',
+    jobs: ['Hume M']
+  },
+  humeFGloves: {
+    name: 'Hume F Gloves',
+    price: 165,
+    stack: 1,
+    description: 'Gloves sized for Hume females.',
+    defense: 2,
+    levelRequirement: 1,
+    slot: 'hands',
+    jobs: ['Hume F']
+  },
+  humeSlacks: {
+    name: 'Hume Slacks',
+    price: 239,
+    stack: 1,
+    description: 'Starting pants for Humes.',
+    defense: 2,
+    levelRequirement: 1,
+    slot: 'legs',
+    jobs: ['Hume']
+  },
+  humeMBoots: {
+    name: 'Hume M Boots',
+    price: 165,
+    stack: 1,
+    description: 'Boots sized for Hume males.',
+    defense: 2,
+    levelRequirement: 1,
+    slot: 'feet',
+    jobs: ['Hume M']
+  },
+  humeFBoots: {
+    name: 'Hume F Boots',
+    price: 165,
+    stack: 1,
+    description: 'Boots sized for Hume females.',
+    defense: 2,
+    levelRequirement: 1,
+    slot: 'feet',
+    jobs: ['Hume F']
+  },
+  galkanSurcoat: {
+    name: 'Galkan Surcoat',
+    price: 276,
+    stack: 1,
+    description: 'Starting surcoat for Galkas.',
+    defense: 6,
+    levelRequirement: 1,
+    slot: 'body',
+    jobs: ['Galka']
+  },
+  galkanBracers: {
+    name: 'Galkan Bracers',
+    price: 165,
+    stack: 1,
+    description: 'Bracers sized for Galkas.',
+    defense: 2,
+    levelRequirement: 1,
+    slot: 'hands',
+    jobs: ['Galka']
+  },
+  galkanBraguette: {
+    name: 'Galkan Braguette',
+    price: 239,
+    stack: 1,
+    description: 'Legwear for Galkas.',
+    defense: 2,
+    levelRequirement: 1,
+    slot: 'legs',
+    jobs: ['Galka']
+  },
+  galkanSandals: {
+    name: 'Galkan Sandals',
+    price: 165,
+    stack: 1,
+    description: 'Sandals for Galkas.',
+    defense: 2,
+    levelRequirement: 1,
+    slot: 'feet',
+    jobs: ['Galka']
+  },
+  chocoboFeather: {
+    name: 'Chocobo Feather',
+    price: 7,
+    stack: 99,
+    description: 'Feather used to revive chocobos.',
+    levelRequirement: 0
+  },
+  dart: {
+    name: 'Dart',
+    price: 9,
+    stack: 99,
+    description: 'A small dart for chocobo racing.',
+    levelRequirement: 0
+  },
+  blackChocoboFeather: {
+    name: 'Black Chocobo Feather',
+    price: 1150,
+    stack: 99,
+    description: 'Revives a black chocobo.',
+    levelRequirement: 0
+  },
+  petFoodAlphaBiscuit: {
+    name: 'Pet Food Alpha Biscuit',
+    price: 11,
+    stack: 99,
+    description: 'Biscuit that boosts pet speed.',
+    levelRequirement: 0
+  },
+  petFoodBetaBiscuit: {
+    name: 'Pet Food Beta Biscuit',
+    price: 82,
+    stack: 99,
+    description: 'Biscuit that extends sprint duration.',
+    levelRequirement: 0
+  },
+  carrotBroth: {
+    name: 'Carrot Broth',
+    price: 82,
+    stack: 99,
+    description: 'Pet broth made from carrots.',
+    levelRequirement: 0
+  },
+  bugBroth: {
+    name: 'Bug Broth',
+    price: 695,
+    stack: 99,
+    description: 'Pet broth teeming with insects.',
+    levelRequirement: 0
+  },
+  herbalBroth: {
+    name: 'Herbal Broth',
+    price: 126,
+    stack: 99,
+    description: 'Aromatic herb-based pet feed.',
+    levelRequirement: 0
+  },
+  carrionBroth: {
+    name: 'Carrion Broth',
+    price: 695,
+    stack: 99,
+    description: 'Pet feed made from carrion.',
+    levelRequirement: 0
+  },
+  scrollChocoboMazurka: {
+    name: 'Scroll of Chocobo Mazurka',
+    price: 50784,
+    stack: 1,
+    description: 'Teaches the song Chocobo Mazurka.',
+    levelRequirement: 75
+  },
+  pickledHerring: {
+    name: 'Pickled Herring',
+    price: 441,
+    stack: 12,
+    description: 'A salty preserved fish.',
+    levelRequirement: 0
+  },
+  hiPotion: {
+    name: 'Hi-Potion',
+    price: 3375,
+    stack: 12,
+    description: 'Restores a large amount of HP.',
+    levelRequirement: 0
+  },
+  triturator: {
+    name: 'Triturator',
+    price: 75,
+    stack: 1,
+    description: 'An alchemy tool for grinding.',
+    levelRequirement: 0
+  },
+  beehiveChip: {
+    name: 'Beehive Chip',
+    price: 192,
+    stack: 99,
+    description: 'A chunk of honeycomb.',
+    levelRequirement: 0
+  },
+  cobaltJellyfish: {
+    name: 'Cobalt Jellyfish',
+    price: 114,
+    stack: 12,
+    description: 'A bright blue jellyfish.',
+    levelRequirement: 0
+  },
+  holyWater: {
+    name: 'Holy Water',
+    price: 5250,
+    stack: 12,
+    description: 'Cures petrification.',
+    levelRequirement: 0
+  },
+  prismPowder: {
+    name: 'Prism Powder',
+    price: 1050,
+    stack: 12,
+    description: 'Creates an invisible barrier.',
+    levelRequirement: 0
+  },
+  bombAsh: {
+    name: 'Bomb Ash',
+    price: 1004,
+    stack: 99,
+    description: 'Ash from an exploded bomb.',
+    levelRequirement: 0
+  },
+  beaugreens: {
+    name: 'Beaugreens',
+    price: 90,
+    stack: 99,
+    description: 'A leafy vegetable from Fauregandi.',
+    levelRequirement: 0
+  },
+  faerieApple: {
+    name: 'Faerie Apple',
+    price: 39,
+    stack: 99,
+    description: 'A sweet apple from Fauregandi.',
+    levelRequirement: 0
+  },
+  mapleLog: {
+    name: 'Maple Log',
+    price: 54,
+    stack: 99,
+    description: 'A log cut from a maple tree.',
+    levelRequirement: 0
   }
 };
 
@@ -846,6 +2087,32 @@ export const vendorInventories = {
   "Blacksmith's Guild": ['bronzeIngot', 'copperOre', 'pickaxe'],
   "Blacksmiths' Guild": ['bronzeIngot', 'copperOre', 'pickaxe'],
   'Mining Guild': ['pickaxe', 'copperOre'],
+  "Boytz's Knickknacks": ['potion', 'ether', 'echoDrops', 'eyeDrops', 'antidote', 'woodenArrow', 'ironArrow', 'crossbowBolt', 'brassFlowerpot', 'pickaxe', 'republicWaystone', 'thievesTools', 'livingKey'],
+  "Gelzerio's Stall": ['lugworm', 'littleWorm', 'bambooFishingRod', 'yewFishingRod', 'willowFishingRod', 'robe', 'cuffs', 'slops', 'ashClogs', 'headgear', 'doublet', 'gloves', 'brais', 'gaiters'],
+  "Deegis's Armour": ['paddedCap', 'ironMask', 'paddedArmor', 'ironMittens', 'brassCap', 'leatherBandana', 'brassHarness', 'leatherVest', 'brassMittens', 'leatherGloves', 'bronzeCap', 'bronzeHarness'],
+  Zemedars: ['ironSubligar', 'lizardTrousers', 'leggings', 'lizardLedelsens', 'buckler', 'brassSubligar', 'leatherTrousers', 'brassLeggings', 'leatherHighboots', 'targe', 'bronzeSubligar', 'chainHose', 'bronzeLeggings', 'greaves', 'lauanShield'],
+  'Proud Beard': ['humeTunic', 'humeVest', 'humeMGloves', 'humeFGloves', 'humeSlacks', 'humeMBoots', 'humeFBoots', 'galkanSurcoat', 'galkanBracers', 'galkanBraguette', 'galkanSandals'],
+  "Neigepance's Chocobo Stables": ['gysahlGreens', 'chocoboFeather', 'dart', 'blackChocoboFeather', 'petFoodAlphaBiscuit', 'petFoodBetaBiscuit', 'carrotBroth', 'bugBroth', 'herbalBroth', 'carrionBroth', 'scrollChocoboMazurka'],
+  "Griselda's Tavern": ['pineappleJuice', 'bretzel', 'pickledHerring', 'melonJuice', 'ironBread', 'meatJerky', 'distilledWater'],
+  "Alchemists' Guild": ['triturator', 'beehiveChip', 'cobaltJellyfish', 'potion', 'hiPotion', 'ether', 'antidote', 'eyeDrops', 'echoDrops', 'holyWater', 'prismPowder', 'bombAsh'],
+  "Rodellieux's Stall": ['beaugreens', 'faerieApple', 'mapleLog'],
+  Denvihr: ['ashLog', 'chestnutLog', 'oakLog', 'copperOre', 'ironOre', 'mythrilOre', 'mokoGrass', 'birdEgg', 'flaxFlower', 'kaiserinCosmetics'],
+  Blabbivix: ['blackChip', 'blueChip', 'clearChip', 'greenChip', 'purpleChip', 'redChip', 'whiteChip', 'yellowChip'],
+  Galvin: ['potion', 'ether', 'echoDrops', 'eyeDrops', 'antidote', 'woodenArrow', 'ironArrow', 'crossbowBolt'],
+  Ilita: ['linkshell', 'pendantCompass'],
+  Numa: ['cottonHachimaki', 'cottonDogi', 'cottonTekko', 'cottonSitabaki', 'cottonKyahan', 'silverObi', 'hachimaki', 'kenpogi', 'tekko', 'sitabaki', 'kyahan', 'bambooStick', 'pickaxe', 'toolbagIno', 'toolbagShika', 'toolbagCho'],
+  Melloa: ['ironBread', 'bretzel', 'pumpernickel', 'sausage', 'bakedPopoto', 'pebbleSoup', 'pineappleJuice', 'melonJuice', 'roastMutton', 'eggSoup', 'distilledWater'],
+  Sawyer: ['ironBread', 'bretzel', 'pumpernickel', 'sausage', 'bakedPopoto', 'pebbleSoup', 'pineappleJuice', 'melonJuice', 'roastMutton', 'eggSoup', 'distilledWater'],
+  Sugandhi: ['degen'],
+  Belka: ['derflandPear', 'ginger', 'gysahlGreens', 'oliveFlower', 'oliveOil', 'wijnruit'],
+  'Zoby Quhyo': ['kazhamPeppers', 'kazhamPineapple', 'mithranTomato', 'blackPepper', 'ogrePumpkin', 'kukuruBean', 'phalaenopsis'],
+  'Dhen Tevryukoh': ['cattleya', 'cinnamon', 'pamamas', 'rattanLumber'],
+  Evelyn: ['sulfur', 'popoto', 'ryeFlour', 'eggplant'],
+  Vattian: ['cactuarNeedle', 'thundermelon', 'watermelon'],
+  Rosswald: ['giantSheepMeat', 'driedMarjoram', 'sanDoriaFlour', 'ryeFlour', 'semolina', 'laTheineCabbage', 'selbinaMilk'],
+  Bagnobrok: ['movalpolosWater', 'copperOre', 'danceshroom', 'coralFungus', 'kopparnickel'],
+  Kachada: ['worldPass', 'goldWorldPass'],
+  Rex: ['bastokMap', 'sandoriaMap', 'windurstMap', 'jeunoMap', 'valkurmMap'],
   'Brunhilde the Armourer': ['mythrilSallet', 'breastplate', 'gauntlets', 'brassMask', 'sallet', 'brassScaleMail', 'brassFingerGauntlets', 'bronzeCap', 'faceguard', 'bronzeHarness', 'scaleMail', 'bronzeMittens', 'scaleFingerGauntlets'],
   'Ciqala': ['bronzeKnuckles', 'brassKnuckles', 'metalKnuckles', 'bronzeHammer', 'brassHammer', 'warhammer', 'mapleWand'],
   'Carmelide': ['tourmaline', 'sardonyx', 'amethyst', 'amber', 'lapisLazuli', 'clearTopaz', 'onyx', 'lightOpal', 'copperRing'],
@@ -860,5 +2127,16 @@ export const shopNpcs = {
   "Dragon's Claw Weaponry": ['Ciqala'],
   "Carmelide's Jewelry Store": ['Carmelide'],
   "Harmodios's Music Shop": ['Hortense'],
-  'Scribe & Notary': ['Sororo']
+  'Scribe & Notary': ['Sororo'],
+  "Galvin's Travel Gear": ['Galvin', 'Ilita', 'Numa'],
+  'Steaming Sheep Restaurant': ['Melloa', 'Sawyer'],
+  "Boytz's Knickknacks": ['Boytz'],
+  "Gelzerio's Stall": ['Gelzerio'],
+  "Deegis's Armour": ['Deegis'],
+  Zemedars: ['Zemedars'],
+  'Proud Beard': ['Proud Beard'],
+  "Neigepance's Chocobo Stables": ['Neigepance'],
+  "Griselda's Tavern": ['Griselda'],
+  "Alchemists' Guild": ['Odoba', 'Maymunah'],
+  "Rodellieux's Stall": ['Rodellieux']
 };


### PR DESCRIPTION
## Summary
- expand Bastok Mines points of interest with each merchant stall
- define many new items for the Bastok Mines shops
- add vendor inventories for Boytz, Gelzerio, Deegis and others
- map new shop NPCs like Rodellieux and Neigepance

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_68804d902fbc83258548c7dde05ddde8