### PR TITLE
Add zoom persistence and shop layout fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -653,6 +653,7 @@ body.portrait .main-layout {
 .vendor-actions {
     display: flex;
     flex-direction: column;
+    align-items: center;
     gap: 4px;
     padding: 0 4px;
 }
@@ -669,11 +670,16 @@ body.portrait .main-layout {
 
 .vendor-name {
     text-align: left;
+    display: flex;
+    align-items: center;
 }
 
 .vendor-price {
     text-align: right;
     width: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
 }
 
 .vendor-qty {

--- a/data/characters.js
+++ b/data/characters.js
@@ -195,6 +195,7 @@ export const characters = [
     signetUntil: 0,
     conquestPoints: 0,
     minutes: 0,
+    uiScale: 1,
     targetIndex: null,
     monsterCoord: '',
     monsters: []
@@ -277,6 +278,7 @@ export const characters = [
     signetUntil: 0,
     conquestPoints: 0,
     minutes: 0,
+    uiScale: 1,
     targetIndex: null,
     monsterCoord: '',
     monsters: []
@@ -366,6 +368,7 @@ export function createCharacterObject(name, job, race, sex = 'Male') {
     signetUntil: 0,
     conquestPoints: 0,
     minutes: 0,
+    uiScale: 1,
     targetIndex: null,
     monsterCoord: '',
     monsters: []
@@ -567,6 +570,7 @@ export function loadCharacters() {
       if (c.targetIndex === undefined) c.targetIndex = null;
       if (!Array.isArray(c.monsters)) c.monsters = [];
       if (c.monsterCoord === undefined) c.monsterCoord = '';
+      if (c.uiScale === undefined) c.uiScale = 1;
       characters.push(c);
       updateDerivedStats(c);
     });
@@ -585,6 +589,7 @@ export function loadCharacterSlot(index) {
     if (!saved[index]) return;
     characters[index] = saved[index];
     if (characters[index].conquestPoints === undefined) characters[index].conquestPoints = 0;
+    if (characters[index].uiScale === undefined) characters[index].uiScale = 1;
     updateDerivedStats(characters[index]);
     setActiveCharacter(characters[index]);
     saveCharacters();

--- a/data/locations.js
+++ b/data/locations.js
@@ -37,7 +37,6 @@ export const zonesByCity = {
         "Dragon's Claw Weaponry",
         "Carmelide's Jewelry Store",
         "Mjoll's General Goods",
-        "Olwyn's General Goods",
         "Harmodios's Music Shop",
         'Scribe & Notary',
         'Tenshodo Entrance',

--- a/data/vendors.js
+++ b/data/vendors.js
@@ -4218,7 +4218,6 @@ export const vendorInventories = {
   'Carmelide': ['tourmaline', 'sardonyx', 'amethyst', 'amber', 'lapisLazuli', 'clearTopaz', 'onyx', 'lightOpal', 'copperRing'],
   Raghd: ['silverRing', 'silverEarring', 'brassRing', 'copperRing'],
   "Mjoll's General Goods": ['woodenArrow', 'ironArrow', 'silverArrow', 'crossbowBolt', 'lightCrossbow', 'crossbow', 'scrollDarkThrenody', 'scrollIceThrenody'],
-  "Olwyn's General Goods": ['potion', 'ether', 'echoDrops', 'eyeDrops', 'antidote'],
   Harmodios: ['piccolo', 'cornette', 'mapleHarp', 'scrollVitalEtude', 'scrollSwiftEtude', 'scrollSageEtude', 'scrollLogicalEtude', 'scrollHerculeanEtude', 'scrollUncannyEtude', 'gemshorn', 'flute', 'scrollBewitchingEtude', 'foeSirvente', 'adventurersDirge'],
   Hortense: ['scrollFoeRequiemI', 'scrollFoeRequiemII', 'scrollFoeRequiemIII', 'scrollFoeRequiemIV', 'scrollFoeRequiemVII', 'scrollArmysPaeon', 'scrollArmysPaeonII', 'scrollArmysPaeonIII', 'scrollArmysPaeonIV', 'scrollArmysPaeonVI', 'scrollValorMinuet', 'scrollValorMinuetII', 'scrollValorMinuetIII', 'scrollValorMinuetV'],
   Sororo: ['scrollDiaga', 'scrollStoneskin', 'scrollSlow', 'scrollCureII', 'scrollBanish', 'scrollBanishga', 'scrollBlink', 'scrollCure', 'scrollCuraga', 'scrollPoisona', 'scrollParalyna', 'scrollBlindna', 'scrollDia', 'scrollProtect', 'scrollShell', 'scrollRepose'],

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,5 @@
 import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls, setupLogControls, setupTimeDisplay, setupMapOverlay, updateTimeDisplay, isLogFullscreen, adjustLogFontSize, setupPressFeedback } from './ui.js';
-import { loadCharacters, initCurrentUser, initNotorious, activeCharacter } from '../data/index.js';
+import { loadCharacters, initCurrentUser, initNotorious, activeCharacter, persistCharacter } from '../data/index.js';
 
 // Entry point: initialize application
 let uiScale = 1;
@@ -16,12 +16,18 @@ function updateScale(delta) {
     } else {
         uiScale = Math.max(0.5, Math.min(2, uiScale + delta));
         document.documentElement.style.setProperty('--ui-scale', uiScale);
+        if (activeCharacter) {
+            activeCharacter.uiScale = uiScale;
+            persistCharacter(activeCharacter);
+        }
     }
 }
 
 function init() {
     initCurrentUser();
     loadCharacters();
+    uiScale = activeCharacter && activeCharacter.uiScale ? activeCharacter.uiScale : 1;
+    document.documentElement.style.setProperty('--ui-scale', uiScale);
     initNotorious();
     renderUserControls();
     const app = document.getElementById('app');


### PR DESCRIPTION
## Summary
- track `uiScale` per character and apply on load
- persist UI scale when adjusting zoom
- remove Olwyn's vendor listing and map reference
- tweak vendor layout to center actions and prices

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_688c2234ed90832599204334aac851f1