### PR TITLE
Implement autosave and temporary buff logic

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -40,6 +40,9 @@ button {
     z-index: 1000;
     display: flex;
     align-items: center;
+    background: rgba(0, 0, 0, 0.6);
+    padding: 4px;
+    border-radius: 4px;
 }
 
 #user-controls {
@@ -49,6 +52,9 @@ button {
     z-index: 999;
     display: flex;
     align-items: center;
+    background: rgba(0, 0, 0, 0.6);
+    padding: 4px;
+    border-radius: 4px;
 }
 
 #user-controls select,

--- a/data/index.js
+++ b/data/index.js
@@ -22,7 +22,11 @@ export {
   setCurrentUser,
   currentUser,
   grantSignet,
-  hasSignet
+  hasSignet,
+  clearTemporaryEffects,
+  pruneExpiredEffects,
+  persistCharacter,
+  setLocation
 } from './characters.js';
 export { proficiencyScale, getScale } from './scales.js';
 export { names, randomName } from './names.js';


### PR DESCRIPTION
## Summary
- autosave character data when important fields change
- track temporary buffs and debuffs with expiration
- clear temporary status when entering a city or after defeat
- update UI to show active temporary effects
- give persistent UI controls a background

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_6880f55451108325a10845d17c20204c