### PR TITLE
Improve vendor UI alignment

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -631,7 +631,20 @@ body.portrait .main-layout {
 .vendor-menu {
     display: flex;
     flex-direction: column;
+}
+
+.shop-menu {
     align-items: center;
+}
+
+.vendor-menu {
+    align-items: flex-start;
+}
+
+.vendor-menu > h2 {
+    width: 100%;
+    text-align: left;
+    margin: 10px 0 0 0;
 }
 
 .vendor-item {
@@ -643,7 +656,7 @@ body.portrait .main-layout {
 
 .vendor-row-top {
     display: grid;
-    grid-template-columns: 1fr auto auto;
+    grid-template-columns: 1fr 80px 90px;
     align-items: center;
     gap: 4px;
     width: 100%;
@@ -656,11 +669,14 @@ body.portrait .main-layout {
     align-items: center;
     gap: 4px;
     padding: 0 4px;
+    width: 90px;
 }
 
 .sell-buttons {
     display: flex;
+    flex-direction: column;
     gap: 4px;
+    width: 100%;
 }
 
 .vendor-item span,
@@ -685,7 +701,7 @@ body.portrait .main-layout {
     display: flex;
     align-items: center;
     justify-content: flex-end;
-    min-width: 60px;
+    width: 80px;
 }
 
 .vendor-qty {

--- a/js/ui.js
+++ b/js/ui.js
@@ -2666,7 +2666,8 @@ export function renderVendorScreen(root, vendor, backFn = null, mode = 'buy') {
     root.innerHTML = '';
     resetDetails();
     const title = document.createElement('h2');
-    title.textContent = vendor;
+    const displayName = vendor.includes(' the ') ? vendor.split(' the ')[0] : vendor;
+    title.textContent = displayName;
     root.appendChild(title);
     if (mode === 'buy') {
         const list = document.createElement('div');


### PR DESCRIPTION
## Summary
- align vendor header with item list
- keep vendor menu items left aligned
- show only NPC's name in vendor header

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688ce46ba5c483258e2b2f287e2d8aa7