### PR TITLE
Fix attack target reference

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -1689,14 +1689,15 @@ function createActionPanel(root, loc) {
     const { actionDiv, attackBtn } = createActionButtons(true);
     attackBtn.disabled = false;
     attackBtn.addEventListener('click', () => {
-        let idx = activeCharacter ? activeCharacter.targetIndex : null;
-        let target = currentTargetMonster;
-        if (!target && idx !== null) target = nearbyMonsters[idx];
-        if (idx === null && target) {
-            const found = nearbyMonsters.indexOf(target);
+        let idx = selectedMonsterIndex;
+        if (idx === null && activeCharacter) idx = activeCharacter.targetIndex;
+        let target = idx !== null ? nearbyMonsters[idx] : currentTargetMonster;
+        if (!target && currentTargetMonster) {
+            const found = nearbyMonsters.indexOf(currentTargetMonster);
             if (found !== -1) {
                 setTargetIndex(found);
                 idx = found;
+                target = nearbyMonsters[found];
             }
         }
         if (!target || idx === null || target.defeated) return;
@@ -2086,6 +2087,9 @@ function renderCombatScreen(app, mobs, destination) {
     }
 
     attackBtn.addEventListener('click', () => {
+        if (selectedMonsterIndex !== null && mobs[selectedMonsterIndex]) {
+            currentTarget = mobs[selectedMonsterIndex];
+        }
         if (!currentTarget) {
             log('No target selected.');
             return;
@@ -2095,6 +2099,9 @@ function renderCombatScreen(app, mobs, destination) {
     });
 
     abilityBtn.addEventListener('click', () => {
+        if (selectedMonsterIndex !== null && mobs[selectedMonsterIndex]) {
+            currentTarget = mobs[selectedMonsterIndex];
+        }
         if (!currentTarget) {
             log('No target selected.');
             return;
@@ -2106,6 +2113,9 @@ function renderCombatScreen(app, mobs, destination) {
     });
 
     magicBtn.addEventListener('click', () => {
+        if (selectedMonsterIndex !== null && mobs[selectedMonsterIndex]) {
+            currentTarget = mobs[selectedMonsterIndex];
+        }
         if (!currentTarget) {
             log('No target selected.');
             return;


### PR DESCRIPTION
## Summary
- use selectedMonsterIndex or currentTargetMonster as the main target lookup
- update combat actions to fetch the monster from the stored index

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_6888da49447483258786858f1d1a844c