### PR TITLE
Fix profile alignment on city screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -505,7 +505,7 @@ body.portrait .character-form {
 .main-layout {
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: flex-start;
     gap: 20px;
 }
 


### PR DESCRIPTION
## Summary
- keep items at the top of `.main-layout` so profile doesn't slide down when city lists expand

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688bf3412804832581c01bd8d9a0cbc9