### PR TITLE
UI polish and flee tweaks

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -159,26 +159,16 @@ body.landscape #area-grid {
     content: '\25BC';
 }
 
+body.combat-active .area-header,
+body.combat-active #area-grid {
+    display: none !important;
+}
+
 .explore-btn {
     margin-bottom: 10px;
 }
 
-#area-actions {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 4px;
-    margin-top: 10px;
-}
 
-#area-actions button, #area-actions select {
-    width: 160px;
-}
-
-.nav-row {
-    display: flex;
-    gap: 10px;
-}
 
 .nav-column {
     display: flex;
@@ -192,6 +182,13 @@ body.landscape #area-grid {
     flex-direction: column;
     align-items: center;
     gap: 4px;
+}
+
+.nav-section {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
 }
 
 #nearby-monsters {
@@ -374,7 +371,7 @@ body.portrait .character-form {
 .main-layout {
     display: flex;
     justify-content: center;
-    align-items: flex-start;
+    align-items: center;
     gap: 20px;
 }
 

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -177,7 +177,9 @@ export function spawnNearbyMonsters(character, zone) {
   const count = Math.floor(Math.random() * 6) + 1;
   const list = [];
   for (let i = 0; i < count; i++) {
-    const mob = { ...pool[Math.floor(Math.random() * pool.length)] };
+    const base = pool[Math.floor(Math.random() * pool.length)];
+    const mob = { ...base };
+    mob.hp = base.hp || parseLevel(base.level) * 20;
     list.push(mob);
   }
   const linkGroups = {};


### PR DESCRIPTION
## Summary
- adjust layout so navigation appears next to character profile
- show HP in character profile button and monster list
- track monster HP when spawning
- update flee so each monster has an individual chance to stop aggro
- hide area controls when in combat

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_6885a4cec5dc832589b228d699ec3c21