### PR TITLE
Fix non-aggro target selection

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -364,7 +364,7 @@ function updateNearbyMonsters(zone, root) {
         persistCharacter(activeCharacter);
         if (aggro.length) {
             const app = root.parentElement || root;
-            renderCombatScreen(app, aggro);
+            renderCombatScreen(app, list);
             return true;
         }
     } else {
@@ -374,7 +374,7 @@ function updateNearbyMonsters(zone, root) {
         const aggro = nearbyMonsters.filter(m => m.aggro && !m.defeated);
         if (aggro.length) {
             const app = root.parentElement || root;
-            renderCombatScreen(app, aggro);
+            renderCombatScreen(app, nearbyMonsters);
             return true;
         }
     }


### PR DESCRIPTION
## Summary
- allow combat screen to show all nearby monsters when aggro is present

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_68890f28f89c8325afd03282cd3d0682