### PR TITLE
Adjust nav button sizing and rounding

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -25,6 +25,7 @@ button {
     background-color: #333;
     color: #fff;
     border: 1px solid #555;
+    border-radius: 4px;
     cursor: pointer;
     min-height: 28px;
 }
@@ -213,8 +214,8 @@ body.landscape #area-grid {
 
 #rest-button {
     width: 150px;
-    margin-top: 10px;
-    margin-bottom: 10px;
+    margin-top: 4px;
+    margin-bottom: 4px;
 }
 
 .mob-column {
@@ -268,16 +269,21 @@ body.portrait .nav-row {
 
 #direction-grid {
     display: grid;
-    grid-template-columns: repeat(3, 40px);
-    grid-template-rows: repeat(3, 40px);
+    grid-template-columns: repeat(3, 150px);
+    grid-template-rows: repeat(3, 150px);
     gap: 4px;
     margin-top: 6px;
 }
 
 #direction-grid button {
-    width: 40px;
-    height: 40px;
+    width: 150px;
+    height: 150px;
     padding: 0;
+}
+
+#direction-grid button:disabled {
+    background-color: #222;
+    color: #777;
 }
 
 #attack-button {

--- a/js/ui.js
+++ b/js/ui.js
@@ -1312,11 +1312,15 @@ function createAreaGrid(root, loc) {
     return grid;
 }
 
-function stepInDirection(coord, dx, dy) {
+function nextCoord(coord, dx, dy) {
     const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
     const x = Math.min(Math.max(0, coord.letter.toUpperCase().charCodeAt(0) - 65 + dx), letters.length - 1);
     const y = Math.max(1, coord.number + dy);
-    const next = { letter: letters[x], number: y };
+    return { letter: letters[x], number: y };
+}
+
+function stepInDirection(coord, dx, dy) {
+    const next = nextCoord(coord, dx, dy);
     if (!canMove(activeCharacter.currentLocation, coord, next)) return coord;
     activeCharacter.subArea = getSubArea(activeCharacter.currentLocation, next);
     return next;
@@ -1367,6 +1371,14 @@ function createActionPanel(root, loc) {
             });
         } else {
             b.textContent = d.l;
+            if (activeCharacter?.coordinates) {
+                const candidate = nextCoord(activeCharacter.coordinates, d.dx, d.dy);
+                if (!canMove(loc.name, activeCharacter.coordinates, candidate)) {
+                    b.disabled = true;
+                }
+            } else {
+                b.disabled = true;
+            }
             b.addEventListener('click', () => {
                 if (!activeCharacter?.coordinates) return;
                 activeCharacter.coordinates = stepInDirection(activeCharacter.coordinates, d.dx, d.dy);


### PR DESCRIPTION
## Summary
- give all buttons rounded corners
- reduce extra space around Rest button
- enlarge navigation buttons to match Rest button's width while staying square
- darken invalid navigation buttons and disable them when movement is blocked

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6886f49d93e48325a8011c7187a3ebdc