### PR TITLE
Remove monster outline highlight and fix defeated color

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -263,16 +263,12 @@ body.portrait .nav-row {
 }
 
 .monster-btn.defeated {
-    background-color: #555;
-    color: #aaa;
+    background-color: lightgray;
+    color: #333;
 }
 
 .monster-btn.aggro {
     background-color: darkred;
-}
-
-.monster-btn.selected {
-    outline: 4px solid yellow;
 }
 
 #direction-grid {

--- a/js/ui.js
+++ b/js/ui.js
@@ -1584,8 +1584,7 @@ function createActionPanel(root, loc) {
             btn.textContent = `${m.name} HP:${m.hp}`;
             btn.className = 'monster-btn';
             if (m.defeated) btn.classList.add('defeated');
-            if (m.aggro) btn.classList.add('aggro');
-            if (i === (activeCharacter ? activeCharacter.targetIndex : null)) btn.classList.add('selected');
+            if (m.aggro && !m.defeated) btn.classList.add('aggro');
             btn.addEventListener('click', () => {
                 if (m.defeated) return;
                 selectedMonsterIndex = i;
@@ -1858,8 +1857,10 @@ function renderCombatScreen(app, mobs, destination) {
         if (listIdx === undefined) listIdx = nearbyMonsters.indexOf(mob);
         if (listIdx !== -1) {
             nearbyMonsters[listIdx].defeated = true;
+            nearbyMonsters[listIdx].aggro = false;
             nearbyMonsters[listIdx].hp = 0;
         }
+        mob.aggro = false;
         updateMonsterDisplay();
         if (mobs.length === 0) {
             const rewards = calculateBattleRewards(activeCharacter, defeated);


### PR DESCRIPTION
## Summary
- remove `.selected` outline styling for monsters
- light grey styling for defeated monsters
- don't apply aggro style once a monster is defeated
- reset aggro flag when monsters die

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_68889153e5488325bbfcfdb6aaa9259b