### PR TITLE
Fix profile toggle and show zone expansion state

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -145,6 +145,18 @@ body.landscape #area-grid {
 .area-header {
     font-weight: bold;
     background-color: #222;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.area-header::before {
+    content: '\25B6';
+    margin-right: 4px;
+}
+
+.area-header.expanded::before {
+    content: '\25BC';
 }
 
 .explore-btn {

--- a/js/ui.js
+++ b/js/ui.js
@@ -498,7 +498,7 @@ export function renderMainMenu() {
         const details = document.createElement('div');
         details.id = 'character-details';
         details.classList.add('hidden');
-        charBtn.addEventListener('click', () => details.classList.toggle('hidden'));
+        charBtn.addEventListener('click', () => toggleDetails(details));
 
         const invBtn = document.createElement('button');
         invBtn.textContent = 'Inventory';
@@ -979,13 +979,15 @@ function createAreaGrid(root, loc) {
     grid.classList.add('vertical');
 
     const sections = [];
-    function makeSection(title) {
+    function makeSection(title, expanded = false) {
         const col = document.createElement('div');
         col.className = 'area-column';
         const header = document.createElement('button');
         header.className = 'area-header';
         header.textContent = title;
+        if (expanded) header.classList.add('expanded');
         const list = document.createElement('ul');
+        if (!expanded) list.classList.add('hidden');
         col.appendChild(header);
         col.appendChild(list);
         grid.appendChild(col);
@@ -993,7 +995,7 @@ function createAreaGrid(root, loc) {
         return list;
     }
 
-    const travelList = makeSection('Zone');
+    const travelList = makeSection('Zone', true);
 
 
     const travelKeywords = /(airship|ferry|chocobo|rental|home point|dock|boat|stable|crystal)/i;
@@ -1144,11 +1146,14 @@ function createAreaGrid(root, loc) {
         }
     });
 
-    sections.forEach((s, idx) => {
-        if (idx !== 0) s.list.classList.add('hidden');
+    sections.forEach((s) => {
         s.header.addEventListener('click', () => {
-            sections.forEach(o => o.list.classList.add('hidden'));
+            sections.forEach(o => {
+                o.list.classList.add('hidden');
+                o.header.classList.remove('expanded');
+            });
             s.list.classList.remove('hidden');
+            s.header.classList.add('expanded');
         });
     });
 


### PR DESCRIPTION
## Summary
- fix profile button toggling by using `toggleDetails`
- show arrow indicator for zone categories
- ensure Zone category is expanded by default

## Testing
- `node scripts/testTaruBlm.js`
- `node scripts/testBalance.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_68856f07723883259c6d386a8f3b4ca3