### PR TITLE
Add spawn point, scroll usage, hide equipped items

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,14 @@ Open `index.html` in a browser. No build step is required.
 - White Mage is fully verified as well, with `verified.traits = true` and `verified.abilities = true`.
 - Paladin and Bard data has been confirmed, with `verified.traits = true` and `verified.abilities = true` for both jobs.
 - Initial bestiary data lists low-level monsters for zones adjacent to the three starting cities.
-- Monsters award experience using their `exp` value from the bestiary instead of level scaling.
+- Experience from battles is based on the level difference between your character and the monster.
 - Basic encounter simulation using `walkAcrossZone()` and `rollForEncounter()` with level-based aggro rates.
 - Traveling through non-combat zones (areas without entries in the bestiary) only
   takes a single turn and never triggers encounters.
-- Leaving a zone begins a return counter at `1/10`. Each subsequent turn spent
-  moving away from the previous zone increases the turns required to return
-  (capped at ten).
+- Each city now tracks a travel-turn counter. Leaving any city sets that city's
+  counter to `1/10` and increments the counters for other cities. Moving deeper
+  into the wilderness increases these counters up to ten, while entering a city
+  resets its counter to `0`.
 - Encountering a monster now opens a battle screen showing player and enemy
   details with an initiative roll to decide who acts first.
 - City vendors now sell basic weapons, armor, scrolls and consumables at

--- a/data/bestiary.js
+++ b/data/bestiary.js
@@ -3,7 +3,6 @@ export const bestiaryByZone = {
     {
       name: 'Forest Hare',
       level: '1-5',
-      exp: 27,
       hp: 30,
       element: 'Water',
       str: 2,
@@ -26,7 +25,6 @@ export const bestiaryByZone = {
     {
       name: 'Wild Rabbit',
       level: '1-2',
-      exp: 27,
       hp: 25,
       element: 'Water',
       str: 2,
@@ -49,7 +47,6 @@ export const bestiaryByZone = {
     {
       name: 'Carrion Worm',
       level: '1-5',
-      exp: 36,
       hp: 50,
       element: 'Earth',
       str: 3,
@@ -74,7 +71,6 @@ export const bestiaryByZone = {
     {
       name: 'Tiny Bee',
       level: '1-3',
-      exp: 10,
       str: 2,
       vit: 2,
       drops: ['Insect Wing', 'Beeswax', 'Honey'],
@@ -90,7 +86,6 @@ export const bestiaryByZone = {
     {
       name: 'Orcish Fodder',
       level: '3-8',
-      exp: 20,
       str: 6,
       vit: 4,
       drops: ['Orcish Axe', 'Bronze Axe', 'Stone'],
@@ -108,7 +103,6 @@ export const bestiaryByZone = {
     {
       name: 'Forest Hare',
       level: '1-5',
-      exp: 27,
       hp: 30,
       element: 'Water',
       str: 2,
@@ -131,7 +125,6 @@ export const bestiaryByZone = {
     {
       name: 'Wild Rabbit',
       level: '1-2',
-      exp: 27,
       hp: 25,
       element: 'Water',
       str: 2,
@@ -154,7 +147,6 @@ export const bestiaryByZone = {
     {
       name: 'Carrion Worm',
       level: '1-5',
-      exp: 36,
       hp: 50,
       element: 'Earth',
       str: 3,
@@ -179,7 +171,6 @@ export const bestiaryByZone = {
     {
       name: 'Tiny Bee',
       level: '1-3',
-      exp: 10,
       str: 2,
       vit: 2,
       drops: ['Insect Wing', 'Beeswax', 'Honey'],
@@ -195,7 +186,6 @@ export const bestiaryByZone = {
     {
       name: 'Orcish Fodder',
       level: '3-8',
-      exp: 20,
       str: 6,
       vit: 4,
       drops: ['Orcish Axe', 'Bronze Axe', 'Stone'],
@@ -213,7 +203,6 @@ export const bestiaryByZone = {
     {
       name: 'Huge Wasp',
       level: '1-2',
-      exp: 11,
       str: 2,
       vit: 2,
       drops: ['Insect Wing', 'Beeswax', 'Honey'],
@@ -229,7 +218,6 @@ export const bestiaryByZone = {
     {
       name: 'Tunnel Worm',
       level: '1-3',
-      exp: 14,
       hp: 25,
       element: 'Earth',
       str: 2,
@@ -253,7 +241,6 @@ export const bestiaryByZone = {
     {
       name: 'Vulture',
       level: '2-6',
-      exp: 30,
       str: 4,
       vit: 2,
       drops: ['Bird Feather', 'Bird Egg'],
@@ -269,7 +256,6 @@ export const bestiaryByZone = {
     {
       name: 'Ding Bat',
       level: '1-5',
-      exp: 16,
       hp: 35,
       element: 'Wind',
       str: 3,
@@ -292,7 +278,6 @@ export const bestiaryByZone = {
     {
       name: 'Stone Eater',
       level: '2-5',
-      exp: 69,
       element: 'Earth',
       str: 3,
       vit: 3,
@@ -316,7 +301,6 @@ export const bestiaryByZone = {
     {
       name: 'Maneating Hornet',
       level: '2-5',
-      exp: 40,
       hp: 100,
       element: 'Wind',
       str: 3,
@@ -341,7 +325,6 @@ export const bestiaryByZone = {
     {
       name: 'Walking Sapling',
       level: '2-6',
-      exp: 40,
       element: 'Earth',
       str: 3,
       vit: 3,
@@ -361,7 +344,6 @@ export const bestiaryByZone = {
     {
       name: 'Huge Wasp',
       level: '1-2',
-      exp: 11,
       str: 2,
       vit: 2,
       drops: ['Insect Wing', 'Beeswax', 'Honey'],
@@ -377,7 +359,6 @@ export const bestiaryByZone = {
     {
       name: 'Tunnel Worm',
       level: '1-3',
-      exp: 14,
       hp: 25,
       element: 'Earth',
       str: 2,
@@ -401,7 +382,6 @@ export const bestiaryByZone = {
     {
       name: 'Vulture',
       level: '2-6',
-      exp: 30,
       str: 4,
       vit: 2,
       drops: ['Bird Feather', 'Bird Egg'],
@@ -417,7 +397,6 @@ export const bestiaryByZone = {
     {
       name: 'Ding Bat',
       level: '1-5',
-      exp: 16,
       hp: 35,
       element: 'Wind',
       str: 3,
@@ -438,7 +417,6 @@ export const bestiaryByZone = {
     {
       name: 'Stone Eater',
       level: '2-5',
-      exp: 69,
       element: 'Earth',
       str: 3,
       vit: 3,
@@ -462,7 +440,6 @@ export const bestiaryByZone = {
     {
       name: 'Maneating Hornet',
       level: '2-5',
-      exp: 40,
       hp: 100,
       element: 'Wind',
       str: 3,
@@ -487,7 +464,6 @@ export const bestiaryByZone = {
     {
       name: 'Walking Sapling',
       level: '2-6',
-      exp: 40,
       element: 'Earth',
       str: 3,
       vit: 3,
@@ -507,7 +483,6 @@ export const bestiaryByZone = {
     {
       name: 'Huge Wasp',
       level: '1-2',
-      exp: 11,
       str: 2,
       vit: 2,
       drops: ['Insect Wing', 'Beeswax', 'Honey'],
@@ -523,7 +498,6 @@ export const bestiaryByZone = {
     {
       name: 'Tunnel Worm',
       level: '1-3',
-      exp: 14,
       hp: 25,
       element: 'Earth',
       str: 2,
@@ -547,7 +521,6 @@ export const bestiaryByZone = {
     {
       name: 'Vulture',
       level: '2-6',
-      exp: 30,
       str: 4,
       vit: 2,
       drops: ['Bird Feather', 'Bird Egg'],
@@ -563,7 +536,6 @@ export const bestiaryByZone = {
     {
       name: 'Mad Sheep',
       level: '2-3',
-      exp: 15,
       str: 2,
       vit: 2,
       drops: ['Sheepskin', 'Sheep Meat', 'Wool'],
@@ -579,7 +551,6 @@ export const bestiaryByZone = {
     {
       name: 'Ding Bat',
       level: '1-5',
-      exp: 16,
       hp: 35,
       element: 'Wind',
       str: 3,
@@ -600,7 +571,6 @@ export const bestiaryByZone = {
     {
       name: 'Walking Sapling',
       level: '2-6',
-      exp: 49,
       hp: 78,
       element: 'Earth',
       str: 3,
@@ -621,7 +591,6 @@ export const bestiaryByZone = {
     {
       name: 'Savanna Rarab',
       level: '1-6',
-      exp: 15,
       str: 3,
       vit: 2,
       drops: ['Rabbit Hide', 'Rabbit Meat'],
@@ -637,7 +606,6 @@ export const bestiaryByZone = {
     {
       name: 'Tiny Mandragora',
       level: '1',
-      exp: 10,
       str: 2,
       vit: 2,
       drops: ['Mandragora Flower', 'La Theine Cabbage'],
@@ -651,9 +619,32 @@ export const bestiaryByZone = {
       resistances: []
     },
     {
+      name: 'Mandragora',
+      level: '3-5',
+      hp: 95,
+      element: 'Earth',
+      str: 3,
+      vit: 3,
+      drops: ['Cornette', 'Four-Leaf Mandragora Bud', 'Two-Leaf Mandragora Bud', 'Yuhtunga Sulfur'],
+      dropRates: {
+        'Cornette': '13%',
+        'Four-Leaf Mandragora Bud': '1%',
+        'Two-Leaf Mandragora Bud': '12%',
+        'Yuhtunga Sulfur': '4%'
+      },
+      steal: 'Saruta Cotton',
+      aggressive: true,
+      linking: false,
+      detection: 'Sound',
+      attacks: ['Root Whip'],
+      skills: [],
+      magic: [],
+      weaknesses: ['Dark', 'Fire', 'Ice', 'Lightning', 'Wind'],
+      resistances: []
+    },
+    {
       name: 'Land Crab',
       level: '1-3',
-      exp: 11,
       hp: 40,
       element: 'Water',
       str: 3,
@@ -677,7 +668,6 @@ export const bestiaryByZone = {
     {
       name: 'Carrion Crow',
       level: '2-6',
-      exp: 37,
       element: 'Fire',
       str: 3,
       vit: 2,
@@ -699,7 +689,6 @@ export const bestiaryByZone = {
     {
       name: 'Yagudo Initiate',
       level: '1-8',
-      exp: 20,
       str: 4,
       vit: 3,
       drops: ['Yagudo Feather', 'Bird Egg'],
@@ -717,7 +706,6 @@ export const bestiaryByZone = {
     {
       name: 'Savanna Rarab',
       level: '1-6',
-      exp: 15,
       str: 3,
       vit: 2,
       drops: ['Rabbit Hide', 'Rabbit Meat'],
@@ -733,7 +721,6 @@ export const bestiaryByZone = {
     {
       name: 'Tiny Mandragora',
       level: '1',
-      exp: 10,
       str: 2,
       vit: 2,
       drops: ['Mandragora Flower', 'La Theine Cabbage'],
@@ -749,7 +736,6 @@ export const bestiaryByZone = {
     {
       name: 'Carrion Crow',
       level: '2-5',
-      exp: 41,
       element: 'Fire',
       str: 3,
       vit: 2,
@@ -771,7 +757,6 @@ export const bestiaryByZone = {
     {
       name: 'Yagudo Initiate',
       level: '1-8',
-      exp: 20,
       str: 4,
       vit: 3,
       drops: ['Yagudo Feather', 'Bird Egg'],
@@ -789,7 +774,6 @@ export const bestiaryByZone = {
     {
       name: 'River Crab',
       level: '2-4',
-      exp: 3,
       element: 'Water',
       str: 3,
       vit: 3,
@@ -811,7 +795,6 @@ export const bestiaryByZone = {
     {
       name: 'Mouse Bat',
       level: '2-4',
-      exp: 0,
       hp: 61,
       element: 'Wind',
       str: 3,
@@ -831,13 +814,46 @@ export const bestiaryByZone = {
       magic: [],
       weaknesses: ['Wind', 'Light'],
       resistances: ['Dark']
+    },
+    {
+      name: 'Giant Amoeba',
+      level: '3-5',
+      element: 'Water',
+      str: 3,
+      vit: 2,
+      drops: ['Zeruhn Soot'],
+      steal: null,
+      aggressive: true,
+      linking: false,
+      detection: 'Sound & Scent',
+      attacks: ['Engulf'],
+      skills: [],
+      magic: [],
+      weaknesses: ['Fire'],
+      resistances: ['Water']
+    },
+    {
+      name: 'Leech',
+      level: '3-5',
+      element: 'Water',
+      str: 3,
+      vit: 2,
+      drops: ['Zeruhn Soot'],
+      steal: null,
+      aggressive: true,
+      linking: true,
+      detection: 'Sound & Scent',
+      attacks: ['Bite'],
+      skills: [],
+      magic: [],
+      weaknesses: ['Light'],
+      resistances: ['Water']
     }
   ],
   'Palborough Mines': [
     {
       name: 'Pit Hare',
       level: '2-6',
-      exp: 42,
       element: 'Earth',
       str: 3,
       vit: 3,
@@ -850,14 +866,37 @@ export const bestiaryByZone = {
       skills: [],
       magic: [],
       weaknesses: ['Water', 'Lightning', 'Dark'],
-      resistances: ['Fire']
+    resistances: ['Fire']
+    }
+  ],
+  'Dangruf Wadi': [
+    {
+      name: 'Stone Eater',
+      level: '3-5',
+      element: 'Earth',
+      str: 3,
+      vit: 3,
+      drops: ['Flint Stone', 'Hermit\'s Ring', 'Zinc Ore', 'Sulfur'],
+      dropRates: {
+        'Hermit\'s Ring': '11%',
+        'Zinc Ore': '11%',
+        'Sulfur': '73%'
+      },
+      steal: 'Pebble',
+      aggressive: true,
+      linking: false,
+      detection: 'Sound',
+      attacks: ['Crush'],
+      skills: [],
+      magic: [],
+      weaknesses: ['Wind', 'Light'],
+      resistances: ['Earth']
     }
   ],
   "King Ranperre's Tomb": [
     {
       name: 'Ding Bat',
       level: '2-5',
-      exp: 30,
       element: 'Wind',
       str: 3,
       vit: 2,
@@ -880,7 +919,6 @@ export const bestiaryByZone = {
     {
       name: 'Carrion Worm',
       level: '2-5',
-      exp: 19,
       element: 'Earth',
       str: 3,
       vit: 3,
@@ -899,14 +937,32 @@ export const bestiaryByZone = {
       skills: ['Poison Mist'],
       magic: [],
       weaknesses: ['Wind', 'Light'],
-      resistances: ['Earth']
+    resistances: ['Earth']
+    }
+  ],
+  'Ghelsba Outpost': [
+    {
+      name: 'Watch Lizard',
+      level: '3-5',
+      element: 'Fire',
+      str: 3,
+      vit: 3,
+      drops: ['Lizard Tail'],
+      steal: null,
+      aggressive: true,
+      linking: true,
+      detection: 'Sound',
+      attacks: ['Bite'],
+      skills: [],
+      magic: [],
+      weaknesses: ['Wind', 'Ice'],
+      resistances: ['Fire']
     }
   ],
   'Giddeus': [
     {
       name: 'Giddeus Pugil',
       level: '2-5',
-      exp: 9,
       hp: 99,
       element: 'Water',
       str: 3,
@@ -925,7 +981,6 @@ export const bestiaryByZone = {
     {
       name: 'Giddeus Bee',
       level: '2-5',
-      exp: 19,
       hp: 90,
       element: 'Wind',
       str: 3,
@@ -945,6 +1000,23 @@ export const bestiaryByZone = {
       skills: [],
       magic: [],
       weaknesses: ['Ice'],
+      resistances: ['Earth']
+    },
+    {
+      name: 'Dirt Eater',
+      level: '3-5',
+      element: 'Earth',
+      str: 3,
+      vit: 3,
+      drops: ['Copper Ore', 'Flint Stone', 'Zinc Ore'],
+      steal: 'Pebble',
+      aggressive: true,
+      linking: false,
+      detection: 'Sound',
+      attacks: ['Bite'],
+      skills: [],
+      magic: [],
+      weaknesses: ['Wind', 'Light'],
       resistances: ['Earth']
     }
   ]

--- a/data/characters.js
+++ b/data/characters.js
@@ -121,6 +121,8 @@ export const characters = [
     sex: 'Male',
     job: 'Thief',
     startingCity: startingCities['Hume'],
+    homeCity: startingCities['Hume'],
+    spawnPoint: zonesByCity[startingCities['Hume']][0].name,
     currentLocation: zonesByCity[startingCities['Hume']][0].name,
     lastZone: null,
     level: 99,
@@ -182,7 +184,9 @@ export const characters = [
     temporaryBuffs: [],
     temporaryDebuffs: [],
     homePoints: [zonesByCity[startingCities['Hume']][0].name],
+    ownedResidences: [startingCities['Hume']],
     currentHomePoint: zonesByCity[startingCities['Hume']][0].name,
+    travelTurns: { [startingCities['Hume']]: 0 },
     signetUntil: 0
   },
   {
@@ -191,6 +195,8 @@ export const characters = [
     sex: 'Female',
     job: 'Black Mage',
     startingCity: startingCities['Tarutaru'],
+    homeCity: startingCities['Tarutaru'],
+    spawnPoint: zonesByCity[startingCities['Tarutaru']][0].name,
     currentLocation: zonesByCity[startingCities['Tarutaru']][0].name,
     lastZone: null,
     level: 99,
@@ -252,7 +258,9 @@ export const characters = [
     temporaryBuffs: [],
     temporaryDebuffs: [],
     homePoints: [zonesByCity[startingCities['Tarutaru']][0].name],
+    ownedResidences: [startingCities['Tarutaru']],
     currentHomePoint: zonesByCity[startingCities['Tarutaru']][0].name,
+    travelTurns: { [startingCities['Tarutaru']]: 0 },
     signetUntil: 0
   }
 ];
@@ -269,6 +277,8 @@ export function createCharacterObject(name, job, race, sex = 'Male') {
     sex,
     job: selectedJob,
     startingCity: startingCities[selectedRace],
+    homeCity: startingCities[selectedRace],
+    spawnPoint: zonesByCity[startingCities[selectedRace]][0].name,
     currentLocation: zonesByCity[startingCities[selectedRace]][0].name,
     lastZone: null,
     level: 1,
@@ -330,7 +340,9 @@ export function createCharacterObject(name, job, race, sex = 'Male') {
     temporaryBuffs: [],
     temporaryDebuffs: [],
     homePoints: [zonesByCity[startingCities[selectedRace]][0].name],
+    ownedResidences: [startingCities[selectedRace]],
     currentHomePoint: zonesByCity[startingCities[selectedRace]][0].name,
+    travelTurns: { [startingCities[selectedRace]]: 0 },
     signetUntil: 0
   };
   updateDerivedStats(character);
@@ -663,11 +675,18 @@ export function setLocation(character, name) {
   character.currentLocation = name;
   const zone = locations.find(l => l.name === name);
   if (zone) {
+    if (!character.travelTurns) character.travelTurns = {};
     if (zone.distance === 0) {
-      clearTemporaryEffects(character);
       character.returnJourney = null;
+      character.travelTurns[zone.city] = 0;
     } else {
       character.returnJourney = { zone: zone.city, turns: zone.distance };
+      character.travelTurns[zone.city] = zone.distance;
+      for (const c in character.travelTurns) {
+        if (c !== zone.city) {
+          character.travelTurns[c] = Math.min(10, (character.travelTurns[c] || 0) + 1);
+        }
+      }
     }
   }
   persistCharacter(character);

--- a/data/experience.js
+++ b/data/experience.js
@@ -1323,11 +1323,24 @@ export const experienceTable = {
 
 export function experienceForKill(playerLevel, monsterLevel) {
   const diff = monsterLevel - playerLevel;
-  const clamped = Math.max(-44, Math.min(15, diff));
-  const row = experienceTable[clamped];
-  if (!row) return 0;
-  const idx = Math.min(19, Math.floor((playerLevel - 1) / 5));
-  return row[idx] || 0;
+  if (diff <= -8) return 0;
+  if (diff >= 6) return 250;
+  const table = {
+    [-7]: 12,
+    [-6]: 20,
+    [-5]: 30,
+    [-4]: 40,
+    [-3]: 60,
+    [-2]: 80,
+    [-1]: 95,
+    0: 100,
+    1: 130,
+    2: 150,
+    3: 170,
+    4: 190,
+    5: 220
+  };
+  return table[diff] || 0;
 }
 
 export const levelTNL = [

--- a/data/locations.js
+++ b/data/locations.js
@@ -31,7 +31,6 @@ export const zonesByCity = {
       connectedAreas: ['Bastok Mines', 'Port Bastok', 'South Gustaberg', 'Bastok Residential Area'],
       pointsOfInterest: [
         'Auction House',
-        'Rental House',
         "Goldsmiths' Guild",
         "Blacksmiths' Guild",
         "Brunhilde's Armourer",
@@ -176,7 +175,7 @@ export const zonesByCity = {
       distance: 0,
       subAreas: [],
       connectedAreas: ["Southern San d'Oria", "Port San d'Oria", "Château d'Oraguille", 'West Ronfaure', "San d'Oria Residential Area"],
-      pointsOfInterest: ['Auction House', 'Rental House', 'Armor Shop', 'Weapon Shop', 'Consumable Shop', 'Item Shop', 'Chocobo Stables', 'Home Point Crystal'],
+      pointsOfInterest: ['Auction House', 'Armor Shop', 'Weapon Shop', 'Consumable Shop', 'Item Shop', 'Chocobo Stables', 'Home Point Crystal'],
       importantNPCs: ['Gate Guard', 'Mission/Fame NPCs', 'Outpost Warper', 'Regional Merchant', 'Elesca']
     },
     {
@@ -250,6 +249,15 @@ export const zonesByCity = {
       connectedAreas: ['East Ronfaure'],
       pointsOfInterest: [],
       importantNPCs: []
+    },
+    {
+      name: 'Ghelsba Outpost',
+      city: "San d'Oria",
+      distance: 2,
+      subAreas: [],
+      connectedAreas: ['West Ronfaure'],
+      pointsOfInterest: ['Outpost'],
+      importantNPCs: []
     }
   ],
   Windurst: [
@@ -259,7 +267,7 @@ export const zonesByCity = {
       distance: 0,
       subAreas: [],
       connectedAreas: ['Windurst Walls', 'Windurst Woods', 'Port Windurst', 'East Sarutabaruta', 'Windurst Residential Area'],
-      pointsOfInterest: ['Auction House', 'Rental House', 'Cooking Guild', "Fisherman's Guild", 'General Store', 'Food Shop', 'Scroll Shop', 'Item Shop', 'Chocobo Stables', 'Home Point Crystal'],
+      pointsOfInterest: ['Auction House', 'Cooking Guild', "Fisherman's Guild", 'General Store', 'Food Shop', 'Scroll Shop', 'Item Shop', 'Chocobo Stables', 'Home Point Crystal'],
       importantNPCs: ['Gate Guard', 'Mission/Quest NPCs', 'Outpost Warper', 'Regional Merchant']
     },
     {
@@ -369,7 +377,7 @@ export const zonesByCity = {
       distance: 0,
       subAreas: [],
       connectedAreas: ['Upper Jeuno', 'Port Jeuno', 'Qufim Island', 'Rolanberry Fields', 'Jeuno Residential Area'],
-      pointsOfInterest: ['Auction House', 'Rental House', 'Chocobo Stables', 'General Goods Shop', 'Armor Shop', 'Weapon Shop', 'Home Point Crystal', 'Map Vendor'],
+      pointsOfInterest: ['Auction House', 'Chocobo Stables', 'General Goods Shop', 'Armor Shop', 'Weapon Shop', 'Home Point Crystal', 'Map Vendor'],
       importantNPCs: ['Fame/Mission/Quest NPCs', 'Outpost Warper', 'Regional Merchant', 'Promurouve']
     },
     {

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -37,11 +37,28 @@ function monstersByDistance(zone) {
   const loc = locations.find(l => l.name === zone);
   const dist = loc?.distance ?? 0;
   if (!mobs.length) return [];
-  const sorted = [...mobs].sort((a, b) => parseLevel(a.level) - parseLevel(b.level));
-  const third = Math.max(1, Math.floor(sorted.length / 3));
-  if (dist <= 1) return sorted.slice(0, third);
-  if (dist === 2) return sorted.slice(third, 2 * third);
-  return sorted.slice(2 * third);
+  const groups = {};
+  for (const m of mobs) {
+    if (!groups[m.name]) groups[m.name] = [];
+    groups[m.name].push(m);
+  }
+  for (const name in groups) {
+    groups[name].sort((a, b) => parseLevel(a.level) - parseLevel(b.level));
+  }
+  const pool = [];
+  for (const name of Object.keys(groups)) {
+    const arr = groups[name];
+    let idx = 0;
+    if (dist <= 1) {
+      idx = 0;
+    } else if (dist === 2) {
+      idx = Math.min(1, arr.length - 1);
+    } else {
+      idx = arr.length - 1;
+    }
+    pool.push(arr[idx]);
+  }
+  return pool.sort((a, b) => parseLevel(a.level) - parseLevel(b.level));
 }
 
 export function randomMonster(zone) {


### PR DESCRIPTION
## Summary
- introduce home city, spawn point and owned residence fields
- remove Rental House from location data
- allow setting spawn point and teleporting between crystals
- hide equipped items in sell list
- allow using spell scrolls from inventory
- prompt to buy rental house when entering residential areas
- respawn at spawn point on defeat
- clear temporary effects only on defeat
- award EXP based on level difference rather than monster values
- add low-level mobs for Zeruhn Mines, Dangruf Wadi, West Sarutabaruta, Giddeus and Ghelsba Outpost
- refine monster selection to pick lower-level variants near towns
- track travel distance per city when moving between zones

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js > /tmp/testBalance.txt && tail -n 5 /tmp/testBalance.txt`
- `node scripts/testTaruBlm.js | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6882518bac7483259cddab541d6747ca