### PR TITLE
Add key items and job presets

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -31,7 +31,10 @@ export {
   formatTime,
   currentVanaTime,
   formatVanaTime,
-  dayElements
+  dayElements,
+  saveJobPreset,
+  equipJobPreset,
+  changeJob
 } from './characters.js';
 export { proficiencyScale, getScale } from './scales.js';
 export { names, randomName } from './names.js';

--- a/data/vendors.js
+++ b/data/vendors.js
@@ -4345,3 +4345,12 @@ export const conquestRewards = {
   emperorBand: 2000,
   warpRing: 5000
 };
+
+// Apply default flags and mark map items as key items
+Object.values(items).forEach(it => {
+  if (it.sellable === undefined) it.sellable = true;
+  if (/^Map of/i.test(it.name)) {
+    it.keyItem = true;
+    it.sellable = false;
+  }
+});


### PR DESCRIPTION
## Summary
- mark map items as key items and add sellable flag
- hide key items from inventory and add key item screen
- add job equipment presets and job change menu
- prevent selling key items or preset gear

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688c2be4dd8c83258cb8284fdc7044bc