### PR TITLE
Add collapsible gear details

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -391,6 +391,38 @@ body.portrait .main-layout {
     margin-top: 4px;
 }
 
+.inventory-item {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+}
+
+.inventory-row-top {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+}
+
+.equipment-item {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+}
+
+.equipment-row-top {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+}
+
+.hidden {
+    display: none;
+}
+
 .char-menu-controls {
     display: flex;
     justify-content: center;
@@ -408,6 +440,13 @@ body.portrait .main-layout {
 .item-description {
     font-size: 0.9em;
     text-align: left;
+}
+
+.item-details {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
 }
 
 .item-stats {


### PR DESCRIPTION
## Summary
- add functions to hide and toggle item details
- reset detail visibility when rendering lists
- wrap gear details in `.item-details` containers
- keep controls inline using new flex classes
- style collapsible rows and hidden items

## Testing
- `node scripts/testBalance.js | head -n 20`
- `node scripts/testTaruBlm.js | head -n 2`
- `node scripts/validateZones.js | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6881ba071e308325a497c58e9dfe1b0c