### PR TITLE
Fix spawn filtering for subareas

### DIFF
--- a/js/encounter.js
+++ b/js/encounter.js
@@ -59,8 +59,12 @@ function spawnChanceFor(monster, zone) {
 export function monstersByDistance(zone, subArea = null) {
   zone = getBaseZone(zone);
   let mobs = bestiaryByZone[zone] || [];
-  if (subArea) mobs = mobs.filter(m => m.subArea === subArea);
-  else mobs = mobs.filter(m => !m.subArea);
+  if (subArea) {
+    const subMobs = mobs.filter(m => m.subArea === subArea);
+    mobs = subMobs.length ? subMobs : mobs.filter(m => !m.subArea);
+  } else {
+    mobs = mobs.filter(m => !m.subArea);
+  }
   const loc = locations.find(l => l.name === zone);
   const dist = loc?.distance ?? 0;
   if (!mobs.length) return [];


### PR DESCRIPTION
## Summary
- improve monster spawning logic for zones with subareas

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_688ad0da436c832582d9650db3610160