### PR TITLE
Consolidate monster targeting

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -1746,19 +1746,17 @@ function renderCombatScreen(app, mobs, destination) {
     if (selectedMonsterIndex === null && activeCharacter && activeCharacter.targetIndex !== null) {
         selectedMonsterIndex = activeCharacter.targetIndex;
     }
-    if (selectedMonsterIndex === null || selectedMonsterIndex >= mobs.length) {
-        selectedMonsterIndex = null;
-        currentTargetMonster = null;
-    } else {
-        currentTargetMonster = mobs[selectedMonsterIndex];
-    }
+    const foundTarget = mobs.find(m => m.listIndex === selectedMonsterIndex);
+    currentTargetMonster = foundTarget || null;
+    if (!foundTarget) selectedMonsterIndex = null;
     if (activeCharacter) activeCharacter.targetIndex = selectedMonsterIndex;
     monsterSelectHandler = idx => {
-        if (mobs[idx]) {
-            selectedMonsterIndex = idx;
-            currentTargetMonster = mobs[idx];
+        const mob = mobs[idx];
+        if (mob) {
+            selectedMonsterIndex = mob.listIndex ?? idx;
+            currentTargetMonster = mob;
             if (activeCharacter) {
-                activeCharacter.targetIndex = idx;
+                activeCharacter.targetIndex = selectedMonsterIndex;
                 persistCharacter(activeCharacter);
             }
         }
@@ -1921,15 +1919,14 @@ function renderCombatScreen(app, mobs, destination) {
             const rewards = calculateBattleRewards(activeCharacter, defeated);
             victory(rewards.exp, rewards.gil, rewards.cp, rewards.drops, rewards.messages);
         } else {
-            if (selectedMonsterIndex === idx) {
+            if (selectedMonsterIndex === listIdx) {
                 selectedMonsterIndex = null;
                 if (activeCharacter) activeCharacter.targetIndex = null;
                 currentTargetMonster = null;
-            } else if (selectedMonsterIndex !== null && selectedMonsterIndex > idx) {
-                selectedMonsterIndex--;
+            } else {
+                currentTargetMonster = mobs.find(m => m.listIndex === selectedMonsterIndex) || null;
                 if (activeCharacter) activeCharacter.targetIndex = selectedMonsterIndex;
             }
-            currentTargetMonster = selectedMonsterIndex !== null ? mobs[selectedMonsterIndex] : null;
             if (activeCharacter) persistCharacter(activeCharacter);
             update();
         }
@@ -2078,7 +2075,7 @@ function renderCombatScreen(app, mobs, destination) {
     }
 
     attackBtn.addEventListener('click', () => {
-        const target = selectedMonsterIndex !== null ? mobs[selectedMonsterIndex] : null;
+        const target = selectedMonsterIndex !== null ? mobs.find(m => m.listIndex === selectedMonsterIndex) : null;
         if (!target) {
             log('No target selected.');
             return;
@@ -2088,7 +2085,7 @@ function renderCombatScreen(app, mobs, destination) {
     });
 
     abilityBtn.addEventListener('click', () => {
-        const target = selectedMonsterIndex !== null ? mobs[selectedMonsterIndex] : null;
+        const target = selectedMonsterIndex !== null ? mobs.find(m => m.listIndex === selectedMonsterIndex) : null;
         if (!target) {
             log('No target selected.');
             return;
@@ -2100,7 +2097,7 @@ function renderCombatScreen(app, mobs, destination) {
     });
 
     magicBtn.addEventListener('click', () => {
-        const target = selectedMonsterIndex !== null ? mobs[selectedMonsterIndex] : null;
+        const target = selectedMonsterIndex !== null ? mobs.find(m => m.listIndex === selectedMonsterIndex) : null;
         if (!target) {
             log('No target selected.');
             return;


### PR DESCRIPTION
## Summary
- keep selectedMonsterIndex consistent between menus and combat
- lookup battle targets by monster listIndex
- adjust targeting when a monster dies

## Testing
- `npm test` *(fails: could not find package.json)*
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_6888e3152de883258af35698e11a1190