### PR TITLE
Persist monster list with character save

### DIFF
--- a/data/characters.js
+++ b/data/characters.js
@@ -194,7 +194,9 @@ export const characters = [
     signetUntil: 0,
     conquestPoints: 0,
     minutes: 0,
-    targetIndex: null
+    targetIndex: null,
+    monsterCoord: '',
+    monsters: []
   },
   {
     name: 'Shantotto',
@@ -273,7 +275,9 @@ export const characters = [
     signetUntil: 0,
     conquestPoints: 0,
     minutes: 0,
-    targetIndex: null
+    targetIndex: null,
+    monsterCoord: '',
+    monsters: []
   }
 ];
 
@@ -359,7 +363,9 @@ export function createCharacterObject(name, job, race, sex = 'Male') {
     signetUntil: 0,
     conquestPoints: 0,
     minutes: 0,
-    targetIndex: null
+    targetIndex: null,
+    monsterCoord: '',
+    monsters: []
   };
   updateDerivedStats(character);
   return character;
@@ -556,6 +562,8 @@ export function loadCharacters() {
     loaded.forEach(c => {
       if (c.conquestPoints === undefined) c.conquestPoints = 0;
       if (c.targetIndex === undefined) c.targetIndex = null;
+      if (!Array.isArray(c.monsters)) c.monsters = [];
+      if (c.monsterCoord === undefined) c.monsterCoord = '';
       characters.push(c);
       updateDerivedStats(c);
     });

--- a/js/ui.js
+++ b/js/ui.js
@@ -291,12 +291,28 @@ function coordKey(coord) {
 
 function updateNearbyMonsters(zone, root) {
     const key = coordKey(activeCharacter.coordinates);
-    if (key !== monsterCoordKey) {
+    if (!activeCharacter.monsters) activeCharacter.monsters = [];
+    if (activeCharacter.monsterCoord === undefined) activeCharacter.monsterCoord = '';
+
+    if (key !== activeCharacter.monsterCoord || !activeCharacter.monsters.length) {
         const { list, aggro } = spawnNearbyMonsters(activeCharacter, zone);
+        list.forEach((m, i) => { m.listIndex = i; });
         nearbyMonsters = list;
+        activeCharacter.monsters = list;
+        activeCharacter.monsterCoord = key;
         monsterCoordKey = key;
         selectedMonsterIndex = null;
         if (activeCharacter) activeCharacter.targetIndex = null;
+        persistCharacter(activeCharacter);
+        if (aggro.length) {
+            const app = root.parentElement || root;
+            renderCombatScreen(app, aggro);
+            return true;
+        }
+    } else {
+        nearbyMonsters = activeCharacter.monsters;
+        monsterCoordKey = key;
+        const aggro = nearbyMonsters.filter(m => m.aggro && !m.defeated);
         if (aggro.length) {
             const app = root.parentElement || root;
             renderCombatScreen(app, aggro);


### PR DESCRIPTION
## Summary
- save generated monster list and associated coordinate on the character
- reuse saved monsters when revisiting the same spot or refreshing

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_68883beccd5c83259bbe3ed7d4e1c249