### PR TITLE
Fix action UI issues and add South Gustaberg map

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -215,8 +215,8 @@ body.landscape #area-grid {
 
 #rest-button {
     width: 150px;
-    margin-top: 4px;
-    margin-bottom: 4px;
+    margin-top: 0;
+    margin-bottom: 0;
 }
 
 .mob-column {

--- a/img/maps/south_gustaberg.svg
+++ b/img/maps/south_gustaberg.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 400">
+  <rect width="400" height="400" fill="#222" />
+  <text x="200" y="200" fill="white" font-size="24" text-anchor="middle">South Gustaberg</text>
+</svg>

--- a/js/ui.js
+++ b/js/ui.js
@@ -1432,6 +1432,12 @@ function createActionPanel(root, loc) {
     const restBtn = document.createElement('button');
     restBtn.id = 'rest-button';
     restBtn.textContent = 'Rest';
+    if (activeCharacter) {
+        const maxHp = activeCharacter.raceHP + activeCharacter.jobHP + activeCharacter.sJobHP;
+        const pct = activeCharacter.hp / maxHp;
+        if (pct < 0.25) restBtn.style.backgroundColor = 'orange';
+        else if (pct < 0.5) restBtn.style.backgroundColor = 'yellow';
+    }
     restBtn.addEventListener('click', () => {
         if (activeCharacter) {
             updateDerivedStats(activeCharacter);
@@ -1591,7 +1597,13 @@ function renderCombatScreen(app, mobs, destination) {
     const navColumn = app.querySelector('.nav-column');
     const actionColumn = document.createElement('div');
     actionColumn.className = 'action-column';
-    if (navColumn) navColumn.appendChild(actionColumn); else container.appendChild(actionColumn);
+    if (navColumn) {
+        const existing = navColumn.querySelectorAll('.action-column');
+        existing.forEach(el => el.remove());
+        navColumn.appendChild(actionColumn);
+    } else {
+        container.appendChild(actionColumn);
+    }
 
     const { actionDiv, attackBtn, abilityBtn, abilitySelect, magicBtn, magicSelect, fleeBtn } = createActionButtons(false);
     actionColumn.appendChild(actionDiv);


### PR DESCRIPTION
## Summary
- prevent duplicate action columns when starting combat
- color-code Rest button based on HP level
- adjust Rest button margins
- add a placeholder South Gustaberg map

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js > /tmp/testBalance.log`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_6887d4e6f8b883259f6d36fb5f382f91