### PR TITLE
Improve shop interactions and profile layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -380,6 +380,12 @@ body.portrait .main-layout {
     flex-direction: column;
 }
 
+.profile-group {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
 .race-img, .job-img, .city-img, .character-img {
     width: clamp(120px, 20vw, 200px);
     height: auto;

--- a/data/index.js
+++ b/data/index.js
@@ -35,7 +35,7 @@ export { cityList, zonesByCity, locations, zoneNames } from './locations.js';
 export { bestiaryByZone, allMonsters } from './bestiary.js';
 export { notoriousMonsters } from './nms.js';
 export { experienceTable, expToLevel, expNeeded, experienceForKill } from './experience.js';
-export { items, vendorInventories, shopNpcs, conquestRewards } from './vendors.js';
+export { items, vendorInventories, shopNpcs, vendorGreetings, vendorTypes, conquestRewards } from './vendors.js';
 export {
   parseLevel,
   conLevel,

--- a/data/vendors.js
+++ b/data/vendors.js
@@ -3478,6 +3478,68 @@ export const shopNpcs = {
   'Map Vendor': ['Karine', 'Rex', 'Elesca', 'Violitte', 'Mhoji Roccoruh', 'Pehki Machumaht', 'Ludwig', 'Lombaria', 'Promurouve', 'Rusese', 'Antiqix', 'Haggleblix', 'Lootblox', 'Riyadahf']
 };
 
+export const vendorGreetings = {
+  'Brunhilde the Armourer': "Welcome to my armoury, traveler!",
+  'Ciqala': 'Looking for a new weapon? Take your pick.',
+  'Carmelide': 'Only the finest jewels for sale here.',
+  'Hortense': 'Care to peruse my collection of scores?',
+  'Sororo': 'Official documents and scrolls, right this way.',
+  'Galvin': 'Travel gear for every journey!',
+  'Ilita': 'Linkshells and rare trinkets at fair prices.',
+  'Numa': 'Sturdy gear for the road.',
+  'Melloa': 'Hungry? We have fresh meals ready.',
+  'Sawyer': 'Sit and relax, I will serve you shortly.',
+  'Boytz': 'Knickknacks and oddities galore!',
+  'Gelzerio': 'Need supplies? Take a look.',
+  'Deegis': 'Armor to keep you standing strong.',
+  'Zemedars': 'Protect your legs and feet with my wares.',
+  'Proud Beard': 'Finest clothing in Bastok!',
+  'Neigepance': 'Chocobo supplies for the discerning rider.',
+  'Griselda': 'Welcome, have a seat and enjoy.',
+  'Amulya': 'Smithing goods for your craft.',
+  'Vicious Eye': 'Tools and metals, sharp and true.',
+  'Nogga': 'Handle these explosives with care!',
+  'Olaf': 'Ammunition and powder ready to go.',
+  'Tomasa': 'A warm meal will do you good.',
+  'Takiyah': 'Goods from distant Qufim, just in.',
+  'Odoba': 'Potions brewed to perfection.',
+  'Maymunah': 'Alchemical supplies for any venture.',
+  'Rodellieux': 'Fresh produce and lumber, take your pick.'
+};
+
+export const vendorTypes = {
+  'Brunhilde the Armourer': 'armor',
+  'Ciqala': 'weapons',
+  'Carmelide': 'jewelry',
+  'Hortense': 'music',
+  'Sororo': 'scribery',
+  'Galvin': 'travel gear',
+  'Ilita': 'linkshells',
+  'Numa': 'equipment',
+  'Melloa': 'food',
+  'Sawyer': 'food',
+  'Boytz': 'knickknacks',
+  'Gelzerio': 'supplies',
+  'Deegis': 'armor',
+  'Zemedars': 'armor',
+  'Proud Beard': 'clothing',
+  'Neigepance': 'chocobo gear',
+  'Griselda': 'tavern fare',
+  'Amulya': 'smithing goods',
+  'Vicious Eye': 'smithing supplies',
+  'Nogga': 'explosives',
+  'Olaf': 'ammunition',
+  'Tomasa': 'meals',
+  'Takiyah': 'regional goods',
+  'Odoba': 'alchemy',
+  'Maymunah': 'alchemy',
+  'Rodellieux': 'produce',
+  'Karine': 'maps', 'Rex': 'maps', 'Elesca': 'maps', 'Violitte': 'maps',
+  'Mhoji Roccoruh': 'maps', 'Pehki Machumaht': 'maps', 'Ludwig': 'maps',
+  'Lombaria': 'maps', 'Promurouve': 'maps', 'Rusese': 'maps', 'Antiqix': 'maps',
+  'Haggleblix': 'maps', 'Lootblox': 'maps', 'Riyadahf': 'maps'
+};
+
 export const conquestRewards = {
   instantReraise: 7,
   instantWarp: 10,

--- a/js/ui.js
+++ b/js/ui.js
@@ -15,6 +15,8 @@ import {
     locations,
     vendorInventories,
     shopNpcs,
+    vendorGreetings,
+    vendorTypes,
     items,
     conquestRewards,
     updateDerivedStats,
@@ -484,10 +486,15 @@ export function renderMainMenu() {
         }
 
         profile.appendChild(imgNav.wrapper);
+
+        const group = document.createElement('div');
+        group.className = 'profile-group';
+
         const charBtn = document.createElement('button');
         charBtn.className = 'profile-btn';
         charBtn.textContent = activeCharacter.name;
-        profile.appendChild(charBtn);
+        group.appendChild(charBtn);
+
         const details = document.createElement('div');
         details.id = 'character-details';
         details.classList.add('hidden');
@@ -514,7 +521,8 @@ export function renderMainMenu() {
         if (modeBtn) details.appendChild(modeBtn);
         details.appendChild(invBtn);
         details.appendChild(equipBtn);
-        profile.appendChild(details);
+        group.appendChild(details);
+        profile.appendChild(group);
         layout.appendChild(profile);
 
         // Previously the main menu displayed several buttons that allowed the
@@ -968,9 +976,7 @@ function renderPlayUI(root) {
 function createAreaGrid(root, loc) {
     const grid = document.createElement('div');
     grid.id = 'area-grid';
-    if (loc.distance === 0) {
-        grid.classList.add('vertical');
-    }
+    grid.classList.add('vertical');
 
     const sections = [];
     function makeSection(title) {
@@ -1782,11 +1788,18 @@ function sellItem(id, qty = 1) {
     alert(`Sold ${qty} x ${item.name} for ${revenue} gil.`);
 }
 
-function renderVendorMenu(root, vendor, backFn = null) {
+function renderVendorMenu(root, vendor, backFn = null, shopName = null) {
     root.innerHTML = '';
     const title = document.createElement('h2');
-    title.textContent = vendor;
+    title.textContent = shopName || vendor;
     root.appendChild(title);
+    const intro = document.createElement('p');
+    if (shopName) intro.textContent = `You enter ${shopName} and approach ${vendor}.`;
+    else intro.textContent = `You approach ${vendor}.`;
+    root.appendChild(intro);
+    const greet = document.createElement('p');
+    greet.textContent = vendorGreetings[vendor] || 'Welcome, traveler.';
+    root.appendChild(greet);
     root.appendChild(characterSummary());
     const buyBtn = document.createElement('button');
     buyBtn.textContent = 'Buy';
@@ -2245,15 +2258,23 @@ function openMenu(name, backFn) {
     const root = document.getElementById('app');
     const backHandler = backFn || (() => refreshMainMenu(root));
     if (shopNpcs[name]) {
+        const npcs = shopNpcs[name];
+        if (npcs.length === 1) {
+            renderVendorMenu(root, npcs[0], backHandler, name);
+            return;
+        }
         root.innerHTML = '';
         const title = document.createElement('h2');
         title.textContent = name;
         root.appendChild(title);
+        const intro = document.createElement('p');
+        intro.textContent = `You enter ${name}. Inside you see:`;
+        root.appendChild(intro);
         const list = document.createElement('ul');
-        shopNpcs[name].forEach(npc => {
+        npcs.forEach(npc => {
             const li = document.createElement('li');
             const btn = document.createElement('button');
-            btn.textContent = npc;
+            btn.textContent = npc + (vendorTypes[npc] ? ` - ${vendorTypes[npc]}` : '');
             btn.addEventListener('click', () => openMenu(npc, () => openMenu(name, backFn)));
             li.appendChild(btn);
             list.appendChild(li);


### PR DESCRIPTION
## Summary
- group profile details with toggle button
- ensure area lists are vertically aligned
- add vendor greetings and vendor types
- show narrative when entering shops, skipping NPC select when only one vendor

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_688540a5dc308325bb2be0e96dcb4697