### PR TITLE
UI layout fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -98,7 +98,7 @@ button:hover {
     flex-direction: column;
     align-items: center;
     gap: 10px;
-    padding: 10px;
+    padding: 30px 10px 10px 10px;
 }
 
 #menu button {
@@ -110,6 +110,11 @@ button:hover {
     justify-content: center;
     gap: 20px;
     margin-top: 20px;
+}
+
+#area-grid.vertical {
+    flex-direction: column !important;
+    align-items: center;
 }
 
 body.portrait #area-grid {
@@ -633,28 +638,36 @@ body.portrait .main-layout {
 }
 
 #action-buttons {
-    display: grid;
+    display: flex;
+    flex-direction: column;
     gap: 8px;
     width: 100%;
-}
-
-body.portrait #action-buttons {
-    grid-template-columns: 1fr 1fr;
-}
-
-body.landscape #action-buttons {
-    grid-template-columns: repeat(4, 1fr);
 }
 
 #action-buttons .action-cell {
     display: flex;
     flex-direction: column;
-    align-items: center;
-    gap: 4px;
+    align-items: stretch;
+    gap: 0;
+    width: 100%;
 }
 
 #action-buttons .action-cell > * {
     width: 100%;
+}
+
+#action-buttons .with-select button {
+    border-bottom: none;
+    border-radius: 4px 4px 0 0;
+}
+
+#action-buttons .with-select select {
+    border: 1px solid #555;
+    border-top: none;
+    border-radius: 0 0 4px 4px;
+    background: #222;
+    color: #fff;
+    margin-top: -1px;
 }
 
 .enemy-list, .party-list {

--- a/js/ui.js
+++ b/js/ui.js
@@ -47,10 +47,12 @@ let nearbyMonsters = [];
 let monsterCoordKey = '';
 let selectedMonsterIndex = null;
 
+const BASE_TOP_PADDING = 60;
+
 function updateGameLogPadding() {
     if (!logPanelElement) return;
     const height = logPanelElement.classList.contains('hidden') ? 0 : logPanelElement.offsetHeight;
-    document.body.style.paddingTop = height + 'px';
+    document.body.style.paddingTop = (BASE_TOP_PADDING + height) + 'px';
 }
 
 export function setupLogControls(btn, panel) {
@@ -966,6 +968,9 @@ function renderPlayUI(root) {
 function createAreaGrid(root, loc) {
     const grid = document.createElement('div');
     grid.id = 'area-grid';
+    if (loc.distance === 0) {
+        grid.classList.add('vertical');
+    }
 
     const sections = [];
     function makeSection(title) {
@@ -1618,14 +1623,14 @@ function renderCombatScreen(root, mobs, destination) {
         attackWrap.appendChild(attackBtn);
 
         const abilityWrap = document.createElement('div');
-        abilityWrap.className = 'action-cell';
-        abilityWrap.appendChild(abilitySelect);
+        abilityWrap.className = 'action-cell with-select';
         abilityWrap.appendChild(abilityBtn);
+        abilityWrap.appendChild(abilitySelect);
 
         const magicWrap = document.createElement('div');
-        magicWrap.className = 'action-cell';
-        magicWrap.appendChild(magicSelect);
+        magicWrap.className = 'action-cell with-select';
         magicWrap.appendChild(magicBtn);
+        magicWrap.appendChild(magicSelect);
 
         const fleeWrap = document.createElement('div');
         fleeWrap.className = 'action-cell';


### PR DESCRIPTION
## Summary
- ensure main menu clears log and button overlays
- stack peaceful zone area categories vertically
- arrange combat options in a vertical list with dropdowns below buttons

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_68852d2ad45483259502807c60e89a1e