### PR TITLE
UI tweaks and map cleanup

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -53,7 +53,7 @@ body.portrait #app {
     position: fixed;
     top: 5px;
     right: 5px;
-    z-index: 1000;
+    z-index: 1100;
     display: flex;
     align-items: center;
     background: rgba(0, 0, 0, 0.6);
@@ -76,7 +76,8 @@ body.portrait #app {
     background: rgba(0, 0, 0, 0.8);
     padding: 8px;
     border-radius: 4px;
-    max-width: 200px;
+    min-width: 140px;
+    max-width: 260px;
     z-index: 1000;
     text-align: left;
     color: #fff;
@@ -447,7 +448,7 @@ body.portrait .main-layout {
 .profile-btn {
     display: block;
     margin: 0 auto;
-    width: 180px;
+    width: clamp(138px, 23vw, 230px);
 }
 
 .image-container {
@@ -699,13 +700,15 @@ body.portrait .main-layout {
 
 #game-log .font-controls {
     position: absolute;
-    top: 4px;
-    right: 4px;
+    top: 5px;
+    right: 5px;
 }
 #game-log .font-controls button {
     width: 28px;
     height: 28px;
     margin-left: 2px;
+    padding: 2px 6px;
+    font-size: 14px;
 }
 
 #action-buttons {

--- a/data/locations.js
+++ b/data/locations.js
@@ -131,16 +131,7 @@ export const zonesByCity = {
         'Cavernous Maw (Abyssea – Altepa)': 'J-10'
       },
       connectedAreas: ['Bastok Markets', 'North Gustaberg (East)', 'North Gustaberg (West)', 'Dangruf Wadi', 'Vomp Hill'],
-      pointsOfInterest: [
-        'Outpost',
-        'Selt Steel Mines',
-        'Vomp Hill Ramp',
-        'Bastok Markets Gate',
-        'Bastok Mines Gate',
-        'Morhen Lighthouse',
-        'Stone Monument',
-        'Goblin Camp'
-      ],
+      pointsOfInterest: [],
       importantNPCs: []
     },
     {

--- a/js/ui.js
+++ b/js/ui.js
@@ -542,20 +542,19 @@ export function renderMainMenu() {
 
     const loc = activeCharacter && locations.find(l => l.name === activeCharacter.currentLocation);
     let navSection = null;
-    let restBtn = null;
     if (loc) {
         if (loc.distance > 0) {
             const actions = createActionPanel(container, loc);
             if (actions) {
-                restBtn = actions.restBtn;
                 navSection = actions.navSection;
             }
+        } else {
+            const grid = createAreaGrid(container, loc);
+            areaDiv.appendChild(grid);
+            menu.appendChild(areaBtn);
+            menu.appendChild(areaDiv);
         }
-        const grid = createAreaGrid(container, loc);
-        areaDiv.appendChild(grid);
     }
-    menu.appendChild(areaBtn);
-    menu.appendChild(areaDiv);
 
     const layout = document.createElement('div');
     layout.className = 'main-layout';
@@ -641,12 +640,14 @@ export function renderMainMenu() {
         details.appendChild(imgNav.wrapper);
 
         const invBtn = document.createElement('button');
+        invBtn.className = 'profile-btn';
         invBtn.textContent = 'Inventory';
         invBtn.addEventListener('click', () => {
             renderInventoryScreen(container);
         });
 
         const equipBtn = document.createElement('button');
+        equipBtn.className = 'profile-btn';
         equipBtn.textContent = 'Equipment';
         equipBtn.addEventListener('click', () => {
             renderEquipmentScreen(container);
@@ -660,11 +661,10 @@ export function renderMainMenu() {
         details.appendChild(lineCp);
         details.appendChild(line6);
         if (modeBtn) details.appendChild(modeBtn);
-        details.appendChild(invBtn);
-        details.appendChild(equipBtn);
+        group.appendChild(invBtn);
+        group.appendChild(equipBtn);
         group.appendChild(details);
         profile.appendChild(group);
-        if (restBtn) profile.appendChild(restBtn);
         layout.appendChild(profile);
 
         // Previously the main menu displayed several buttons that allowed the
@@ -1411,6 +1411,7 @@ function createActionPanel(root, loc) {
     navSection.className = 'nav-section';
     const navCol = document.createElement('div');
     navCol.className = 'nav-column';
+    navCol.appendChild(restBtn);
     navCol.appendChild(dirGrid);
 
     const coordDisp = document.createElement('div');
@@ -1427,7 +1428,7 @@ function createActionPanel(root, loc) {
     navSection.appendChild(navCol);
     navSection.appendChild(mobCol);
 
-    return { restBtn, navSection };
+    return { navSection };
 }
 
 


### PR DESCRIPTION
## Summary
- keep log button above fullscreen log overlay
- align detailed time view and widen
- make profile, inventory, and equipment buttons visible and same width as the character image
- move rest button into nav section
- show area menu only in city zones
- clean up South Gustaberg points of interest

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_6886c1a9b0a88325886723140bab90fb