### PR TITLE
Fix target switching after killing monsters

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -1754,6 +1754,15 @@ function createActionPanel(root, loc) {
         } else {
             group.push(target);
         }
+        // Assign listIndex for additional group members so targeting works
+        group.forEach(m => {
+            if (m.listIndex === undefined) {
+                m.listIndex = nearbyMonsters.length;
+                m.hp = m.hp || parseLevel(m.level) * 20;
+                nearbyMonsters.push(m);
+                if (activeCharacter) activeCharacter.monsters.push(m);
+            }
+        });
         renderCombatScreen(root.parentElement, group);
     });
     actionColumn.appendChild(actionDiv);


### PR DESCRIPTION
## Summary
- ensure all monsters in an encounter receive a `listIndex`
- push additional spawned monsters to `nearbyMonsters` so they can be targeted

## Testing
- `node scripts/testTaruBlm.js`
- `node scripts/testBalance.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688a14c877948325b5975199f3130655