### PR TITLE
Fix monster selection highlighting

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -1568,7 +1568,13 @@ function createActionPanel(root, loc) {
             if (activeCharacter.targetIndex !== null && activeCharacter.targetIndex >= nearbyMonsters.length) {
                 activeCharacter.targetIndex = nearbyMonsters.length ? 0 : null;
             }
-            selectedMonsterIndex = activeCharacter.targetIndex;
+            if (selectedMonsterIndex === null || selectedMonsterIndex === undefined) {
+                selectedMonsterIndex = activeCharacter.targetIndex;
+            } else if (activeCharacter.targetIndex === null || activeCharacter.targetIndex === undefined) {
+                activeCharacter.targetIndex = selectedMonsterIndex;
+            } else {
+                selectedMonsterIndex = activeCharacter.targetIndex;
+            }
         } else {
             selectedMonsterIndex = null;
         }


### PR DESCRIPTION
## Summary
- keep `selectedMonsterIndex` in sync with `activeCharacter.targetIndex`
- persist index when the target index is temporarily missing

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_6888567c5fcc8325801b6a1fac5c8b8f