### PR TITLE
Refine combat layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -419,7 +419,7 @@ body.portrait .main-layout {
 .profile-btn {
     display: block;
     margin: 0 auto;
-    width: 160px;
+    width: 180px;
 }
 
 .image-container {
@@ -630,16 +630,24 @@ body.portrait .main-layout {
 /* Combat screen layout */
 #combat-screen {
     display: grid;
-    grid-template-columns: 1fr 1fr 2fr;
+    grid-template-columns: 1fr 2fr;
     gap: 10px;
     padding: 4px;
     align-items: start;
 }
-.enemy-column, .log-column, .action-column {
+.enemy-column, .log-column {
     display: flex;
     flex-direction: column;
     align-items: center;
     gap: 8px;
+}
+
+.action-column {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
 }
 
 #combat-log {
@@ -728,13 +736,14 @@ body.portrait .main-layout {
     align-items: center;
     justify-content: space-between;
     width: 100%;
+    cursor: pointer;
+}
+.target-name {
+    flex: 1;
+    text-align: left;
 }
 .target-stats {
     margin-left: 6px;
     white-space: nowrap;
-}
-.target-button {
-    width: 100%;
-    flex: 1;
 }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -1365,30 +1365,30 @@ function renderCombatScreen(root, mobs, destination) {
     enemyList.className = 'enemy-list';
     enemyColumn.appendChild(enemyList);
 
-    const actionColumn = document.createElement('div');
-    actionColumn.className = 'action-column';
-
     const logColumn = document.createElement('div');
     logColumn.className = 'log-column';
+
+    const actionColumn = document.createElement('div');
+    actionColumn.className = 'action-column';
 
     const enemyEntries = [];
     mobs.forEach((m, idx) => {
         m.currentHP = (m.hp || parseLevel(m.level) * 20);
         const entry = document.createElement('div');
         entry.className = 'target-entry';
-        const btn = document.createElement('button');
-        btn.className = 'target-button';
-        btn.id = `enemy-${idx}`;
-        btn.textContent = m.name;
-        btn.addEventListener('click', () => {
-            currentTarget = m;
-        });
+        entry.id = `enemy-${idx}`;
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'target-name';
+        nameSpan.textContent = m.name;
         const stat = document.createElement('span');
         stat.className = 'target-stats';
         stat.textContent = `HP:${m.currentHP}`;
-        entry.appendChild(btn);
+        entry.addEventListener('click', () => {
+            currentTarget = m;
+        });
+        entry.appendChild(nameSpan);
         entry.appendChild(stat);
-        enemyEntries.push({ entry, btn, stat });
+        enemyEntries.push({ entry, stat });
         enemyList.appendChild(entry);
     });
     let currentTarget = mobs[0];
@@ -1398,9 +1398,9 @@ function renderCombatScreen(root, mobs, destination) {
     logDiv.className = 'combat-log';
 
     logColumn.appendChild(logDiv);
+    logColumn.appendChild(actionColumn);
 
     container.appendChild(enemyColumn);
-    container.appendChild(actionColumn);
     container.appendChild(logColumn);
     root.appendChild(container);
 


### PR DESCRIPTION
## Summary
- remove redundant target buttons
- move combat action buttons into the log column
- size profile button like other menu buttons

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_68868d82c36883258eebb25f90fbf057