### PR TITLE
Simplify battle flow and layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -212,7 +212,7 @@ body.landscape #area-grid {
 }
 
 #rest-button {
-    width: 120px;
+    width: 128px;
 }
 
 .mob-column {
@@ -440,7 +440,7 @@ body.portrait .main-layout {
 
 #character-details button {
     margin: 2px auto;
-    width: 160px;
+    width: 128px;
 }
 
 .profile-group {
@@ -463,7 +463,7 @@ body.portrait .main-layout {
 .profile-btn {
     display: block;
     margin: 0 auto;
-    width: clamp(138px, 23vw, 230px);
+    width: 128px;
 }
 
 .image-container {


### PR DESCRIPTION
## Summary
- return to the main menu automatically when a battle ends
- update monster list display during combat
- remove confirmation buttons from combat end
- keep the character profile above the rest button
- adjust button widths for a tidy nav column

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_6886e004e22c8325a37faa607f9986c8