### PR TITLE
Implement unified reward calculation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -505,6 +505,20 @@ body.portrait .main-layout {
     text-align: left;
 }
 
+#game-log {
+    position: fixed;
+    bottom: 40px;
+    left: 5px;
+    right: 5px;
+    max-height: 200px;
+    overflow-y: auto;
+    background: rgba(0, 0, 0, 0.8);
+    padding: 4px;
+    border-radius: 4px;
+    text-align: left;
+    z-index: 1000;
+}
+
 #action-buttons {
     display: grid;
     gap: 8px;
@@ -524,6 +538,10 @@ body.landscape #action-buttons {
     flex-direction: column;
     align-items: center;
     gap: 4px;
+}
+
+#action-buttons .action-cell > * {
+    width: 100%;
 }
 
 .enemy-list, .party-list {

--- a/data/index.js
+++ b/data/index.js
@@ -48,3 +48,4 @@ export {
   randomMonster,
   huntEncounter
 } from '../js/encounter.js';
+export { calculateBattleRewards, findItemIdByName } from '../js/rewards.js';

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <body>
     <div id="scale-controls">
         <button id="back-button">Back</button>
+        <button id="log-button">Log</button>
         <button id="character-select">Character Select</button>
         <button class="scale-btn" id="scale-dec">-</button>
         <button class="scale-btn" id="scale-inc">+</button>
@@ -17,6 +18,7 @@
     <div id="app">
         <!-- UI will be rendered here -->
     </div>
+    <div id="game-log" class="log-overlay hidden"></div>
 
     <script type="module" src="js/main.js"></script>
 </body>

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls } from './ui.js';
+import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls, setupLogControls } from './ui.js';
 import { loadCharacters, initCurrentUser } from '../data/index.js';
 
 // Entry point: initialize application
@@ -37,6 +37,10 @@ function init() {
         inc.addEventListener('click', () => updateScale(0.1));
         dec.addEventListener('click', () => updateScale(-0.1));
     }
+
+    const logBtn = document.getElementById('log-button');
+    const logPanel = document.getElementById('game-log');
+    if (logBtn && logPanel) setupLogControls(logBtn, logPanel);
 
     const charBtn = document.getElementById('character-select');
     if (charBtn) {

--- a/js/rewards.js
+++ b/js/rewards.js
@@ -1,0 +1,64 @@
+import { items } from '../data/vendors.js';
+import { experienceForKill } from '../data/experience.js';
+import { hasSignet } from '../data/characters.js';
+import { parseLevel } from './encounter.js';
+
+export function findItemIdByName(name) {
+  for (const [id, data] of Object.entries(items)) {
+    if (data.name === name) return id;
+  }
+  return null;
+}
+
+function parseDropRate(rate) {
+  if (rate === undefined) return null;
+  if (typeof rate === 'number') return rate;
+  if (typeof rate === 'string') {
+    let r = rate.replace(/%/g, '').trim();
+    if (r.includes('-')) {
+      const [min, max] = r.split('-').map(Number);
+      return (min + max) / 2;
+    }
+    const num = Number(r);
+    return isNaN(num) ? null : num;
+  }
+  return null;
+}
+
+export function calculateBattleRewards(character, defeated) {
+  let exp = 0;
+  let gil = 0;
+  let cp = 0;
+  const drops = [];
+
+  for (const mob of defeated) {
+    const mobLevel = parseLevel(mob.level);
+    const xp = experienceForKill(character.level, mobLevel);
+    exp += xp;
+
+    if (character.level >= 6 && hasSignet(character)) {
+      cp += Math.floor(xp / 10);
+    }
+
+    if (/(Orc|Yagudo|Goblin|Quadav|Moblin)/i.test(mob.name)) {
+      gil += Math.floor(mobLevel * 5 + Math.random() * mobLevel * 5);
+    }
+
+    if (mob.drops && mob.drops.length) {
+      for (const name of mob.drops) {
+        const chance = parseDropRate(mob.dropRates?.[name]) ?? (100 / mob.drops.length);
+        if (Math.random() * 100 < chance) {
+          const id = findItemIdByName(name);
+          if (id) drops.push({ id, qty: 1 });
+        }
+      }
+    }
+
+    if (hasSignet(character) && Math.random() < 0.1) {
+      const crystalId = Object.keys(items).find(k => /Crystal/i.test(items[k].name));
+      if (crystalId) drops.push({ id: crystalId, qty: 1 });
+    }
+  }
+
+  return { exp, gil, cp, drops };
+}


### PR DESCRIPTION
## Summary
- add `calculateBattleRewards` utility
- expose reward helpers from data index
- use reward function when monsters are defeated
- log button shows combat history when held
- expand log when leveling and announce stat gains
- ensure combat actions are stacked vertically with full-width controls

## Testing
- `node scripts/testBalance.js > /tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_6882cf03a3b48325912099cbfe120726