### PR TITLE
Use mob EXP values

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Open `index.html` in a browser. No build step is required.
 - White Mage is fully verified as well, with `verified.traits = true` and `verified.abilities = true`.
 - Paladin and Bard data has been confirmed, with `verified.traits = true` and `verified.abilities = true` for both jobs.
 - Initial bestiary data lists low-level monsters for zones adjacent to the three starting cities.
-- `experienceForKill(level, targetLevel)` replicates FFXI's EXP table including level difference adjustments.
+- Monsters award experience using their `exp` value from the bestiary instead of level scaling.
 - Basic encounter simulation using `walkAcrossZone()` and `rollForEncounter()` with level-based aggro rates.
 - Traveling through non-combat zones (areas without entries in the bestiary) only
   takes a single turn and never triggers encounters.

--- a/js/ui.js
+++ b/js/ui.js
@@ -28,7 +28,7 @@ import {
     persistCharacter,
     setLocation
 } from '../data/index.js';
-import { randomName, raceInfo, jobInfo, cityImages, characterImages, getZoneTravelTurns, rollForEncounter, exploreEncounter, parseLevel, experienceForKill, expNeeded } from '../data/index.js';
+import { randomName, raceInfo, jobInfo, cityImages, characterImages, getZoneTravelTurns, rollForEncounter, exploreEncounter, parseLevel, expNeeded } from '../data/index.js';
 
 let backButtonElement = null;
 let openDetailElement = null;
@@ -1195,7 +1195,7 @@ function renderCombatScreen(root, mob, destination) {
     }
 
     function monsterDefeated() {
-        const exp = experienceForKill(activeCharacter.level, mobLevel);
+        const exp = mob.exp || 0;
         let gil = 0;
         if (/(Orc|Yagudo|Goblin|Quadav|Moblin)/i.test(mob.name)) {
             gil = Math.floor(mobLevel * 5 + Math.random() * mobLevel * 5);


### PR DESCRIPTION
## Summary
- drop dependency on experienceForKill
- award EXP based on each monster's `exp` property
- update README to mention change

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js | head`
- `node scripts/testTaruBlm.js | head`


------
https://chatgpt.com/codex/tasks/task_e_6881c44c16308325bac0d4a38e078615