### PR TITLE
Improve character creation UI and images

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -205,6 +205,18 @@ body.portrait .character-form {
 
 .form-field {
     margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.form-field label {
+    width: 90px;
+}
+
+.form-field input,
+.form-field select {
+    flex: 1;
 }
 
 .form-stats {

--- a/data/descriptions.js
+++ b/data/descriptions.js
@@ -83,3 +83,80 @@ export const cityImages = {
   "San d'Oria": 'https://via.placeholder.com/150?text=San+d%27Oria',
   Windurst: 'https://via.placeholder.com/150?text=Windurst'
 };
+
+export const characterImages = {
+  Hume: {
+    Male: {
+      Warrior: 'Male Hume/Male hume warrior.png',
+      Monk: 'Male Hume/Male hume monk.png',
+      'White Mage': 'Male Hume/Male hume white mage.png',
+      'Black Mage': 'Male Hume/Male hume black mage.png',
+      'Red Mage': 'Male Hume/Male hume red mage.png',
+      Thief: 'Male Hume/Male hume Thief.png'
+    },
+    Female: {
+      Warrior: 'Female Hume/Female Hume Warrior.png',
+      Monk: 'Female Hume/Female Hume Monk.png',
+      'White Mage': 'Female Hume/Female Hume White Mage.png',
+      'Black Mage': 'Female Hume/Female Hume Black Mage.png',
+      'Red Mage': 'Female Hume/Female Hume Red Mage.png',
+      Thief: 'Female Hume/Female Hume Thief 1.png'
+    }
+  },
+  Elvaan: {
+    Male: {
+      Warrior: 'Male Elvaan/Male Elvaan Warrior.png',
+      Monk: 'Male Elvaan/Male Elvaan Monk.png',
+      'White Mage': 'Male Elvaan/Male Elvaan White Mage.png',
+      'Black Mage': 'Male Elvaan/Male Elvaan Black Mage.png',
+      'Red Mage': 'Male Elvaan/Male Elvaan Red Mage.png',
+      Thief: 'Male Elvaan/Male Elvaan Thief.png'
+    },
+    Female: {
+      Warrior: 'Female Elvaan/Female elvaan warrior.png',
+      Monk: 'Female Elvaan/Female elvaan monk.png',
+      'White Mage': 'Female Elvaan/Female elvaan white mage.png',
+      'Black Mage': 'Female Elvaan/Female elvaan black mage.png',
+      'Red Mage': 'Female Elvaan/Female elvaan red mage.png',
+      Thief: 'Female Elvaan/Female Elvaan Thief 1.png'
+    }
+  },
+  Tarutaru: {
+    Male: {
+      Warrior: 'Male Tarutaru/Male Tarutaru Warrior.png',
+      Monk: 'Male Tarutaru/Male Tarutaru Monk.png',
+      'White Mage': 'Male Tarutaru/Male Tarutaru White Mage.png',
+      'Black Mage': 'Male Tarutaru/Male Tarutaru Black Mage.png',
+      'Red Mage': 'Male Tarutaru/Male Tarutaru Red Mage.png',
+      Thief: 'Male Tarutaru/Male Tarutaru Thief.png'
+    },
+    Female: {
+      Warrior: 'Female Tarutaru/Female Tarutaru Warrior.png',
+      Monk: 'Female Tarutaru/Female Tarutaru Monk.png',
+      'White Mage': 'Female Tarutaru/Female Tarutaru White Mage.png',
+      'Black Mage': 'Female Tarutaru/Female Tarutaru Black Mage.png',
+      'Red Mage': 'Female Tarutaru/Female Tarutaru Red Mage.png',
+      Thief: 'Female Tarutaru/Female Tarutaru Thief.png'
+    }
+  },
+  Mithra: {
+    Female: {
+      Warrior: 'Mithra/Mithra warrior.png',
+      Monk: 'Mithra/Mithra monk.png',
+      'White Mage': 'Mithra/Mithra white mage.png',
+      'Black Mage': 'Mithra/Mithra black mage.png',
+      'Red Mage': 'Mithra/Mithra Red Mage.png',
+      Thief: 'Mithra/Mithra thief.png'
+    }
+  },
+  Galka: {
+    Male: {
+      Warrior: 'Galka/Galka Warrior.png',
+      Monk: 'Galka/Galka Monk.png',
+      'White Mage': 'Galka/Galka White Mage.png',
+      'Black Mage': 'Galka/Galka Black Mage.png',
+      'Red Mage': 'Galka/Galka Red Mage.png',
+      Thief: 'Galka/Galka Thief.png'
+    }
+  }
+};

--- a/data/index.js
+++ b/data/index.js
@@ -30,7 +30,7 @@ export {
 } from './characters.js';
 export { proficiencyScale, getScale } from './scales.js';
 export { names, randomName } from './names.js';
-export { raceInfo, jobInfo, cityImages } from './descriptions.js';
+export { raceInfo, jobInfo, cityImages, characterImages } from './descriptions.js';
 export { cityList, zonesByCity, locations, zoneNames } from './locations.js';
 export { bestiaryByZone, allMonsters } from './bestiary.js';
 export { experienceTable, expToLevel, expNeeded, experienceForKill } from './experience.js';

--- a/js/ui.js
+++ b/js/ui.js
@@ -28,7 +28,7 @@ import {
     persistCharacter,
     setLocation
 } from '../data/index.js';
-import { randomName, raceInfo, jobInfo, cityImages, getZoneTravelTurns, rollForEncounter, exploreEncounter, parseLevel, experienceForKill, expNeeded } from '../data/index.js';
+import { randomName, raceInfo, jobInfo, cityImages, characterImages, getZoneTravelTurns, rollForEncounter, exploreEncounter, parseLevel, experienceForKill, expNeeded } from '../data/index.js';
 
 let backButtonElement = null;
 
@@ -290,7 +290,7 @@ export function renderMainMenu() {
 
         const charImg = document.createElement('img');
         charImg.className = 'character-img';
-        charImg.src = raceInfo[activeCharacter.race]?.image || '';
+        charImg.src = characterImages[activeCharacter.race]?.[activeCharacter.sex]?.[activeCharacter.job] || '';
 
     const line2 = document.createElement('div');
 
@@ -323,22 +323,23 @@ export function renderMainMenu() {
         }
         line6.textContent = progressText;
 
-        const modeBtn = document.createElement('button');
-        modeBtn.textContent = `Mode: ${activeCharacter.xpMode}`;
-        modeBtn.addEventListener('click', () => {
-            if (activeCharacter.level >= 99) {
-                if (activeCharacter.xpMode === 'EXP') activeCharacter.xpMode = 'LP';
-                else if (activeCharacter.xpMode === 'LP') activeCharacter.xpMode = 'CP';
-                else activeCharacter.xpMode = 'EXP';
-            } else if (activeCharacter.level >= 75) {
-                activeCharacter.xpMode = activeCharacter.xpMode === 'EXP' ? 'LP' : 'EXP';
-            } else {
-                activeCharacter.xpMode = 'EXP';
-            }
-            persistCharacter(activeCharacter);
-            const menu = renderMainMenu();
-            container.replaceWith(menu);
-        });
+        let modeBtn = null;
+        if (activeCharacter.level >= 75) {
+            modeBtn = document.createElement('button');
+            modeBtn.textContent = `Mode: ${activeCharacter.xpMode}`;
+            modeBtn.addEventListener('click', () => {
+                if (activeCharacter.level >= 99) {
+                    if (activeCharacter.xpMode === 'EXP') activeCharacter.xpMode = 'LP';
+                    else if (activeCharacter.xpMode === 'LP') activeCharacter.xpMode = 'CP';
+                    else activeCharacter.xpMode = 'EXP';
+                } else {
+                    activeCharacter.xpMode = activeCharacter.xpMode === 'EXP' ? 'LP' : 'EXP';
+                }
+                persistCharacter(activeCharacter);
+                const menu = renderMainMenu();
+                container.replaceWith(menu);
+            });
+        }
 
         profile.appendChild(charImg);
         profile.appendChild(line2);
@@ -346,7 +347,7 @@ export function renderMainMenu() {
         profile.appendChild(line4);
         profile.appendChild(line5);
         profile.appendChild(line6);
-        profile.appendChild(modeBtn);
+        if (modeBtn) profile.appendChild(modeBtn);
         layout.appendChild(profile);
 
         // Previously the main menu displayed several buttons that allowed the
@@ -509,6 +510,10 @@ function renderNewCharacterForm(root) {
     const inputs = document.createElement('div');
     inputs.className = 'form-inputs';
 
+    const statsList = document.createElement('ul');
+    statsList.className = 'stats-list';
+    inputs.appendChild(statsList);
+
     const nameField = document.createElement('div');
     nameField.className = 'form-field';
     const nameLabel = document.createElement('label');
@@ -595,10 +600,6 @@ function renderNewCharacterForm(root) {
         updateInfo();
     });
     inputs.appendChild(randomBtn);
-
-    const statsList = document.createElement('ul');
-    statsList.className = 'stats-list';
-    inputs.appendChild(statsList);
     const cityDiv = document.createElement('div');
     cityDiv.className = 'start-city';
     inputs.appendChild(cityDiv);
@@ -614,11 +615,9 @@ function renderNewCharacterForm(root) {
 
     const raceHeader = document.createElement('h3');
     raceHeader.className = 'race-header';
-    statsCol.appendChild(raceHeader);
 
     const raceDesc = document.createElement('p');
     raceDesc.className = 'race-desc';
-    statsCol.appendChild(raceDesc);
 
     const raceImg = document.createElement('img');
     raceImg.className = 'race-img';
@@ -630,6 +629,9 @@ function renderNewCharacterForm(root) {
     const infoCol = document.createElement('div');
     infoCol.className = 'form-traits';
 
+    infoCol.appendChild(raceHeader);
+    infoCol.appendChild(raceDesc);
+
     const jobHeader = document.createElement('h3');
     jobHeader.className = 'job-header';
     infoCol.appendChild(jobHeader);
@@ -637,10 +639,6 @@ function renderNewCharacterForm(root) {
     const jobDesc = document.createElement('p');
     jobDesc.className = 'job-desc';
     infoCol.appendChild(jobDesc);
-
-    const jobImg = document.createElement('img');
-    jobImg.className = 'job-img';
-    infoCol.appendChild(jobImg);
 
     const traitsHeader = document.createElement('h4');
     traitsHeader.textContent = 'Traits';
@@ -670,10 +668,9 @@ function renderNewCharacterForm(root) {
         );
         statsList.innerHTML = '';
         raceHeader.textContent = raceSelect.value;
-        raceImg.src = raceInfo[raceSelect.value]?.image || '';
+        raceImg.src = characterImages[raceSelect.value]?.[sexSelect.value]?.[jobSelect.value] || '';
         raceDesc.textContent = raceInfo[raceSelect.value]?.description || '';
         jobHeader.textContent = jobSelect.value;
-        jobImg.src = jobInfo[jobSelect.value]?.image || '';
         let jd = jobInfo[jobSelect.value]?.description || '';
         jd = jd.replace(/ (Skills:)/, '<br><br>$1')
                .replace(/ (Magic:)/, '<br><br>$1')


### PR DESCRIPTION
## Summary
- map race/job/sex images in data files
- export `characterImages` for other modules
- style form fields consistently and reorder character creation sections
- display correct character image and hide mode selector until level 75

## Testing
- `node --check js/ui.js`
- `node --check data/descriptions.js`
- `node --check data/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68819ad576f4832583cb1b91fe38f146