### PR TITLE
Fix direction grid width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -269,15 +269,16 @@ body.portrait .nav-row {
 
 #direction-grid {
     display: grid;
-    grid-template-columns: repeat(3, 150px);
-    grid-template-rows: repeat(3, 150px);
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(3, 1fr);
+    width: 150px;
     gap: 4px;
     margin-top: 6px;
 }
 
 #direction-grid button {
-    width: 150px;
-    height: 150px;
+    width: 100%;
+    aspect-ratio: 1 / 1;
     padding: 0;
 }
 


### PR DESCRIPTION
## Summary
- adjust `#direction-grid` CSS rules so the whole grid is only 150px wide
- size each grid button with `aspect-ratio` so the grid stays square

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6886f9bedc9c8325b35889eaf490ef2a