### PR TITLE
Enable item popups

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -663,7 +663,8 @@ body.portrait .main-layout {
     gap: 4px;
 }
 
-.vendor-item span {
+.vendor-item span,
+.vendor-item button.vendor-name-btn {
     flex: 1;
     text-align: left;
 }
@@ -672,6 +673,11 @@ body.portrait .main-layout {
     text-align: left;
     display: flex;
     align-items: center;
+    background: none;
+    border: none;
+    color: inherit;
+    padding: 0;
+    cursor: pointer;
 }
 
 .vendor-price {
@@ -754,6 +760,15 @@ body.portrait .main-layout {
     width: 90px;
     padding: 2px 6px;
     min-height: 0;
+}
+
+.item-name-btn {
+    width: auto;
+    background: none;
+    border: none;
+    color: inherit;
+    padding: 0;
+    cursor: pointer;
 }
 
 .equipment-item {
@@ -951,6 +966,39 @@ body.portrait .main-layout {
     cursor: grab;
 }
 #map-overlay .map-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: rgba(0,0,0,0.7);
+    color: #fff;
+    border: none;
+    padding: 4px 8px;
+    font-size: 20px;
+    cursor: pointer;
+}
+
+/* Item popup */
+#item-popup {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1240;
+}
+#item-popup-content {
+    background: rgba(0,0,0,0.9);
+    padding: 10px;
+    border-radius: 4px;
+    color: #fff;
+    text-align: left;
+    max-width: 300px;
+}
+#item-popup-close {
     position: absolute;
     top: 10px;
     right: 10px;

--- a/index.html
+++ b/index.html
@@ -25,6 +25,10 @@
         <button id="map-close" class="map-close">X</button>
         <img id="map-image" src="" alt="map">
     </div>
+    <div id="item-popup" class="hidden">
+        <button id="item-popup-close" class="item-popup-close">X</button>
+        <div id="item-popup-content" class="item-popup-content"></div>
+    </div>
 
     <script src="js/panzoom.min.js"></script>
     <script type="module" src="js/main.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls, setupLogControls, setupTimeDisplay, setupMapOverlay, updateTimeDisplay, isLogFullscreen, adjustLogFontSize, setupPressFeedback } from './ui.js';
+import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls, setupLogControls, setupTimeDisplay, setupMapOverlay, setupItemPopup, updateTimeDisplay, isLogFullscreen, adjustLogFontSize, setupPressFeedback } from './ui.js';
 import { loadCharacters, initCurrentUser, initNotorious, activeCharacter, persistCharacter } from '../data/index.js';
 
 // Entry point: initialize application
@@ -69,6 +69,13 @@ function init() {
     const mapClose = document.getElementById('map-close');
     if (mapOverlay && mapImage && mapClose) {
         setupMapOverlay(mapOverlay, mapImage, mapClose);
+    }
+
+    const itemPopup = document.getElementById('item-popup');
+    const itemPopupContent = document.getElementById('item-popup-content');
+    const itemPopupClose = document.getElementById('item-popup-close');
+    if (itemPopup && itemPopupContent && itemPopupClose) {
+        setupItemPopup(itemPopup, itemPopupContent, itemPopupClose);
     }
 
     const charBtn = document.getElementById('character-select');

--- a/js/ui.js
+++ b/js/ui.js
@@ -61,6 +61,9 @@ let mapOverlayElement = null;
 let mapImageElement = null;
 let mapCloseElement = null;
 let mapPanzoomInstance = null;
+let itemPopupCloseElement = null;
+let itemPopupElement = null;
+let itemPopupContentElement = null;
 const gameLogMessages = [];
 let currentTurn = 0;
 let logFontSize = 14;
@@ -207,6 +210,53 @@ export function setupMapOverlay(el, img, closeBtn) {
         mapPanzoomInstance = Panzoom(mapImageElement, { maxScale: 5 });
         mapOverlayElement.addEventListener('wheel', mapPanzoomInstance.zoomWithWheel);
     }
+}
+
+export function setupItemPopup(el, content, closeBtn) {
+    itemPopupElement = el;
+    itemPopupContentElement = content;
+    itemPopupCloseElement = closeBtn;
+    if (itemPopupCloseElement) {
+        itemPopupCloseElement.addEventListener('click', () => {
+            if (itemPopupElement) itemPopupElement.classList.add('hidden');
+        });
+    }
+}
+
+export function showItemPopup(item) {
+    if (!itemPopupElement || !itemPopupContentElement) return;
+    itemPopupContentElement.innerHTML = '';
+    const desc = document.createElement('div');
+    desc.className = 'item-description';
+    desc.textContent = item.description || item.name;
+    itemPopupContentElement.appendChild(desc);
+    if (item.effects) {
+        const eff = document.createElement('div');
+        eff.className = 'item-effects';
+        eff.textContent = 'Effects: ' + item.effects.join(', ');
+        itemPopupContentElement.appendChild(eff);
+    }
+    if (item.abilities) {
+        const ab = document.createElement('div');
+        ab.className = 'item-abilities';
+        ab.textContent = 'Abilities: ' + item.abilities.join(', ');
+        itemPopupContentElement.appendChild(ab);
+    }
+    const stats = basicStatsText(item);
+    if (stats) {
+        const s = document.createElement('div');
+        s.className = 'item-stats';
+        s.textContent = stats;
+        itemPopupContentElement.appendChild(s);
+    }
+    const req = requirementText(item);
+    if (req) {
+        const r = document.createElement('div');
+        r.className = 'item-req';
+        r.textContent = req;
+        itemPopupContentElement.appendChild(r);
+    }
+    itemPopupElement.classList.remove('hidden');
 }
 
 function zoneSlug(name) {
@@ -2629,9 +2679,10 @@ export function renderVendorScreen(root, vendor, backFn = null, mode = 'buy') {
         const top = document.createElement('div');
         top.className = 'vendor-row-top';
 
-        const name = document.createElement('span');
-        name.className = 'vendor-name';
+        const name = document.createElement('button');
+        name.className = 'vendor-name vendor-name-btn';
         name.textContent = item.name;
+        name.addEventListener('click', () => showItemPopup(item));
         if (!meetsRequirements(item)) name.style.color = 'red';
         else if (canEquipItem(item) && isBetterItem(item)) name.style.color = 'lightgreen';
         if (/^scroll/i.test(id)) {
@@ -2653,9 +2704,6 @@ export function renderVendorScreen(root, vendor, backFn = null, mode = 'buy') {
 
         const actions = document.createElement('div');
         actions.className = 'vendor-actions';
-        const detail = document.createElement('button');
-        detail.textContent = 'Details';
-        actions.appendChild(detail);
         let qtyInput = null;
         if (item.stack > 1) {
             qtyInput = document.createElement('input');
@@ -2697,7 +2745,6 @@ export function renderVendorScreen(root, vendor, backFn = null, mode = 'buy') {
             detailsWrap.appendChild(r);
         }
         row.appendChild(detailsWrap);
-        detail.addEventListener('click', () => toggleDetails(detailsWrap));
             list.appendChild(row);
         });
         root.appendChild(list);
@@ -2718,10 +2765,11 @@ export function renderVendorScreen(root, vendor, backFn = null, mode = 'buy') {
         const top = document.createElement('div');
         top.className = 'vendor-row-top';
 
-        const name = document.createElement('span');
-        name.className = 'vendor-name';
+        const name = document.createElement('button');
+        name.className = 'vendor-name vendor-name-btn';
         const qtyText = item.stack > 1 || entry.qty > 1 ? ` x${entry.qty}` : '';
         name.textContent = item.name + qtyText;
+        name.addEventListener('click', () => showItemPopup(item));
         const price = document.createElement('span');
         const sp = item.sellPrice || Math.floor(item.price / 2);
         price.className = 'vendor-price';
@@ -2761,9 +2809,6 @@ export function renderVendorScreen(root, vendor, backFn = null, mode = 'buy') {
             sellGroup.appendChild(sellAllBtn);
         }
         actions.appendChild(sellGroup);
-        const detailBtn = document.createElement('button');
-        detailBtn.textContent = 'Details';
-        actions.appendChild(detailBtn);
         top.appendChild(actions);
         row.appendChild(top);
 
@@ -2774,7 +2819,6 @@ export function renderVendorScreen(root, vendor, backFn = null, mode = 'buy') {
         desc.textContent = item.description || item.name;
         detailsWrap.appendChild(desc);
         row.appendChild(detailsWrap);
-        detailBtn.addEventListener('click', () => toggleDetails(detailsWrap));
         sellList.appendChild(row);
         });
         root.appendChild(sellList);
@@ -2797,9 +2841,10 @@ export function renderConquestShop(root, backFn = null) {
         const top = document.createElement('div');
         top.className = 'vendor-row-top';
 
-        const name = document.createElement('span');
-        name.className = 'vendor-name';
+        const name = document.createElement('button');
+        name.className = 'vendor-name vendor-name-btn';
         name.textContent = item.name;
+        name.addEventListener('click', () => showItemPopup(item));
         const price = document.createElement('span');
         price.className = 'vendor-price';
         price.textContent = `${cost} CP`;
@@ -2809,9 +2854,6 @@ export function renderConquestShop(root, backFn = null) {
 
         const actions = document.createElement('div');
         actions.className = 'vendor-actions';
-        const detail = document.createElement('button');
-        detail.textContent = 'Details';
-        actions.appendChild(detail);
         const buyBtn = document.createElement('button');
         buyBtn.textContent = 'Buy';
         buyBtn.addEventListener('click', () => {
@@ -2836,7 +2878,6 @@ export function renderConquestShop(root, backFn = null) {
         desc.textContent = item.description || item.name;
         detailsWrap.appendChild(desc);
         row.appendChild(detailsWrap);
-        detail.addEventListener('click', () => toggleDetails(detailsWrap));
         list.appendChild(row);
     });
     root.appendChild(list);
@@ -2875,19 +2916,22 @@ export function renderEquipmentScreen(root) {
             const info = document.createElement('div');
             info.className = 'equipment-info';
             const nameDiv = document.createElement('span');
-            nameDiv.textContent = `${slots[key]}: ${item ? item.name : itemId || 'Empty'}`;
-            if (item && !meetsRequirements(item)) nameDiv.style.color = 'red';
+            if (item) {
+                nameDiv.textContent = `${slots[key]}: `;
+                const nameBtn = document.createElement('button');
+                nameBtn.className = 'item-name-btn';
+                nameBtn.textContent = item.name;
+                if (!meetsRequirements(item)) nameBtn.style.color = 'red';
+                nameBtn.addEventListener('click', () => showItemPopup(item));
+                nameDiv.appendChild(nameBtn);
+            } else {
+                nameDiv.textContent = `${slots[key]}: ${itemId || 'Empty'}`;
+            }
             info.appendChild(nameDiv);
             top.appendChild(info);
 
             const actions = document.createElement('div');
             actions.className = 'equipment-actions';
-            let detailsBtn = null;
-            if (item) {
-                detailsBtn = document.createElement('button');
-                detailsBtn.textContent = 'Details';
-                actions.appendChild(detailsBtn);
-            }
             if (itemId) {
                 const unequip = document.createElement('button');
                 unequip.textContent = 'Unequip';
@@ -2933,7 +2977,6 @@ export function renderEquipmentScreen(root) {
                 detailsWrap.appendChild(r);
             }
             li.appendChild(detailsWrap);
-            if (detailsBtn) detailsBtn.addEventListener('click', () => toggleDetails(detailsWrap));
             list.appendChild(li);
         }
         root.appendChild(list);
@@ -3066,17 +3109,18 @@ export function renderInventoryScreen(root) {
             info.className = 'item-info';
             const qtyText = ent.item.stack > 1 && ent.qty > 1 ? ` x${ent.qty}` : '';
             const statsInline = basicStatsText(ent.item);
-            info.textContent = ent.item.name + qtyText + (statsInline ? ` (${statsInline})` : '');
-            if (!meetsRequirements(ent.item)) info.style.color = 'red';
-            else if (canEquipItem(ent.item) && isBetterItem(ent.item)) info.style.color = 'lightgreen';
+            const nameBtn = document.createElement('button');
+            nameBtn.className = 'item-name-btn';
+            nameBtn.textContent = ent.item.name + qtyText + (statsInline ? ` (${statsInline})` : '');
+            if (!meetsRequirements(ent.item)) nameBtn.style.color = 'red';
+            else if (canEquipItem(ent.item) && isBetterItem(ent.item)) nameBtn.style.color = 'lightgreen';
+            nameBtn.addEventListener('click', () => showItemPopup(ent.item));
+            info.appendChild(nameBtn);
             row.appendChild(info);
 
             const actions = document.createElement('div');
             actions.className = 'item-actions';
 
-            const detailsBtn = document.createElement('button');
-            detailsBtn.textContent = 'Details';
-            actions.appendChild(detailsBtn);
 
             if (canEquipItem(ent.item)) {
                 if (activeCharacter.equipment[ent.item.slot] !== ent.id) {
@@ -3131,7 +3175,6 @@ export function renderInventoryScreen(root) {
                 detailsWrap.appendChild(r);
             }
             li.appendChild(detailsWrap);
-            detailsBtn.addEventListener('click', () => toggleDetails(detailsWrap));
             ul.appendChild(li);
         });
     });


### PR DESCRIPTION
## Summary
- make item names clickable to show advanced item details
- remove old Details buttons
- add new item popup overlay with close button
- style vendor and inventory name buttons

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688cca80f11c832598c796740d946691