### PR TITLE
Update city navigation and shop refresh

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -204,6 +204,44 @@ body.landscape #area-grid {
     content: '\25BC';
 }
 
+.city-area-grid {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    margin-top: 4px;
+}
+
+.city-nav-column {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+
+.city-list-column {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+}
+
+.city-list-column button {
+    width: 160px;
+    margin: 1px 0;
+}
+
+.city-subheader {
+    margin: 1px 0;
+    width: 160px;
+}
+
+.main-area-header {
+    margin: 1px 0;
+    padding: 1px;
+}
+
+.main-area-header::before {
+    content: none;
+}
+
 
 
 .explore-btn {


### PR DESCRIPTION
## Summary
- classify shields as weapons
- refresh vendor prices after buying
- display city travel options in new sidebar layout
- style new city area navigation elements

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688bbddc328483259a3199cb24860f66