### PR TITLE
Fix monster outline reset in combat

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -1568,6 +1568,10 @@ function createActionPanel(root, loc) {
             btn.disabled = m.defeated;
             monsterList.appendChild(btn);
         });
+        if (selectedMonsterIndex !== null) {
+            const focusBtn = monsterList.children[selectedMonsterIndex];
+            if (focusBtn) focusBtn.focus();
+        }
     }
 
     renderMonsters();


### PR DESCRIPTION
## Summary
- maintain focus on selected monster button when updating list during combat

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688815cdcb548325a06974f7e6afa2a6