### PR TITLE
Fix Vomp Hill transitions and aggro handling

### DIFF
--- a/data/locations.js
+++ b/data/locations.js
@@ -126,7 +126,7 @@ export const zonesByCity = {
         'Dangruf Wadi': 'D-9',
         'North Gustaberg (West)': 'E-6',
         'North Gustaberg (East)': 'H-5',
-        'Vomp Hill L1': 'I-9',
+        'Vomp Hill L1': 'H-9',
         'Goblin Camp': 'K-10',
         'Cavernous Maw (Abyssea – Altepa)': 'J-10'
       },

--- a/data/maps.js
+++ b/data/maps.js
@@ -46,9 +46,9 @@ registerZoneMap('South Gustaberg', {
   'G-7': {}, 'G-8': {}, 'G-9': { allowedFrom: ['G-8', 'H-8', 'H-9'] },
   'H-5': { noDiagonal: true },
   'H-6': { noDiagonal: true },
-  'H-7': {}, 'H-8': {}, 'H-9': { entryTo: 'Vomp Hill L1', entryLabel: 'Vomp Hill' }, 'H-10': {},
+  'H-7': {}, 'H-8': {}, 'H-9': { entryTo: 'Vomp Hill L1', entryLabel: 'Ramp Up' }, 'H-10': {},
   'I-7': { pois: ['Cave Entrance'] }, 'I-9': {}, 'I-10': {},
-  'J-7': {}, 'J-8': { entryTo: 'Vomp Hill L1', entryLabel: 'Vomp Hill' }, 'J-9': {}, 'J-10': { pois: ['Cavernous Maw'] },
+  'J-7': {}, 'J-8': {}, 'J-9': {}, 'J-10': { pois: ['Cavernous Maw'] },
   'K-7': {}, 'K-8': {}, 'K-9': { subArea: 'Goblin Camp' },
   'K-10': { subArea: 'Goblin Camp', entryTo: 'Goblin Camp', entryLabel: 'Goblin Camp' },
   'L-8': { allowedFrom: ['K-8', 'K-9', 'L-9'] }, 'L-9': {}, 'L-10': {},
@@ -62,10 +62,7 @@ registerZoneMap('Vomp Hill L1', {
   'I-7': { subArea: 'Vomp Hill' },
   'I-8': { subArea: 'Vomp Hill' },
   'I-9': { subArea: 'Vomp Hill' },
-  'J-8': { subArea: 'Vomp Hill', entries: [
-    { to: 'South Gustaberg', label: 'Ramp Down' },
-    { to: 'Vomp Hill L2', label: 'Ramp Up' }
-  ] },
+  'J-8': { subArea: 'Vomp Hill', entryTo: 'Vomp Hill L2', entryLabel: 'Ramp Up' },
   'J-9': { subArea: 'Vomp Hill' }
 });
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -434,7 +434,7 @@ function updateNearbyMonsters(zone, root) {
         persistCharacter(activeCharacter);
         if (aggro.length) {
             const app = root.parentElement || root;
-            renderCombatScreen(app, list);
+            renderCombatScreen(app, aggro);
             return true;
         }
     } else {
@@ -444,7 +444,7 @@ function updateNearbyMonsters(zone, root) {
         const aggro = nearbyMonsters.filter(m => m.aggro && !m.defeated);
         if (aggro.length) {
             const app = root.parentElement || root;
-            renderCombatScreen(app, nearbyMonsters);
+            renderCombatScreen(app, aggro);
             return true;
         }
     }


### PR DESCRIPTION
## Summary
- clean up redundant Vomp Hill transitions
- correct ramp coordinates between South Gustaberg and Vomp Hill
- only aggressive monsters start combat

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688cb71aa4308325afb7d2e9779dbfcf