### PR TITLE
Fix monster list clearing on monster defeat

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -1776,7 +1776,11 @@ function createActionPanel(root, loc) {
 
 function renderCombatScreen(app, mobs, destination) {
     if (!activeCharacter) return;
-    if (!Array.isArray(mobs)) mobs = [mobs];
+    if (!Array.isArray(mobs)) {
+        mobs = [mobs];
+    } else {
+        mobs = [...mobs];
+    }
     document.body.classList.add('combat-active');
     const container = app.querySelector('#combat-column');
     if (!container) return;
@@ -1807,7 +1811,8 @@ function renderCombatScreen(app, mobs, destination) {
     if (!currentTargetMonster) selectedMonsterIndex = null;
     if (activeCharacter) activeCharacter.targetIndex = selectedMonsterIndex;
     monsterSelectHandler = idx => {
-        const mob = mobs[idx];
+        let mob = mobs.find(m => m.listIndex === idx);
+        if (!mob) mob = mobs[idx];
         if (mob) {
             selectedMonsterIndex = mob.listIndex ?? idx;
             currentTargetMonster = mob;


### PR DESCRIPTION
## Summary
- prevent combat from splicing the active monster list
- fix selecting a new target during battle

## Testing
- `node scripts/validateZones.js`
- `node scripts/testTaruBlm.js`
- `node scripts/testBalance.js`


------
https://chatgpt.com/codex/tasks/task_e_68897db5237c832581f853bb5f065063