### PR TITLE
Enhance combat logs and monster list

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -158,6 +158,29 @@ body.landscape #area-grid {
     width: 160px;
 }
 
+.nav-row {
+    display: flex;
+    gap: 10px;
+}
+
+#nearby-monsters {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.monster-btn {
+    width: 100px;
+}
+
+.monster-btn.aggro {
+    background-color: darkred;
+}
+
+.monster-btn.selected {
+    outline: 4px solid yellow;
+}
+
 #direction-grid {
     display: grid;
     grid-template-columns: repeat(3, 40px);
@@ -176,9 +199,6 @@ body.landscape #area-grid {
     margin-top: 6px;
 }
 
-.hunt-select {
-    width: 160px;
-}
 
 .form-header {
     display: flex;
@@ -561,7 +581,7 @@ body.portrait .main-layout {
     padding: 4px;
     align-items: start;
 }
-.enemy-column, .log-column, .action-column {
+.enemy-column, .log-column {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/data/index.js
+++ b/data/index.js
@@ -48,6 +48,7 @@ export {
   exploreEncounter,
   randomMonster,
   huntEncounter,
+  spawnNearbyMonsters,
   parseCoordinate,
   coordinateDistance,
   stepToward


### PR DESCRIPTION
## Summary
- implement multiplicative aggro chance when spawning nearby monsters
- replace explore with attack button in navigation and allow target selection
- remove defeated monsters from the local list after battle
- keep combat log overflow for two turns and adjust page padding with game log
- highlight selected monster with thicker border

## Testing
- `node --check js/ui.js`
- `node --check js/encounter.js`


------
https://chatgpt.com/codex/tasks/task_e_6883fad5fde08325a40a9f291973fb31