### PR TITLE
Fix vendor sell screen

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -2431,7 +2431,7 @@ export function renderVendorScreen(root, vendor, backFn = null, mode = 'buy') {
         sellBtn.addEventListener('click', () => {
             const q = qtyInput ? parseInt(qtyInput.value, 10) || 1 : 1;
             sellItem(entry.id, q);
-            renderVendorScreen(root, vendor, backFn);
+            renderVendorScreen(root, vendor, backFn, 'sell');
         });
         top.appendChild(sellBtn);
         row.appendChild(top);


### PR DESCRIPTION
## Summary
- keep vendor screen in 'sell' mode after an item sale

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688967e344f08325a8c65649f7422ce4