### PR TITLE
Enable retargeting any monster

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -121,7 +121,11 @@ export function setTargetIndex(idx) {
 
 export function getSelectedMonster(list = nearbyMonsters) {
     if (selectedMonsterIndex === null || !Array.isArray(list)) return null;
-    return list.find(m => m.listIndex === selectedMonsterIndex) || list[selectedMonsterIndex] || null;
+    let mob = list.find(m => m.listIndex === selectedMonsterIndex) || list[selectedMonsterIndex];
+    if (!mob && list !== nearbyMonsters) {
+        mob = nearbyMonsters[selectedMonsterIndex];
+    }
+    return mob || null;
 }
 
 function updateGameLogPadding() {
@@ -1821,7 +1825,7 @@ function renderCombatScreen(app, mobs, destination) {
     if (activeCharacter) activeCharacter.targetIndex = selectedMonsterIndex;
     monsterSelectHandler = idx => {
         let mob = mobs.find(m => m.listIndex === idx);
-        if (!mob) mob = mobs[idx];
+        if (!mob) mob = nearbyMonsters[idx];
         if (mob) {
             selectedMonsterIndex = mob.listIndex ?? idx;
             currentTargetMonster = mob;


### PR DESCRIPTION
## Summary
- allow target helper to fall back to global monster list
- update combat targeting handler to use nearby monsters when needed

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688a1870533483258253b8a4c4118a7d