### PR TITLE
Fix monster targeting reset

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -1892,15 +1892,14 @@ function renderCombatScreen(app, mobs, destination) {
             victory(rewards.exp, rewards.gil, rewards.cp, rewards.drops, rewards.messages);
         } else {
             if (selectedMonsterIndex === idx) {
-                selectedMonsterIndex = 0;
+                selectedMonsterIndex = null;
+                if (activeCharacter) activeCharacter.targetIndex = null;
             } else if (selectedMonsterIndex > idx) {
                 selectedMonsterIndex--;
+                if (activeCharacter) activeCharacter.targetIndex = selectedMonsterIndex;
             }
             currentTarget = mobs[selectedMonsterIndex] || mobs[0];
-            if (activeCharacter) {
-                activeCharacter.targetIndex = selectedMonsterIndex;
-                persistCharacter(activeCharacter);
-            }
+            if (activeCharacter) persistCharacter(activeCharacter);
             update();
         }
     }


### PR DESCRIPTION
## Summary
- keep monster selection after each attack
- clear selection when the defeated monster was targeted

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_6888ab1781348325a2317338438e1d41