### PR TITLE
Fix navigation and combat UI issues

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -293,11 +293,6 @@ body.portrait .nav-row {
     font-size: 20px;
 }
 
-#coord-display {
-    margin-top: 6px;
-}
-
-
 .form-header {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
## Summary
- show coordinates in the center navigation button instead of an attack button
- keep combat action buttons visible and reuse them each turn

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_6887567443608325996133e6e63bce56