### PR TITLE
Implement autosave and temporary buff logic

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -40,6 +40,9 @@ button {
     z-index: 1000;
     display: flex;
     align-items: center;
+    background: rgba(0, 0, 0, 0.6);
+    padding: 4px;
+    border-radius: 4px;
 }
 
 #user-controls {
@@ -49,6 +52,9 @@ button {
     z-index: 999;
     display: flex;
     align-items: center;
+    background: rgba(0, 0, 0, 0.6);
+    padding: 4px;
+    border-radius: 4px;
 }
 
 #user-controls select,

--- a/data/index.js
+++ b/data/index.js
@@ -22,7 +22,11 @@ export {
   setCurrentUser,
   currentUser,
   grantSignet,
-  hasSignet
+  hasSignet,
+  clearTemporaryEffects,
+  pruneExpiredEffects,
+  persistCharacter,
+  setLocation
 } from './characters.js';
 export { proficiencyScale, getScale } from './scales.js';
 export { names, randomName } from './names.js';

--- a/js/ui.js
+++ b/js/ui.js
@@ -22,7 +22,11 @@ import {
     setCurrentUser,
     currentUser,
     grantSignet,
-    hasSignet
+    hasSignet,
+    clearTemporaryEffects,
+    pruneExpiredEffects,
+    persistCharacter,
+    setLocation
 } from '../data/index.js';
 import { randomName, raceInfo, jobInfo, cityImages, getZoneTravelTurns, rollForEncounter, exploreEncounter, parseLevel } from '../data/index.js';
 
@@ -210,8 +214,15 @@ function statusEffectsDisplay() {
     const div = document.createElement('div');
     div.id = 'status-effects';
     if (!activeCharacter) return div;
-    const buffs = activeCharacter.buffs || [];
-    const debuffs = activeCharacter.debuffs || [];
+    pruneExpiredEffects(activeCharacter);
+    const buffs = [
+        ...(activeCharacter.buffs || []),
+        ...((activeCharacter.temporaryBuffs || []).map(b => b.name))
+    ];
+    const debuffs = [
+        ...(activeCharacter.debuffs || []),
+        ...((activeCharacter.temporaryDebuffs || []).map(d => d.name))
+    ];
     if (!hasSignet(activeCharacter)) {
         const idx = buffs.indexOf('Signet');
         if (idx !== -1) buffs.splice(idx, 1);
@@ -751,8 +762,11 @@ export function renderAreaScreen(root) {
             travelList.appendChild(exploreLi);
         }
 
-        const travelKeywords = /(airship|ferry|chocobo|home point|gate|dock|boat)/i;
+        const travelKeywords = /(airship|ferry|chocobo|rental|home point|dock|boat|stable|crystal)/i;
         const travelPOIs = loc.pointsOfInterest.filter(p => travelKeywords.test(p));
+
+        const craftingKeywords = /guild/i;
+        const craftingPOIs = loc.pointsOfInterest.filter(p => craftingKeywords.test(p) && !travelPOIs.includes(p));
 
         loc.connectedAreas.forEach(area => {
             const li = document.createElement('li');
@@ -780,7 +794,7 @@ export function renderAreaScreen(root) {
                 activeCharacter.travel.remaining -= 1;
                 if (activeCharacter.travel.remaining <= 0) {
                     const prev = loc.name;
-                    activeCharacter.currentLocation = area;
+                    setLocation(activeCharacter, area);
                     activeCharacter.travel = null;
                     if (activeCharacter.returnJourney) {
                         if (area === activeCharacter.returnJourney.zone) {
@@ -792,6 +806,7 @@ export function renderAreaScreen(root) {
                         activeCharacter.returnJourney = { zone: prev, turns: 1 };
                     }
                 }
+                persistCharacter(activeCharacter);
                 renderAreaScreen(root);
             });
             li.appendChild(btn);
@@ -808,6 +823,23 @@ export function renderAreaScreen(root) {
         });
         travelCol.appendChild(travelList);
 
+        const craftCol = document.createElement('div');
+        craftCol.className = 'area-column';
+        const craftHeader = document.createElement('h3');
+        craftHeader.textContent = 'Crafting';
+        craftCol.appendChild(craftHeader);
+        const craftList = document.createElement('ul');
+
+        craftingPOIs.forEach(p => {
+            const li = document.createElement('li');
+            const btn = document.createElement('button');
+            btn.textContent = p;
+            btn.addEventListener('click', () => openMenu(p));
+            li.appendChild(btn);
+            craftList.appendChild(li);
+        });
+        craftCol.appendChild(craftList);
+
         const marketCol = document.createElement('div');
         marketCol.className = 'area-column';
         const marketHeader = document.createElement('h3');
@@ -815,8 +847,8 @@ export function renderAreaScreen(root) {
         marketCol.appendChild(marketHeader);
         const marketList = document.createElement('ul');
 
-        const marketKeywords = /(shop|store|auction|guild|merchant|market)/i;
-        const marketPOIs = loc.pointsOfInterest.filter(p => marketKeywords.test(p) && !travelPOIs.includes(p));
+        const marketKeywords = /(shop|store|auction|merchant|market|armor|armour|weapon|smith|vendor)/i;
+        const marketPOIs = loc.pointsOfInterest.filter(p => marketKeywords.test(p) && !travelPOIs.includes(p) && !craftingPOIs.includes(p));
 
         marketPOIs.forEach(p => {
             const li = document.createElement('li');
@@ -836,7 +868,7 @@ export function renderAreaScreen(root) {
         const otherList = document.createElement('ul');
 
         loc.pointsOfInterest.forEach(p => {
-            if (travelPOIs.includes(p) || marketPOIs.includes(p)) return;
+            if (travelPOIs.includes(p) || craftingPOIs.includes(p) || marketPOIs.includes(p)) return;
             const li = document.createElement('li');
             const btn = document.createElement('button');
             btn.textContent = p;
@@ -860,6 +892,7 @@ export function renderAreaScreen(root) {
         otherCol.appendChild(otherList);
 
         grid.appendChild(travelCol);
+        grid.appendChild(craftCol);
         grid.appendChild(marketCol);
         grid.appendChild(otherCol);
         root.appendChild(grid);
@@ -993,8 +1026,9 @@ function renderCombatScreen(root, mob, destination) {
             activeCharacter.gil += gil;
             addItemsToInventory(itemDrops);
             if (destination && activeCharacter.hp > 0) {
-                activeCharacter.currentLocation = destination;
+                setLocation(activeCharacter, destination);
             }
+            persistCharacter(activeCharacter);
             renderAreaScreen(root);
         });
         lootDiv.appendChild(btn);
@@ -1093,7 +1127,8 @@ function renderCombatScreen(root, mob, destination) {
     function endBattle() {
         if (activeCharacter.hp <= 0) {
             activeCharacter.hp = 1;
-            activeCharacter.currentLocation = activeCharacter.currentHomePoint || activeCharacter.startingCity;
+            setLocation(activeCharacter, activeCharacter.currentHomePoint || activeCharacter.startingCity);
+            clearTemporaryEffects(activeCharacter);
             log('You were defeated and return to your home point.');
         }
         battleEnded = true;
@@ -1101,8 +1136,9 @@ function renderCombatScreen(root, mob, destination) {
         btn.textContent = 'Continue';
         btn.addEventListener('click', () => {
             if (destination && activeCharacter.hp > 0) {
-                activeCharacter.currentLocation = destination;
+                setLocation(activeCharacter, destination);
             }
+            persistCharacter(activeCharacter);
             renderAreaScreen(root);
         });
         root.appendChild(btn);
@@ -1235,7 +1271,7 @@ export function renderTravelScreen(root) {
             const btn = document.createElement('button');
             btn.textContent = area;
             btn.addEventListener('click', () => {
-                activeCharacter.currentLocation = area;
+                setLocation(activeCharacter, area);
                 renderAreaScreen(root);
             });
             li.appendChild(btn);
@@ -1280,6 +1316,7 @@ function buyItem(id, qty = 1) {
     } else {
         activeCharacter.inventory.push({ id, qty });
     }
+    persistCharacter(activeCharacter);
     alert(`Purchased ${qty} x ${item.name}.`);
 }
 
@@ -1411,6 +1448,7 @@ export function renderEquipmentScreen(root) {
                 unequip.textContent = 'Unequip';
                 unequip.addEventListener('click', () => {
                     activeCharacter.equipment[key] = null;
+                    persistCharacter(activeCharacter);
                     renderEquipmentScreen(root);
                 });
                 li.appendChild(unequip);
@@ -1451,6 +1489,7 @@ function equipItem(id, root) {
     const item = items[id];
     if (!canEquipItem(item)) return;
     activeCharacter.equipment[item.slot] = id;
+    persistCharacter(activeCharacter);
     renderInventoryScreen(root);
 }
 
@@ -1551,12 +1590,14 @@ function openMenu(name, backFn) {
         if (!activeCharacter.homePoints.includes(zone)) {
             activeCharacter.homePoints.push(zone);
             alert('You have attuned to this home point crystal.');
+            persistCharacter(activeCharacter);
         }
         const setBtn = document.createElement('button');
         setBtn.textContent = 'Set Home Point';
         setBtn.addEventListener('click', () => {
             activeCharacter.currentHomePoint = zone;
             alert('Home point set.');
+            persistCharacter(activeCharacter);
         });
         root.appendChild(setBtn);
         const select = document.createElement('select');
@@ -1570,7 +1611,8 @@ function openMenu(name, backFn) {
             const dest = select.value;
             if (activeCharacter.gil < 1000) return alert('Not enough gil.');
             activeCharacter.gil -= 1000;
-            activeCharacter.currentLocation = dest;
+            setLocation(activeCharacter, dest);
+            persistCharacter(activeCharacter);
             renderAreaScreen(root);
         });
         root.appendChild(document.createElement('br'));
@@ -1588,6 +1630,7 @@ function openMenu(name, backFn) {
         signetBtn.addEventListener('click', () => {
             grantSignet(activeCharacter);
             alert('Signet bestowed.');
+            persistCharacter(activeCharacter);
             renderAreaScreen(root);
         });
         root.appendChild(signetBtn);


### PR DESCRIPTION
## Summary
- autosave character data when important fields change
- track temporary buffs and debuffs with expiration
- clear temporary status when entering a city or after defeat
- update UI to show active temporary effects
- give persistent UI controls a background
- refine city area categories

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_6880f55451108325a10845d17c20204c