### PR TITLE
Refactor area actions and add directional movement

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -158,6 +158,24 @@ body.landscape #area-grid {
     width: 160px;
 }
 
+#direction-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 40px);
+    grid-template-rows: repeat(3, 40px);
+    gap: 4px;
+    margin-top: 6px;
+}
+
+#direction-grid button {
+    width: 40px;
+    height: 40px;
+    padding: 0;
+}
+
+#coord-display {
+    margin-top: 6px;
+}
+
 .hunt-select {
     width: 160px;
 }


### PR DESCRIPTION
## Summary
- move rest/hunt controls outside of the collapsible area menu
- add a directional travel grid with explore in the center
- show player coordinates below the travel buttons
- remove unused legacy UI functions

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_6883f20ddd088325a0c79fa0af2b4cdf