### PR TITLE
Layout fix for monster column

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -247,8 +247,8 @@ body.landscape .nav-row {
 }
 
 body.portrait .nav-row {
-    flex-direction: column;
-    align-items: center;
+    flex-direction: row;
+    align-items: flex-start;
 }
 
 #nearby-monsters {


### PR DESCRIPTION
## Summary
- keep monster list beside nav and profile even in portrait mode

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_6888213df0bc8325b6c7533efa9467b5