### PR TITLE
Move menu and log to bottom

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -9,7 +9,7 @@ body {
     color: #eee;
     text-align: center;
     margin: 0;
-    padding: 60px 0 0 0;
+    padding: 0 0 60px 0;
     font-size: clamp(14px, 2vw, 20px);
 }
 
@@ -51,7 +51,7 @@ body.portrait #app {
 
 #scale-controls {
     position: fixed;
-    top: 5px;
+    bottom: 5px;
     right: 5px;
     z-index: 1100;
     display: flex;
@@ -72,7 +72,7 @@ body.portrait #app {
 #time-popup {
     position: fixed;
     right: 5px;
-    top: 40px;
+    bottom: 40px;
     background: rgba(0, 0, 0, 0.8);
     padding: 8px;
     border-radius: 4px;
@@ -212,7 +212,9 @@ body.landscape #area-grid {
 }
 
 #rest-button {
-    width: 128px;
+    width: 150px;
+    margin-top: 10px;
+    margin-bottom: 10px;
 }
 
 .mob-column {
@@ -233,6 +235,7 @@ body.landscape #area-grid {
     display: flex;
     flex-direction: column;
     gap: 10px;
+    align-items: center;
 }
 
 body.portrait .nav-row {
@@ -243,11 +246,11 @@ body.portrait .nav-row {
 #nearby-monsters {
     display: flex;
     flex-direction: column;
-    gap: 4px;
+    gap: 10px;
 }
 
 .monster-btn {
-    width: 120px;
+    width: 150px;
 }
 
 .monster-btn.defeated {
@@ -463,7 +466,7 @@ body.portrait .main-layout {
 .profile-btn {
     display: block;
     margin: 0 auto;
-    width: 128px;
+    width: 150px;
 }
 
 .image-container {
@@ -693,7 +696,7 @@ body.portrait .main-layout {
 
 #game-log {
     position: fixed;
-    top: 40px;
+    bottom: 40px;
     left: 5px;
     right: 5px;
     max-height: 200px;

--- a/js/ui.js
+++ b/js/ui.js
@@ -64,12 +64,12 @@ let monsterListElement = null;
 let updateMonsterDisplay = () => {};
 let navColumnElement = null;
 
-const BASE_TOP_PADDING = 60;
+const BASE_BOTTOM_PADDING = 60;
 
 function updateGameLogPadding() {
     if (!logPanelElement) return;
     const height = logPanelElement.classList.contains('hidden') ? 0 : logPanelElement.offsetHeight;
-    document.body.style.paddingTop = (BASE_TOP_PADDING + height) + 'px';
+    document.body.style.paddingBottom = (BASE_BOTTOM_PADDING + height) + 'px';
 }
 
 export function setupTimeDisplay(el, popup) {


### PR DESCRIPTION
## Summary
- put the persistent control bar at the bottom
- open the time popup and log upwards from bottom
- widen profile, rest and monster buttons
- increase spacing in the nav screen
- adjust body padding logic for bottom placement

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_6886e3fb5dac8325b188a67f43e2aa61