### PR TITLE
Improve inventory layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -536,16 +536,18 @@ body.portrait .main-layout {
     text-align: left;
 }
 
+
 .inventory-section {
-    width: fit-content;
-    margin: 0 auto 10px auto;
+    width: 100%;
+    margin: 0 0 10px 0;
 }
 
 .inventory-header {
     display: block;
-    margin: 20px auto 5px auto;
+    margin: 20px 0 5px 0;
     font-size: 1.2em;
     font-weight: bold;
+    text-align: left;
 }
 
 .inventory-list {
@@ -569,7 +571,7 @@ body.portrait .main-layout {
     display: grid;
     grid-template-columns: 1fr auto;
     align-items: center;
-    gap: 8px;
+    gap: 4px;
 }
 
 .item-actions {

--- a/js/ui.js
+++ b/js/ui.js
@@ -2259,9 +2259,6 @@ export function renderInventoryScreen(root) {
     if (!activeCharacter) return;
     root.innerHTML = '';
     resetDetails();
-    const title = document.createElement('h2');
-    title.textContent = 'Inventory';
-    root.appendChild(title);
     const categories = {
         Weapons: [],
         Armor: [],


### PR DESCRIPTION
## Summary
- drop redundant Inventory heading
- keep category headers left-aligned
- keep consistent row width across categories
- tighten spacing between item info and action buttons

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_6886c55e79ec83259a879bbf689f3880