### PR TITLE
Fix fishing-only mob spawns

### DIFF
--- a/js/encounter.js
+++ b/js/encounter.js
@@ -194,7 +194,9 @@ export function spawnNearbyMonsters(character, zone) {
   const pool = monstersByDistance(zone, subArea);
   if (!pool.length) return { list: [], aggro: [] };
   const coordStr = `${character.coordinates.letter}-${character.coordinates.number}`;
-  const available = pool.filter(m => !m.coords || m.coords.includes(coordStr));
+  const available = pool.filter(m =>
+    !m.fishingOnly && (!m.coords || m.coords.includes(coordStr))
+  );
   if (!available.length) return { list: [], aggro: [] };
   const count = Math.floor(Math.random() * 6) + 1;
   const list = [];


### PR DESCRIPTION
## Summary
- exclude fishing-only monsters from random spawn lists

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_688ac057f9288325b6a68557786810b3