### PR TITLE
Show EXP needed for next level

### DIFF
--- a/data/experience.js
+++ b/data/experience.js
@@ -1329,3 +1329,19 @@ export function experienceForKill(playerLevel, monsterLevel) {
   const idx = Math.min(19, Math.floor((playerLevel - 1) / 5));
   return row[idx] || 0;
 }
+
+export const expToLevel = (() => {
+  const table = { 1: 0 };
+  let total = 0;
+  for (let lvl = 1; lvl < 100; lvl++) {
+    total += lvl * 100;
+    table[lvl + 1] = total;
+  }
+  return table;
+})();
+
+export function expNeeded(character) {
+  const next = expToLevel[character.level + 1];
+  if (next === undefined) return 0;
+  return Math.max(next - (character.experience || 0), 0);
+}

--- a/data/index.js
+++ b/data/index.js
@@ -33,7 +33,7 @@ export { names, randomName } from './names.js';
 export { raceInfo, jobInfo, cityImages } from './descriptions.js';
 export { cityList, zonesByCity, locations, zoneNames } from './locations.js';
 export { bestiaryByZone, allMonsters } from './bestiary.js';
-export { experienceTable, experienceForKill } from './experience.js';
+export { experienceTable, expToLevel, expNeeded, experienceForKill } from './experience.js';
 export { items, vendorInventories, shopNpcs } from './vendors.js';
 export {
   parseLevel,

--- a/js/ui.js
+++ b/js/ui.js
@@ -28,7 +28,7 @@ import {
     persistCharacter,
     setLocation
 } from '../data/index.js';
-import { randomName, raceInfo, jobInfo, cityImages, getZoneTravelTurns, rollForEncounter, exploreEncounter, parseLevel, experienceForKill } from '../data/index.js';
+import { randomName, raceInfo, jobInfo, cityImages, getZoneTravelTurns, rollForEncounter, exploreEncounter, parseLevel, experienceForKill, expNeeded } from '../data/index.js';
 
 let backButtonElement = null;
 
@@ -310,11 +310,15 @@ export function renderMainMenu() {
         const line5 = document.createElement('div');
         line5.textContent = `Gil: ${activeCharacter.gil}`;
 
+        const line6 = document.createElement('div');
+        line6.textContent = `EXP to Next Level: ${expNeeded(activeCharacter)}`;
+
         profile.appendChild(charImg);
         profile.appendChild(line2);
         profile.appendChild(line3);
         profile.appendChild(line4);
         profile.appendChild(line5);
+        profile.appendChild(line6);
         layout.appendChild(profile);
 
         // Previously the main menu displayed several buttons that allowed the


### PR DESCRIPTION
## Summary
- create cumulative EXP table with helper
- export new helper from data index
- display EXP needed on main menu

## Testing
- `node scripts/testTaruBlm.js`
- `node scripts/testBalance.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688181c9e128832583ca7eb34a1d1506