### PR TITLE
fix persistent combat state on death

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -2128,6 +2128,15 @@ function renderCombatScreen(app, mobs, destination) {
         monsterSelectHandler = null;
         selectedMonsterIndex = null;
         if (activeCharacter) activeCharacter.targetIndex = null;
+        nearbyMonsters = [];
+        monsterIndexList = [];
+        monsterNameList = [];
+        monsterHpList = [];
+        monsterCoordKey = '';
+        if (activeCharacter) {
+            activeCharacter.monsters = [];
+            activeCharacter.monsterCoord = '';
+        }
         currentTargetMonster = null;
         if (destination && activeCharacter.hp > 0) {
             setLocation(activeCharacter, destination);


### PR DESCRIPTION
## Summary
- reset monster lists and target data when the player dies

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688a40c56eb88325bbb72a5557934d20