### PR TITLE
Add button press effect and target indicator

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -126,6 +126,9 @@ body.portrait #app {
     width: 28px;
 }
 
+button.pressed {
+    filter: brightness(1.2);
+}
 button:hover {
     background-color: #444;
 }
@@ -271,6 +274,10 @@ body.portrait .nav-row {
     background-color: darkred;
 }
 
+
+.monster-btn.target {
+    outline: 2px solid yellow;
+}
 #direction-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls, setupLogControls, setupTimeDisplay, setupMapOverlay, updateTimeDisplay, isLogFullscreen, adjustLogFontSize } from './ui.js';
+import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls, setupLogControls, setupTimeDisplay, setupMapOverlay, updateTimeDisplay, isLogFullscreen, adjustLogFontSize, setupPressFeedback } from './ui.js';
 import { loadCharacters, initCurrentUser, initNotorious, activeCharacter } from '../data/index.js';
 
 // Entry point: initialize application
@@ -28,6 +28,7 @@ function init() {
     app.innerHTML = '';
     const menu = renderMainMenu();
     app.appendChild(menu);
+    setupPressFeedback(document.body);
     if (!activeCharacter) {
         renderCharacterMenu(menu);
     }

--- a/js/ui.js
+++ b/js/ui.js
@@ -79,6 +79,29 @@ let monsterHpList = [];
 
 const BASE_BOTTOM_PADDING = 60;
 
+// Apply a lightened style while a button is actively pressed
+export function setupPressFeedback(root = document.body) {
+    function add(e) {
+        const btn = e.target.closest('button');
+        if (btn) btn.classList.add('pressed');
+    }
+    function remove() {
+        root.querySelectorAll('button.pressed').forEach(b => b.classList.remove('pressed'));
+    }
+    root.addEventListener('mousedown', add);
+    root.addEventListener('touchstart', add, { passive: true });
+    ['mouseup','mouseleave','touchend','touchcancel'].forEach(ev =>
+        root.addEventListener(ev, remove));
+}
+
+// Highlight the selected monster in the nearby monster list
+export function updateTargetIndicator() {
+    if (!monsterListElement) return;
+    Array.from(monsterListElement.children).forEach((btn, idx) => {
+        btn.classList.toggle('target', idx === selectedMonsterIndex);
+    });
+}
+
 function updateGameLogPadding() {
     if (!logPanelElement) return;
     const height = logPanelElement.classList.contains('hidden') ? 0 : logPanelElement.offsetHeight;
@@ -1585,6 +1608,7 @@ function createActionPanel(root, loc) {
             btn.className = 'monster-btn';
             if (m.defeated) btn.classList.add('defeated');
             if (m.aggro && !m.defeated) btn.classList.add('aggro');
+            if (i === selectedMonsterIndex) btn.classList.add('target');
             btn.addEventListener('click', () => {
                 if (m.defeated) return;
                 selectedMonsterIndex = i;
@@ -1607,6 +1631,7 @@ function createActionPanel(root, loc) {
             const focusBtn = monsterList.children[activeCharacter.targetIndex];
             if (focusBtn) focusBtn.focus();
         }
+        updateTargetIndicator();
         monsterList.scrollTop = prevScroll;
     }
 


### PR DESCRIPTION
## Summary
- show lightening effect while buttons are held down
- highlight targeted monster in monster list
- wire button press effect into main initialization

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_6888a314babc8325bd3181fe2eb03721