### PR TITLE
Fix main menu initialization error

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -412,10 +412,10 @@ export function renderMainMenu() {
     areaBtn.addEventListener('click', () => areaDiv.classList.toggle('hidden'));
 
     const loc = activeCharacter && locations.find(l => l.name === activeCharacter.currentLocation);
+    let navSection = null;
+    let restBtn = null;
     if (loc) {
         updateNearbyMonsters(loc.name, container);
-        let navSection = null;
-        let restBtn = null;
         if (loc.distance > 0) {
             const actions = createActionPanel(container, loc);
             if (actions) {


### PR DESCRIPTION
## Summary
- declare `navSection` and `restBtn` outside of location check to avoid reference errors

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688659f997f88325bb011789f490494b