### PR TITLE
Add time display and fullscreen log toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,6 @@
 :root {
     --ui-scale: 1;
+    --log-font-size: 14px;
 }
 
 body {
@@ -44,6 +45,10 @@ button {
     background: rgba(0, 0, 0, 0.6);
     padding: 4px;
     border-radius: 4px;
+}
+#scale-controls #time-display {
+    margin-right: 6px;
+    min-width: 140px;
 }
 
 #user-controls {
@@ -656,6 +661,27 @@ body.portrait .main-layout {
     border-radius: 4px;
     text-align: left;
     z-index: 1000;
+    font-size: var(--log-font-size);
+}
+
+#game-log.fullscreen {
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 100%;
+    max-height: none;
+}
+
+#game-log .font-controls {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+}
+#game-log .font-controls button {
+    width: 28px;
+    height: 28px;
+    margin-left: 2px;
 }
 
 #action-buttons {

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
     <div id="scale-controls">
+        <span id="time-display"></span>
         <button id="back-button">Back</button>
         <button id="log-button">Log</button>
         <button id="character-select">Character Select</button>

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls, setupLogControls } from './ui.js';
+import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls, setupLogControls, setupTimeDisplay, updateTimeDisplay } from './ui.js';
 import { loadCharacters, initCurrentUser, initNotorious, activeCharacter } from '../data/index.js';
 
 // Entry point: initialize application
@@ -45,6 +45,12 @@ function init() {
     const logBtn = document.getElementById('log-button');
     const logPanel = document.getElementById('game-log');
     if (logBtn && logPanel) setupLogControls(logBtn, logPanel);
+
+    const timeEl = document.getElementById('time-display');
+    if (timeEl) {
+        setupTimeDisplay(timeEl);
+        updateTimeDisplay();
+    }
 
     const charBtn = document.getElementById('character-select');
     if (charBtn) {


### PR DESCRIPTION
## Summary
- show game time in settings bar
- allow toggling log to full screen
- support font size control for log
- only show last two turns in popup view
- keep log font size in CSS variable

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_6886778961048325aa750b9e5a9ff6d2