### PR TITLE
Fix .hidden class to override ID styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -561,7 +561,7 @@ body.portrait .main-layout {
 }
 
 .hidden {
-    display: none;
+    display: none !important;
 }
 
 .char-menu-controls {


### PR DESCRIPTION
## Summary
- set `.hidden` to use `display: none !important` so it hides profile sections regardless of ID rules

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_68857ce39b848325b21440867c680cd0