### PR TITLE
Improve character creation layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -199,7 +199,7 @@ body.portrait .character-form {
 }
 
 .form-inputs {
-    flex: 1;
+    flex: 0.8;
     text-align: left;
 }
 
@@ -220,7 +220,7 @@ body.portrait .character-form {
 }
 
 .form-stats {
-    flex: 1;
+    flex: 1.2;
     text-align: left;
 }
 
@@ -285,7 +285,7 @@ body.portrait .main-layout {
 }
 
 .race-img, .job-img, .city-img, .character-img {
-    width: 150px;
+    width: clamp(120px, 20vw, 200px);
     height: auto;
     display: block;
     margin: 0 auto 10px auto;
@@ -303,6 +303,7 @@ body.portrait .main-layout {
 
 .stats-list {
     margin-top: 10px;
+    margin-bottom: 10px;
 }
 
 .stats-list li {

--- a/js/ui.js
+++ b/js/ui.js
@@ -600,12 +600,6 @@ function renderNewCharacterForm(root) {
         updateInfo();
     });
     inputs.appendChild(randomBtn);
-    const cityDiv = document.createElement('div');
-    cityDiv.className = 'start-city';
-    inputs.appendChild(cityDiv);
-    const cityImg = document.createElement('img');
-    cityImg.className = 'city-img';
-    inputs.appendChild(cityImg);
 
     form.appendChild(inputs);
     // middle column: stats display
@@ -622,6 +616,13 @@ function renderNewCharacterForm(root) {
     const raceImg = document.createElement('img');
     raceImg.className = 'race-img';
     statsCol.appendChild(raceImg);
+
+    const cityDiv = document.createElement('div');
+    cityDiv.className = 'start-city';
+    statsCol.appendChild(cityDiv);
+    const cityImg = document.createElement('img');
+    cityImg.className = 'city-img';
+    statsCol.appendChild(cityImg);
 
     form.appendChild(statsCol);
 


### PR DESCRIPTION
## Summary
- shrink first column and expand second column in character creation screen
- add spacing below the stat list
- make images responsive on main and creation screens
- move starting city info under the character image

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_6881a7e6169c8325852d9e9ac4e717f8