### PR TITLE
Add automatic loot and UI improvements

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -211,6 +211,10 @@ body.landscape #area-grid {
     gap: 4px;
 }
 
+#rest-button {
+    width: 120px;
+}
+
 .mob-column {
     display: flex;
     flex-direction: column;
@@ -225,6 +229,17 @@ body.landscape #area-grid {
     gap: 10px;
 }
 
+.nav-row {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+body.portrait .nav-row {
+    flex-direction: row;
+    align-items: flex-start;
+}
+
 #nearby-monsters {
     display: flex;
     flex-direction: column;
@@ -232,7 +247,7 @@ body.landscape #area-grid {
 }
 
 .monster-btn {
-    width: 100px;
+    width: 120px;
 }
 
 .monster-btn.defeated {


### PR DESCRIPTION
## Summary
- resize rest and monster buttons for consistency
- arrange monster list beside navigation controls in portrait
- expose attack button under navigation panel
- automatically display combat log messages
- auto-claim battle rewards and refill HP/MP on defeat

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_6886d42d42548325b9a71b63e6c284a2