### PR TITLE
Add world time system

### DIFF
--- a/data/characters.js
+++ b/data/characters.js
@@ -2,6 +2,7 @@ import { jobs, jobNames } from './jobs.js';
 import { races, raceNames, startingCities } from './races.js';
 import { zonesByCity, locations } from './locations.js';
 import { parseCoordinate } from '../js/encounter.js';
+import { bestiaryByZone } from './bestiary.js';
 import { getScale, proficiencyScale } from './scales.js';
 
 const aldoScale = buildScaleFields('Hume', 'Thief');
@@ -191,7 +192,8 @@ export const characters = [
     currentHomePoint: zonesByCity[startingCities['Hume']][0].name,
     travelTurns: { [startingCities['Hume']]: 0 },
     signetUntil: 0,
-    conquestPoints: 0
+    conquestPoints: 0,
+    minutes: 0
   },
   {
     name: 'Shantotto',
@@ -268,7 +270,8 @@ export const characters = [
     currentHomePoint: zonesByCity[startingCities['Tarutaru']][0].name,
     travelTurns: { [startingCities['Tarutaru']]: 0 },
     signetUntil: 0,
-    conquestPoints: 0
+    conquestPoints: 0,
+    minutes: 0
   }
 ];
 
@@ -352,7 +355,8 @@ export function createCharacterObject(name, job, race, sex = 'Male') {
     currentHomePoint: zonesByCity[startingCities[selectedRace]][0].name,
     travelTurns: { [startingCities[selectedRace]]: 0 },
     signetUntil: 0,
-    conquestPoints: 0
+    conquestPoints: 0,
+    minutes: 0
   };
   updateDerivedStats(character);
   return character;
@@ -707,4 +711,20 @@ export function setLocation(character, name, from) {
     }
   }
   persistCharacter(character);
+}
+
+export function advanceTime(character, zone, turns = 1) {
+  if (!character) return;
+  const loc = locations.find(l => l.name === zone);
+  const hasMonsters = bestiaryByZone[zone] && bestiaryByZone[zone].length > 0;
+  if (loc && loc.distance > 0 && hasMonsters) {
+    character.minutes = (character.minutes || 0) + 10 * turns;
+  }
+}
+
+export function formatTime(minutes = 0) {
+  const day = Math.floor(minutes / 1440) + 1;
+  const hour = Math.floor((minutes % 1440) / 60);
+  const min = minutes % 60;
+  return `Day ${day} ${hour.toString().padStart(2, '0')}:${min.toString().padStart(2, '0')}`;
 }

--- a/data/index.js
+++ b/data/index.js
@@ -26,7 +26,9 @@ export {
   clearTemporaryEffects,
   pruneExpiredEffects,
   persistCharacter,
-  setLocation
+  setLocation,
+  advanceTime,
+  formatTime
 } from './characters.js';
 export { proficiencyScale, getScale } from './scales.js';
 export { names, randomName } from './names.js';

--- a/js/ui.js
+++ b/js/ui.js
@@ -38,7 +38,9 @@ import {
     stepToward,
     checkForNM,
     getSubArea,
-    canMove
+    canMove,
+    advanceTime,
+    formatTime
 } from '../data/index.js';
 import { randomName, raceInfo, jobInfo, cityImages, characterImages, getZoneTravelTurns, exploreEncounter, parseLevel, expNeeded, expToLevel} from '../data/index.js';
 
@@ -459,6 +461,9 @@ export function renderMainMenu() {
         const line5 = document.createElement('div');
         line5.textContent = `Gil: ${activeCharacter.gil}`;
 
+        const lineTime = document.createElement('div');
+        lineTime.textContent = `Time: ${formatTime(activeCharacter.minutes || 0)}`;
+
         const lineCp = document.createElement('div');
         lineCp.textContent = `Conquest Points: ${activeCharacter.conquestPoints || 0}`;
 
@@ -523,6 +528,7 @@ export function renderMainMenu() {
         details.appendChild(line3);
         details.appendChild(line4);
         details.appendChild(line5);
+        details.appendChild(lineTime);
         details.appendChild(lineCp);
         details.appendChild(line6);
         if (modeBtn) details.appendChild(modeBtn);
@@ -1047,6 +1053,7 @@ function createAreaGrid(root, loc) {
                 }
             }
             activeCharacter.travel.remaining -= 1;
+            advanceTime(activeCharacter, loc.name);
             if (activeCharacter.travel.remaining <= 0) {
                 setLocation(activeCharacter, area, loc.name);
                 activeCharacter.travel = null;
@@ -1190,6 +1197,8 @@ function createActionPanel(root, loc) {
         if (activeCharacter) {
             updateDerivedStats(activeCharacter);
             activeCharacter.tp = 0;
+            advanceTime(activeCharacter, loc.name);
+            persistCharacter(activeCharacter);
         }
         refreshMainMenu(root.parentElement);
     });
@@ -1225,6 +1234,7 @@ function createActionPanel(root, loc) {
             b.addEventListener('click', () => {
                 if (!activeCharacter?.coordinates) return;
                 activeCharacter.coordinates = stepInDirection(activeCharacter.coordinates, d.dx, d.dy);
+                advanceTime(activeCharacter, loc.name);
                 persistCharacter(activeCharacter);
                 if (updateNearbyMonsters(loc.name, root)) return;
                 const nm = checkForNM(


### PR DESCRIPTION
## Summary
- track minutes for each character
- expose helpers for advancing and formatting game time
- display the current time in the profile panel
- increment time when resting, traveling or moving in hostile zones

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_688674c67adc8325bfbfe72b643d9591