### PR TITLE
Update log controls and Earthsday icon

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -687,7 +687,7 @@ body.portrait .main-layout {
     padding: 4px;
     border-radius: 4px;
     text-align: left;
-    z-index: 1000;
+    z-index: 1200;
     font-size: var(--log-font-size);
 }
 
@@ -700,18 +700,6 @@ body.portrait .main-layout {
     max-height: none;
 }
 
-#game-log .font-controls {
-    position: absolute;
-    top: 5px;
-    right: 5px;
-}
-#game-log .font-controls button {
-    width: 28px;
-    height: 28px;
-    margin-left: 2px;
-    padding: 2px 6px;
-    font-size: 14px;
-}
 
 #action-buttons {
     display: flex;

--- a/data/characters.js
+++ b/data/characters.js
@@ -746,7 +746,7 @@ const dayNames = [
 
 export const dayElements = {
   Firesday: '🔥',
-  Earthsday: '🌍',
+  Earthsday: '🪨',
   Watersday: '💧',
   Windsday: '💨',
   Iceday: '❄️',

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls, setupLogControls, setupTimeDisplay, updateTimeDisplay } from './ui.js';
+import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls, setupLogControls, setupTimeDisplay, updateTimeDisplay, isLogFullscreen, adjustLogFontSize } from './ui.js';
 import { loadCharacters, initCurrentUser, initNotorious, activeCharacter } from '../data/index.js';
 
 // Entry point: initialize application
@@ -11,8 +11,12 @@ function applyOrientation() {
 }
 
 function updateScale(delta) {
-    uiScale = Math.max(0.5, Math.min(2, uiScale + delta));
-    document.documentElement.style.setProperty('--ui-scale', uiScale);
+    if (isLogFullscreen()) {
+        adjustLogFontSize(delta * 20);
+    } else {
+        uiScale = Math.max(0.5, Math.min(2, uiScale + delta));
+        document.documentElement.style.setProperty('--ui-scale', uiScale);
+    }
 }
 
 function init() {

--- a/js/ui.js
+++ b/js/ui.js
@@ -169,28 +169,25 @@ export function setupLogControls(btn, panel) {
     logButtonElement = btn;
     logPanelElement = panel;
     if (!logButtonElement || !logPanelElement) return;
-    const fontControls = document.createElement('div');
-    fontControls.className = 'font-controls hidden';
-    const dec = document.createElement('button');
-    dec.textContent = '-';
-    const inc = document.createElement('button');
-    inc.textContent = '+';
-    fontControls.appendChild(dec);
-    fontControls.appendChild(inc);
-    logPanelElement.appendChild(fontControls);
     updateLogFont();
 
     const toggle = () => {
         const fs = logPanelElement.classList.toggle('fullscreen');
         logPanelElement.classList.toggle('hidden', false);
-        fontControls.classList.toggle('hidden', !fs);
         pruneLog();
         updateGameLogPadding();
     };
     logButtonElement.addEventListener('click', toggle);
-    dec.addEventListener('click', e => { e.stopPropagation(); logFontSize = Math.max(8, logFontSize - 2); updateLogFont(); });
-    inc.addEventListener('click', e => { e.stopPropagation(); logFontSize = Math.min(32, logFontSize + 2); updateLogFont(); });
     pruneLog();
+}
+
+export function adjustLogFontSize(delta) {
+    logFontSize = Math.max(8, Math.min(32, logFontSize + delta));
+    updateLogFont();
+}
+
+export function isLogFullscreen() {
+    return !!(logPanelElement && logPanelElement.classList.contains('fullscreen'));
 }
 
 export function addGameLog(msg) {


### PR DESCRIPTION
## Summary
- prevent log from sitting behind the persistent menu by raising its `z-index`
- remove embedded log font zoom buttons
- allow page zoom controls to adjust log font when the log is fullscreen
- update Earthsday icon to a rock

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_6886cfc4e8388325adf2a79fe01e1152