### PR TITLE
Adjust log display and UI spacing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -270,6 +270,7 @@ body.portrait .nav-row {
     display: flex;
     flex-direction: column;
     gap: 0;
+    margin-top: 3px;
 }
 
 .monster-btn {
@@ -443,7 +444,7 @@ body.portrait .character-form {
 
 /* Active character profile */
 #active-profile {
-    margin-top: 20px;
+    margin-top: 3px;
 }
 
 .main-layout {

--- a/js/ui.js
+++ b/js/ui.js
@@ -250,11 +250,23 @@ function updateLogFont() {
 }
 
 function pruneLog() {
-    const cutoff = currentTurn - 1;
+    const full = logPanelElement.classList.contains('fullscreen');
+    let shown = 0;
     gameLogMessages.forEach(obj => {
-        const show = logPanelElement.classList.contains('fullscreen') || obj.turn >= cutoff;
+        let show;
+        if (full) {
+            show = true;
+        } else if (obj.turn === currentTurn && shown < 5) {
+            show = true;
+            shown++;
+        } else {
+            show = false;
+        }
         obj.div.style.display = show ? '' : 'none';
     });
+    if (!full && shown === 0 && gameLogMessages.length) {
+        gameLogMessages[0].div.style.display = '';
+    }
     updateGameLogPadding();
 }
 


### PR DESCRIPTION
## Summary
- refine popup log behavior to always show at least one line and at most five from the current turn
- tighten spacing for monster list and character profile

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_6888e9b1bfa08325b6231556f66e671b