### PR TITLE
Implement Conquest Points

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ Open `index.html` in a browser. No build step is required.
   fSTR and pDIF formulas.
 - Hit chance now factors Dexterity and Agility with weapon and evasion skill
   to compute accuracy and evasion.
+- Defeating monsters with Signet now awards Conquest Points which can be spent
+  at Gate Guards on special items.
+- Areas with monsters now include a Hunt option to target specific enemies and
+  immediately engage them.

--- a/css/style.css
+++ b/css/style.css
@@ -486,6 +486,10 @@ body.portrait .main-layout {
 /* Combat screen layout */
 #combat-screen {
     display: flex;
+    gap: 10px;
+}
+#combat-main {
+    display: flex;
     flex-direction: column;
     align-items: center;
     gap: 10px;
@@ -517,5 +521,16 @@ body.landscape #action-buttons {
     flex-direction: column;
     align-items: center;
     gap: 4px;
+}
+
+.enemy-list, .party-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 120px;
+}
+
+.target-button {
+    width: 100%;
 }
 

--- a/data/characters.js
+++ b/data/characters.js
@@ -187,7 +187,8 @@ export const characters = [
     ownedResidences: [startingCities['Hume']],
     currentHomePoint: zonesByCity[startingCities['Hume']][0].name,
     travelTurns: { [startingCities['Hume']]: 0 },
-    signetUntil: 0
+    signetUntil: 0,
+    conquestPoints: 0
   },
   {
     name: 'Shantotto',
@@ -261,7 +262,8 @@ export const characters = [
     ownedResidences: [startingCities['Tarutaru']],
     currentHomePoint: zonesByCity[startingCities['Tarutaru']][0].name,
     travelTurns: { [startingCities['Tarutaru']]: 0 },
-    signetUntil: 0
+    signetUntil: 0,
+    conquestPoints: 0
   }
 ];
 
@@ -343,7 +345,8 @@ export function createCharacterObject(name, job, race, sex = 'Male') {
     ownedResidences: [startingCities[selectedRace]],
     currentHomePoint: zonesByCity[startingCities[selectedRace]][0].name,
     travelTurns: { [startingCities[selectedRace]]: 0 },
-    signetUntil: 0
+    signetUntil: 0,
+    conquestPoints: 0
   };
   updateDerivedStats(character);
   return character;
@@ -538,6 +541,7 @@ export function loadCharacters() {
     const loaded = JSON.parse(data);
     characters.length = 0;
     loaded.forEach(c => {
+      if (c.conquestPoints === undefined) c.conquestPoints = 0;
       characters.push(c);
       updateDerivedStats(c);
     });
@@ -555,6 +559,7 @@ export function loadCharacterSlot(index) {
     const saved = JSON.parse(localStorage.getItem(`ffxiChars_${currentUser}`) || '[]');
     if (!saved[index]) return;
     characters[index] = saved[index];
+    if (characters[index].conquestPoints === undefined) characters[index].conquestPoints = 0;
     updateDerivedStats(characters[index]);
     setActiveCharacter(characters[index]);
     saveCharacters();

--- a/data/index.js
+++ b/data/index.js
@@ -34,7 +34,7 @@ export { raceInfo, jobInfo, cityImages, characterImages } from './descriptions.j
 export { cityList, zonesByCity, locations, zoneNames } from './locations.js';
 export { bestiaryByZone, allMonsters } from './bestiary.js';
 export { experienceTable, expToLevel, expNeeded, experienceForKill } from './experience.js';
-export { items, vendorInventories, shopNpcs } from './vendors.js';
+export { items, vendorInventories, shopNpcs, conquestRewards } from './vendors.js';
 export {
   parseLevel,
   conLevel,
@@ -45,5 +45,6 @@ export {
   rollForEncounter,
   walkAcrossZone,
   exploreEncounter,
-  randomMonster
+  randomMonster,
+  huntEncounter
 } from '../js/encounter.js';

--- a/data/vendors.js
+++ b/data/vendors.js
@@ -3282,6 +3282,74 @@ export const items = {
     stack: 99,
     description: 'Expands Mog House storage when used.',
     levelRequirement: 0
+  },
+  instantReraise: {
+    name: 'Instant Reraise',
+    price: 0,
+    stack: 1,
+    description: 'Grants the Reraise effect when used.',
+    levelRequirement: 0
+  },
+  instantWarp: {
+    name: 'Instant Warp',
+    price: 0,
+    stack: 1,
+    description: 'Teleports you to your Home Point.',
+    levelRequirement: 0
+  },
+  returnRing: {
+    name: 'Return Ring',
+    price: 0,
+    stack: 1,
+    description: 'Outpost warp ring with 10 charges.',
+    slot: 'leftRing',
+    levelRequirement: 0,
+    jobs: baseJobNames
+  },
+  homingRing: {
+    name: 'Homing Ring',
+    price: 0,
+    stack: 1,
+    description: 'Outpost warp ring with 30 charges.',
+    slot: 'leftRing',
+    levelRequirement: 0,
+    jobs: baseJobNames
+  },
+  chariotBand: {
+    name: 'Chariot Band',
+    price: 0,
+    stack: 1,
+    description: 'Grants +75% EXP up to 10,000.',
+    slot: 'leftRing',
+    levelRequirement: 0,
+    jobs: baseJobNames
+  },
+  empressBand: {
+    name: 'Empress Band',
+    price: 0,
+    stack: 1,
+    description: 'Grants +50% EXP up to 1,000 per charge.',
+    slot: 'leftRing',
+    levelRequirement: 0,
+    jobs: baseJobNames
+  },
+  emperorBand: {
+    name: 'Emperor Band',
+    price: 0,
+    stack: 1,
+    description: 'Grants +50% EXP up to 30,000 per charge.',
+    slot: 'leftRing',
+    levelRequirement: 0,
+    jobs: baseJobNames
+  },
+  warpRing: {
+    name: 'Warp Ring',
+    price: 0,
+    stack: 1,
+    description: 'Warp to Home Point.',
+    slot: 'leftRing',
+    levelRequirement: 0,
+    jobs: baseJobNames
   }
 };
 
@@ -3396,4 +3464,15 @@ export const shopNpcs = {
   "Alchemists' Guild": ['Odoba', 'Maymunah'],
   "Rodellieux's Stall": ['Rodellieux'],
   'Map Vendor': ['Karine', 'Rex', 'Elesca', 'Violitte', 'Mhoji Roccoruh', 'Pehki Machumaht', 'Ludwig', 'Lombaria', 'Promurouve', 'Rusese', 'Antiqix', 'Haggleblix', 'Lootblox', 'Riyadahf']
+};
+
+export const conquestRewards = {
+  instantReraise: 7,
+  instantWarp: 10,
+  returnRing: 2500,
+  homingRing: 9000,
+  chariotBand: 500,
+  empressBand: 1000,
+  emperorBand: 2000,
+  warpRing: 5000
 };

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -125,3 +125,21 @@ export function exploreEncounter(zone) {
   if (!mobs.length) return null;
   return mobs[Math.floor(Math.random() * mobs.length)];
 }
+
+export function huntEncounter(zone, targetName) {
+  const mobs = bestiaryByZone[zone] || [];
+  const matches = mobs.filter(m => m.name === targetName);
+  if (!matches.length) return [];
+  const pick = { ...matches[Math.floor(Math.random() * matches.length)] };
+  const group = [pick];
+  const firstWord = targetName.split(' ')[0];
+  const sameRace = mobs.filter(m => m.name.startsWith(firstWord));
+  if ((pick.linking || /(Goblin|Orc|Yagudo|Quadav)/i.test(firstWord)) && sameRace.length > 1) {
+    const extra = Math.random() < 0.5 ? 1 : 0;
+    for (let i = 0; i < extra; i++) {
+      const mob = { ...sameRace[Math.floor(Math.random() * sameRace.length)] };
+      group.push(mob);
+    }
+  }
+  return group;
+}


### PR DESCRIPTION
## Summary
- add conquest point reward items
- track CP on characters and display totals
- award CP from battles when Signet is active
- add Conquest reward shop accessed through Gate Guards
- recognize I.M. NPCs as gate guards
- add Hunt option with dropdown for targeted monsters
- support multi-enemy encounters with side target list

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_68827251883883258b34ff01add76759