### PR TITLE
Improve main menu layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -25,6 +25,7 @@ button {
     color: #fff;
     border: 1px solid #555;
     cursor: pointer;
+    min-height: 28px;
 }
 
 #app {
@@ -46,15 +47,7 @@ button {
 }
 
 #user-controls {
-    position: fixed;
-    top: 38px;
-    right: 5px;
-    z-index: 999;
-    display: flex;
-    align-items: center;
-    background: rgba(0, 0, 0, 0.6);
-    padding: 4px;
-    border-radius: 4px;
+    display: none;
 }
 
 #user-controls select,
@@ -97,21 +90,12 @@ button:hover {
 }
 
 #menu {
-    margin-top: 50px;
+    margin-top: 0;
     display: flex;
-    gap: 10px;
-    padding: 10px;
-}
-
-body.portrait #menu {
     flex-direction: column;
     align-items: center;
-}
-
-body.landscape #menu {
-    flex-direction: row;
-    align-items: center;
-    justify-content: center;
+    gap: 10px;
+    padding: 10px;
 }
 
 #menu button {
@@ -178,6 +162,7 @@ body.landscape #area-grid {
 
 .slot-entry button {
     margin-left: 5px;
+    width: 80px;
 }
 
 #slot-container {
@@ -267,6 +252,18 @@ body.portrait .character-form {
     margin-top: 20px;
 }
 
+.main-layout {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 20px;
+}
+
+body.portrait .main-layout {
+    flex-direction: column;
+    align-items: center;
+}
+
 #active-profile div {
     margin-top: 6px;
 }
@@ -347,6 +344,18 @@ body.portrait .character-form {
 
 .inventory-list li {
     margin-top: 4px;
+}
+
+.char-menu-controls {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin-bottom: 20px;
+}
+
+.char-menu-controls select,
+.char-menu-controls button {
+    width: 180px;
 }
 
 .item-description {

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls } from './ui.js';
+import { renderMainMenu, renderCharacterMenu, setupBackButton } from './ui.js';
 import { loadCharacters, initCurrentUser } from '../data/index.js';
 
 // Entry point: initialize application
@@ -23,8 +23,6 @@ function init() {
     const menu = renderMainMenu();
     app.appendChild(menu);
 
-    const userContainer = document.getElementById('user-controls');
-    if (userContainer) renderUserControls();
 
     const backBtn = document.getElementById('back-button');
     if (backBtn) setupBackButton(backBtn);


### PR DESCRIPTION
## Summary
- remove floating user controls and integrate in character menu
- allow taller buttons and ensure consistent widths
- adjust main menu layout so profile displays beside buttons
- show active character name as heading and add gil display
- display `Active` instead of `Load` for the current slot

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688140f06c188325bd8518ec17586d71