### PR TITLE
Fix vendor headers and list layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -15,8 +15,8 @@ body {
 }
 
 h1, h2 {
-    margin-top: 20px;
-    padding-right: 150px;
+    margin-top: 10px;
+    padding-right: 0;
 }
 
 button {
@@ -643,18 +643,12 @@ body.portrait .main-layout {
 
 .vendor-row-top {
     display: grid;
-    grid-template-columns: 1fr auto;
+    grid-template-columns: 1fr 80px auto;
     align-items: center;
     gap: 4px;
     width: 100%;
 }
 
-.vendor-info {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 4px;
-}
 
 .vendor-actions {
     display: flex;
@@ -671,6 +665,15 @@ body.portrait .main-layout {
 .vendor-item span {
     flex: 1;
     text-align: left;
+}
+
+.vendor-name {
+    text-align: left;
+}
+
+.vendor-price {
+    text-align: right;
+    width: 80px;
 }
 
 .vendor-qty {

--- a/js/ui.js
+++ b/js/ui.js
@@ -2607,9 +2607,8 @@ export function renderVendorScreen(root, vendor, backFn = null, mode = 'buy') {
         const top = document.createElement('div');
         top.className = 'vendor-row-top';
 
-        const info = document.createElement('div');
-        info.className = 'vendor-info';
         const name = document.createElement('span');
+        name.className = 'vendor-name';
         name.textContent = item.name;
         if (!meetsRequirements(item)) name.style.color = 'red';
         else if (canEquipItem(item) && isBetterItem(item)) name.style.color = 'lightgreen';
@@ -2623,12 +2622,12 @@ export function renderVendorScreen(root, vendor, backFn = null, mode = 'buy') {
                 name.style.color = 'lightskyblue';
             }
         }
-        info.appendChild(name);
         const price = document.createElement('span');
-        price.textContent = ` - ${item.price} gil`;
+        price.className = 'vendor-price';
+        price.textContent = `${item.price} gil`;
         if (item.price > activeCharacter.gil) price.style.color = 'red';
-        info.appendChild(price);
-        top.appendChild(info);
+        top.appendChild(name);
+        top.appendChild(price);
 
         const actions = document.createElement('div');
         actions.className = 'vendor-actions';
@@ -2697,17 +2696,16 @@ export function renderVendorScreen(root, vendor, backFn = null, mode = 'buy') {
         const top = document.createElement('div');
         top.className = 'vendor-row-top';
 
-        const info = document.createElement('div');
-        info.className = 'vendor-info';
         const name = document.createElement('span');
+        name.className = 'vendor-name';
         const qtyText = item.stack > 1 || entry.qty > 1 ? ` x${entry.qty}` : '';
         name.textContent = item.name + qtyText;
-        info.appendChild(name);
         const price = document.createElement('span');
         const sp = item.sellPrice || Math.floor(item.price / 2);
-        price.textContent = ` - ${sp} gil`;
-        info.appendChild(price);
-        top.appendChild(info);
+        price.className = 'vendor-price';
+        price.textContent = `${sp} gil`;
+        top.appendChild(name);
+        top.appendChild(price);
 
         const actions = document.createElement('div');
         actions.className = 'vendor-actions';
@@ -2777,16 +2775,15 @@ export function renderConquestShop(root, backFn = null) {
         const top = document.createElement('div');
         top.className = 'vendor-row-top';
 
-        const info = document.createElement('div');
-        info.className = 'vendor-info';
         const name = document.createElement('span');
+        name.className = 'vendor-name';
         name.textContent = item.name;
-        info.appendChild(name);
         const price = document.createElement('span');
-        price.textContent = ` - ${cost} CP`;
+        price.className = 'vendor-price';
+        price.textContent = `${cost} CP`;
         if (cost > (activeCharacter.conquestPoints || 0)) price.style.color = 'red';
-        info.appendChild(price);
-        top.appendChild(info);
+        top.appendChild(name);
+        top.appendChild(price);
 
         const actions = document.createElement('div');
         actions.className = 'vendor-actions';
@@ -3131,11 +3128,19 @@ function openMenu(name, backFn) {
             const btn = document.createElement('button');
             const displayName = npc.includes(' the ') ? npc.split(' the ')[0] : npc;
             btn.textContent = displayName;
-            btn.addEventListener('click', () => openMenu(npc, () => openMenu(name, backFn)));
+            btn.addEventListener('click', () => {
+                renderVendorScreen(root, npc, () => openMenu(name, backFn), 'buy');
+            });
             li.appendChild(btn);
             list.appendChild(li);
         });
         screen.appendChild(list);
+        const sellBtn = document.createElement('button');
+        sellBtn.textContent = 'Sell';
+        sellBtn.addEventListener('click', () => {
+            renderVendorScreen(root, npcs[0], () => openMenu(name, backFn), 'sell');
+        });
+        screen.appendChild(sellBtn);
         root.appendChild(screen);
         showBackButton(backHandler);
     } else if (vendorInventories[name]) {


### PR DESCRIPTION
## Summary
- make headers centered for vendor and shop screens
- split vendor item rows into name, cost and actions columns
- add `Sell` button on multivendor shop lists and open vendor wares directly

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688c194d0b24832583f73282c4ec46fa