### PR TITLE
Fix city UI padding and time popup width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -82,7 +82,7 @@ body.portrait #app {
     padding: 8px;
     border-radius: 4px;
     min-width: 140px;
-    max-width: 260px;
+    max-width: none;
     z-index: 1000;
     text-align: left;
     color: #fff;
@@ -200,6 +200,10 @@ body.landscape #area-grid {
     margin-right: 4px;
 }
 
+.city-subheader::before {
+    margin-right: 8px;
+}
+
 .area-header.expanded::before {
     content: '\25BC';
 }
@@ -223,6 +227,12 @@ body.landscape #area-grid {
     gap: 1px;
 }
 
+.city-area-list {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+}
+
 .city-list-column button {
     width: 160px;
     margin: 1px 0;
@@ -231,6 +241,8 @@ body.landscape #area-grid {
 .city-subheader {
     margin: 1px 0;
     width: 160px;
+    justify-content: flex-start;
+    padding-left: 4px;
 }
 
 .main-area-header {
@@ -487,7 +499,7 @@ body.portrait .character-form {
 
 /* Active character profile */
 #active-profile {
-    margin-top: 1px;
+    margin: 0 0 1px 0;
 }
 
 .main-layout {

--- a/js/ui.js
+++ b/js/ui.js
@@ -209,6 +209,10 @@ export function showMap(zone) {
 
 function updateTimePopup() {
     if (!timePopupElement) return;
+    const controls = document.getElementById('scale-controls');
+    if (controls) {
+        timePopupElement.style.width = controls.offsetWidth + 'px';
+    }
     const vt = currentVanaTime();
     const icon = dayElements[vt.weekday] || '';
     const openHour = 8;
@@ -1339,7 +1343,10 @@ function createAreaGrid(root, loc) {
             ? activeCharacter.travel.remaining
             : total;
         const destLoc = locations.find(l => l.name === area);
-        const display = destLoc?.displayName || area;
+        let display = destLoc?.displayName || area;
+        if (!destLoc?.displayName) {
+            display = display.replace(/^North\s/, 'N. ').replace(/^South\s/, 'S. ');
+        }
         if (total > 1) {
             btn.textContent = `${display} (${travel}/${total})`;
         } else {
@@ -1517,7 +1524,10 @@ function createCityAreaGrid(root, loc) {
             ? activeCharacter.travel.remaining
             : total;
         const destLoc = locations.find(l => l.name === area);
-        const display = destLoc?.displayName || area;
+        let display = destLoc?.displayName || area;
+        if (!destLoc?.displayName) {
+            display = display.replace(/^North\s/, 'N. ').replace(/^South\s/, 'S. ');
+        }
         if (total > 1) {
             btn.textContent = `${display} (${travel}/${total})`;
         } else {


### PR DESCRIPTION
## Summary
- tweak character profile margin in city UI
- left align city subheader buttons and adjust arrow spacing
- remove bullets from city area lists
- enlarge time popup width and auto-match persistent menu width
- abbreviate long area names for narrow buttons

## Testing
- `node scripts/testTaruBlm.js`
- `node scripts/testBalance.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688befd014988325b8df89c4ab6e02bc