### PR TITLE
Fix vendor NPC inventory mapping

### DIFF
--- a/data/locations.js
+++ b/data/locations.js
@@ -127,7 +127,7 @@ export const zonesByCity = {
         'Vomp Hill': 'I-9',
         'Cavernous Maw (Abyssea – Altepa)': 'J-10'
       },
-      connectedAreas: ['Bastok Markets', 'North Gustaberg (East)', 'North Gustaberg (West)', 'Konschtat Highlands', 'Dangruf Wadi', 'Vomp Hill'],
+      connectedAreas: ['Bastok Markets', 'North Gustaberg (East)', 'North Gustaberg (West)', 'Dangruf Wadi', 'Vomp Hill'],
       pointsOfInterest: ['Outpost', 'Selt Steel Mines', 'Vomp Hill Ramp'],
       importantNPCs: []
     },
@@ -146,7 +146,7 @@ export const zonesByCity = {
       city: 'Bastok',
       distance: 2,
       subAreas: [],
-      connectedAreas: ['North Gustaberg (West)', 'South Gustaberg', 'Valkurm Dunes', 'Gusgen Mines', 'Pashhow Marshlands'],
+      connectedAreas: ['North Gustaberg (West)', 'Valkurm Dunes', 'Gusgen Mines', 'Pashhow Marshlands'],
       pointsOfInterest: ['Outpost', 'Crag of Dem'],
       importantNPCs: []
     },

--- a/data/vendors.js
+++ b/data/vendors.js
@@ -3441,6 +3441,18 @@ export const vendorInventories = {
   'Sororo': ['scrollCure', 'scrollCureII', 'scrollCuraga', 'scrollPoisona', 'scrollParalyna', 'scrollBlindna', 'scrollDia', 'scrollDiaga', 'scrollBanish', 'scrollBanishga', 'scrollBlink', 'scrollProtect', 'scrollShell', 'scrollStoneskin', 'scrollSlow']
 };
 
+// Map vendor NPCs to their shop inventories
+vendorInventories.Boytz = vendorInventories["Boytz's Knickknacks"];
+vendorInventories.Gelzerio = vendorInventories["Gelzerio's Stall"];
+vendorInventories.Deegis = vendorInventories["Deegis's Armour"];
+vendorInventories.Neigepance = vendorInventories["Neigepance's Chocobo Stables"];
+vendorInventories.Griselda = vendorInventories["Griselda's Tavern"];
+vendorInventories.Amulya = vendorInventories["Blacksmith's Guild"];
+vendorInventories['Vicious Eye'] = vendorInventories['Blacksmith Supplies'];
+vendorInventories.Odoba = vendorInventories["Alchemists' Guild"];
+vendorInventories.Maymunah = vendorInventories["Alchemists' Guild"];
+vendorInventories.Rodellieux = vendorInventories["Rodellieux's Stall"];
+
 export const shopNpcs = {
   'Brunhilde\'s Armourer': ['Brunhilde the Armourer'],
   "Dragon's Claw Weaponry": ['Ciqala'],


### PR DESCRIPTION
## Summary
- map vendor NPC names to their shop inventories
- remove erroneous connection between South Gustaberg and Konschtat Highlands

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_68845fa775a88325ba6171345803db95