### PR TITLE
Fix zone menus and update monster data

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -165,8 +165,12 @@ body.landscape #area-grid {
 
 .slot-entry button {
     margin-left: 5px;
-    width: 80px;
+    width: auto;
+    padding: 2px 6px;
+    font-size: 14px;
+    line-height: 1;
     text-align: center;
+    min-height: 0;
 }
 
 #slot-container {
@@ -396,7 +400,9 @@ body.portrait .main-layout {
 
 .char-menu-controls select,
 .char-menu-controls button {
-    width: 180px;
+    width: auto;
+    padding: 2px 6px;
+    font-size: 14px;
 }
 
 .item-description {

--- a/data/bestiary.js
+++ b/data/bestiary.js
@@ -3,17 +3,73 @@ export const bestiaryByZone = {
     {
       name: 'Forest Hare',
       level: '1-5',
+      exp: 27,
+      hp: 30,
+      element: 'Water',
       str: 2,
       vit: 2,
-      drops: ['Rabbit Hide', 'Rabbit Meat'],
+      drops: ['Hare Meat', 'Rabbit Hide'],
+      dropRates: {
+        'Hare Meat': '50-75%',
+        'Rabbit Hide': '2-10%'
+      },
+      steal: 'San d\'Oria Carrot',
       aggressive: false,
       linking: false,
-      detection: 'Sight',
-      attacks: ['Attack'],
-      skills: ['Foot Kick'],
+      detection: 'Sight & Scent',
+      attacks: ['Nip'],
+      skills: [],
       magic: [],
-      weaknesses: ['Fire'],
-      resistances: []
+      weaknesses: ['Ice', 'Lightning'],
+      resistances: ['Fire', 'Earth']
+    },
+    {
+      name: 'Wild Rabbit',
+      level: '1-2',
+      exp: 27,
+      hp: 25,
+      element: 'Water',
+      str: 2,
+      vit: 2,
+      drops: ['Hare Meat', 'Rabbit Hide'],
+      dropRates: {
+        'Hare Meat': '50-75%',
+        'Rabbit Hide': '2-10%'
+      },
+      steal: 'San d\'Oria Carrot',
+      aggressive: false,
+      linking: false,
+      detection: 'Sight & Scent',
+      attacks: ['Nip'],
+      skills: [],
+      magic: [],
+      weaknesses: ['Ice', 'Lightning'],
+      resistances: ['Fire', 'Earth']
+    },
+    {
+      name: 'Carrion Worm',
+      level: '1-5',
+      exp: 36,
+      hp: 50,
+      element: 'Earth',
+      str: 3,
+      vit: 3,
+      drops: ['Copper Ore', 'Flint Stone', 'Silver Ore', 'Zinc Ore'],
+      dropRates: {
+        'Copper Ore': '5-15%',
+        'Flint Stone': '10-20%',
+        'Silver Ore': '1-5%',
+        'Zinc Ore': '1-3%'
+      },
+      steal: 'Pebble',
+      aggressive: true,
+      linking: false,
+      detection: 'Sound',
+      attacks: ['Bite'],
+      skills: ['Poison Mist'],
+      magic: [],
+      weaknesses: ['Wind', 'Light'],
+      resistances: ['Earth']
     },
     {
       name: 'Tiny Bee',
@@ -50,17 +106,73 @@ export const bestiaryByZone = {
     {
       name: 'Forest Hare',
       level: '1-5',
+      exp: 27,
+      hp: 30,
+      element: 'Water',
       str: 2,
       vit: 2,
-      drops: ['Rabbit Hide', 'Rabbit Meat'],
+      drops: ['Hare Meat', 'Rabbit Hide'],
+      dropRates: {
+        'Hare Meat': '50-75%',
+        'Rabbit Hide': '2-10%'
+      },
+      steal: 'San d\'Oria Carrot',
       aggressive: false,
       linking: false,
-      detection: 'Sight',
-      attacks: ['Attack'],
-      skills: ['Foot Kick'],
+      detection: 'Sight & Scent',
+      attacks: ['Nip'],
+      skills: [],
       magic: [],
-      weaknesses: ['Fire'],
-      resistances: []
+      weaknesses: ['Ice', 'Lightning'],
+      resistances: ['Fire', 'Earth']
+    },
+    {
+      name: 'Wild Rabbit',
+      level: '1-2',
+      exp: 27,
+      hp: 25,
+      element: 'Water',
+      str: 2,
+      vit: 2,
+      drops: ['Hare Meat', 'Rabbit Hide'],
+      dropRates: {
+        'Hare Meat': '50-75%',
+        'Rabbit Hide': '2-10%'
+      },
+      steal: 'San d\'Oria Carrot',
+      aggressive: false,
+      linking: false,
+      detection: 'Sight & Scent',
+      attacks: ['Nip'],
+      skills: [],
+      magic: [],
+      weaknesses: ['Ice', 'Lightning'],
+      resistances: ['Fire', 'Earth']
+    },
+    {
+      name: 'Carrion Worm',
+      level: '1-5',
+      exp: 36,
+      hp: 50,
+      element: 'Earth',
+      str: 3,
+      vit: 3,
+      drops: ['Copper Ore', 'Flint Stone', 'Silver Ore', 'Zinc Ore'],
+      dropRates: {
+        'Copper Ore': '5-15%',
+        'Flint Stone': '10-20%',
+        'Silver Ore': '1-5%',
+        'Zinc Ore': '1-3%'
+      },
+      steal: 'Pebble',
+      aggressive: true,
+      linking: false,
+      detection: 'Sound',
+      attacks: ['Bite'],
+      skills: ['Poison Mist'],
+      magic: [],
+      weaknesses: ['Wind', 'Light'],
+      resistances: ['Earth']
     },
     {
       name: 'Tiny Bee',
@@ -112,16 +224,25 @@ export const bestiaryByZone = {
     {
       name: 'Tunnel Worm',
       level: '1-3',
+      exp: 14,
+      hp: 25,
+      element: 'Earth',
       str: 2,
       vit: 2,
-      drops: ['Worm Thread', 'Pebble'],
+      drops: ['Flint Stone', 'Copper Ore', 'Zinc Ore'],
+      dropRates: {
+        'Flint Stone': '17.5-23.5%',
+        'Copper Ore': '0-1.8%',
+        'Zinc Ore': '2.5-6%'
+      },
+      steal: 'Pebble',
       aggressive: false,
       linking: false,
       detection: 'Sound',
-      attacks: ['Attack'],
-      skills: ['Sandpit'],
+      attacks: ['Bite'],
+      skills: ['Sandpit', 'Stone'],
       magic: [],
-      weaknesses: ['Ice'],
+      weaknesses: ['Wind', 'Light'],
       resistances: ['Earth']
     },
     {
@@ -138,6 +259,29 @@ export const bestiaryByZone = {
       magic: [],
       weaknesses: ['Lightning'],
       resistances: []
+    },
+    {
+      name: 'Ding Bat',
+      level: '1-5',
+      exp: 16,
+      hp: 35,
+      element: 'Wind',
+      str: 3,
+      vit: 2,
+      drops: ['Bat Wing'],
+      dropRates: {
+        'Bat Wing': '14.5-31.2%'
+      },
+      steal: null,
+      aggressive: true,
+      linking: false,
+      detection: 'Sound',
+      attacks: ['Claw'],
+      skills: [],
+      magic: [],
+      weaknesses: ['Ice', 'Light'],
+      resistances: ['Water', 'Dark'],
+      nightOnly: true
     }
   ],
   'North Gustaberg (West)': [
@@ -159,16 +303,25 @@ export const bestiaryByZone = {
     {
       name: 'Tunnel Worm',
       level: '1-3',
+      exp: 14,
+      hp: 25,
+      element: 'Earth',
       str: 2,
       vit: 2,
-      drops: ['Worm Thread', 'Pebble'],
+      drops: ['Flint Stone', 'Copper Ore', 'Zinc Ore'],
+      dropRates: {
+        'Flint Stone': '17.5-23.5%',
+        'Copper Ore': '0-1.8%',
+        'Zinc Ore': '2.5-6%'
+      },
+      steal: 'Pebble',
       aggressive: false,
       linking: false,
       detection: 'Sound',
-      attacks: ['Attack'],
-      skills: ['Sandpit'],
+      attacks: ['Bite'],
+      skills: ['Sandpit', 'Stone'],
       magic: [],
-      weaknesses: ['Ice'],
+      weaknesses: ['Wind', 'Light'],
       resistances: ['Earth']
     },
     {
@@ -185,6 +338,27 @@ export const bestiaryByZone = {
       magic: [],
       weaknesses: ['Lightning'],
       resistances: []
+    },
+    {
+      name: 'Ding Bat',
+      level: '1-5',
+      exp: 16,
+      hp: 35,
+      element: 'Wind',
+      str: 3,
+      vit: 2,
+      drops: ['Bat Wing'],
+      dropRates: { 'Bat Wing': '14.5-31.2%' },
+      steal: null,
+      aggressive: true,
+      linking: false,
+      detection: 'Sound',
+      attacks: ['Claw'],
+      skills: [],
+      magic: [],
+      weaknesses: ['Ice', 'Light'],
+      resistances: ['Water', 'Dark'],
+      nightOnly: true
     }
   ],
   'South Gustaberg': [
@@ -206,16 +380,25 @@ export const bestiaryByZone = {
     {
       name: 'Tunnel Worm',
       level: '1-3',
+      exp: 14,
+      hp: 25,
+      element: 'Earth',
       str: 2,
       vit: 2,
-      drops: ['Worm Thread', 'Pebble'],
+      drops: ['Flint Stone', 'Copper Ore', 'Zinc Ore'],
+      dropRates: {
+        'Flint Stone': '17.5-23.5%',
+        'Copper Ore': '0-1.8%',
+        'Zinc Ore': '2.5-6%'
+      },
+      steal: 'Pebble',
       aggressive: false,
       linking: false,
       detection: 'Sound',
-      attacks: ['Attack'],
-      skills: ['Sandpit'],
+      attacks: ['Bite'],
+      skills: ['Sandpit', 'Stone'],
       magic: [],
-      weaknesses: ['Ice'],
+      weaknesses: ['Wind', 'Light'],
       resistances: ['Earth']
     },
     {
@@ -232,6 +415,27 @@ export const bestiaryByZone = {
       magic: [],
       weaknesses: ['Fire'],
       resistances: []
+    },
+    {
+      name: 'Ding Bat',
+      level: '1-5',
+      exp: 16,
+      hp: 35,
+      element: 'Wind',
+      str: 3,
+      vit: 2,
+      drops: ['Bat Wing'],
+      dropRates: { 'Bat Wing': '14.5-31.2%' },
+      steal: null,
+      aggressive: true,
+      linking: false,
+      detection: 'Sound',
+      attacks: ['Claw'],
+      skills: [],
+      magic: [],
+      weaknesses: ['Ice', 'Light'],
+      resistances: ['Water', 'Dark'],
+      nightOnly: true
     }
   ],
   'West Sarutabaruta': [
@@ -264,6 +468,30 @@ export const bestiaryByZone = {
       magic: [],
       weaknesses: ['Fire'],
       resistances: []
+    },
+    {
+      name: 'Land Crab',
+      level: '1-3',
+      exp: 11,
+      hp: 40,
+      element: 'Water',
+      str: 3,
+      vit: 3,
+      drops: ['Chunk of Rock Salt', 'Slice of Land Crab Meat', 'Water Cluster'],
+      dropRates: {
+        'Chunk of Rock Salt': '20-23%',
+        'Slice of Land Crab Meat': '1-2%',
+        'Water Cluster': '0.01%'
+      },
+      steal: 'Rock Salt',
+      aggressive: false,
+      linking: false,
+      detection: 'Sight',
+      attacks: ['Claw'],
+      skills: [],
+      magic: [],
+      weaknesses: ['Ice', 'Lightning'],
+      resistances: ['Fire', 'Earth']
     },
     {
       name: 'Yagudo Initiate',

--- a/js/ui.js
+++ b/js/ui.js
@@ -52,7 +52,8 @@ function createImageContainer() {
     let index = 0;
 
     function update() {
-        img.src = images[index] || '';
+        const src = images[index] || '';
+        img.src = src ? encodeURI(src) : '';
         const show = images.length > 1;
         left.style.display = show ? 'block' : 'none';
         right.style.display = show ? 'block' : 'none';
@@ -963,13 +964,14 @@ export function renderAreaScreen(root) {
             marketItems.push(li);
         });
         let marketCol = null;
+        let marketList = null;
         if (marketItems.length) {
             marketCol = document.createElement('div');
             marketCol.className = 'area-column';
             const marketHeader = document.createElement('h3');
             marketHeader.textContent = 'Marketplace';
             marketCol.appendChild(marketHeader);
-            const marketList = document.createElement('ul');
+            marketList = document.createElement('ul');
             marketItems.forEach(li => marketList.appendChild(li));
             marketCol.appendChild(marketList);
         }
@@ -997,7 +999,7 @@ export function renderAreaScreen(root) {
             btn.textContent = n;
             btn.addEventListener('click', () => openMenu(n));
             li.appendChild(btn);
-            if (merchantNPC.test(n)) {
+            if (merchantNPC.test(n) && marketList) {
                 marketList.appendChild(li);
             } else {
                 otherList.appendChild(li);


### PR DESCRIPTION
## Summary
- prevent missing grid columns in area screens when no marketplaces exist
- URL-encode race/job image paths
- style character menu buttons for better alignment
- expand starter monster entries with drops and stats

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js | head -n 5`
- `node scripts/testTaruBlm.js | head -n 4`

------
https://chatgpt.com/codex/tasks/task_e_6881b0e03e308325aaa2d01d29c6cf87