### PR TITLE
Implement shop updates and city area memory

### DIFF
--- a/data/characters.js
+++ b/data/characters.js
@@ -200,6 +200,7 @@ export const characters = [
     uiScale: 1,
     targetIndex: null,
     monsterCoord: '',
+    citySections: {},
     monsters: []
   },
   {
@@ -283,6 +284,7 @@ export const characters = [
     uiScale: 1,
     targetIndex: null,
     monsterCoord: '',
+    citySections: {},
     monsters: []
   }
 ];
@@ -375,6 +377,7 @@ export function createCharacterObject(name, job, race, sex = 'Male') {
     uiScale: 1,
     targetIndex: null,
     monsterCoord: '',
+    citySections: {},
     monsters: []
   };
   updateDerivedStats(character);
@@ -575,6 +578,7 @@ export function loadCharacters() {
       if (!Array.isArray(c.monsters)) c.monsters = [];
       if (c.monsterCoord === undefined) c.monsterCoord = '';
       if (c.uiScale === undefined) c.uiScale = 1;
+      if (!c.citySections) c.citySections = {};
       if (!c.jobPresets) c.jobPresets = {};
       if (!c.jobPresets[c.job]) c.jobPresets[c.job] = { ...(c.equipment || {}) };
       characters.push(c);
@@ -596,6 +600,7 @@ export function loadCharacterSlot(index) {
     characters[index] = saved[index];
     if (characters[index].conquestPoints === undefined) characters[index].conquestPoints = 0;
     if (characters[index].uiScale === undefined) characters[index].uiScale = 1;
+    if (!characters[index].citySections) characters[index].citySections = {};
     if (!characters[index].jobPresets) characters[index].jobPresets = {};
     if (!characters[index].jobPresets[characters[index].job]) {
       characters[index].jobPresets[characters[index].job] = { ...(characters[index].equipment || {}) };
@@ -821,6 +826,7 @@ export function equipJobPreset(character, job) {
 
 export function changeJob(character, job) {
   if (!character || !job || character.job === job) return;
+  if (!/Residential Area/i.test(character.currentLocation || '')) return;
   saveJobPreset(character);
   character.job = job;
   if (!character.jobs) character.jobs = { [job]: 1 };

--- a/data/vendors.js
+++ b/data/vendors.js
@@ -4346,6 +4346,7 @@ vendorInventories.Odoba = vendorInventories["Alchemists' Guild"];
 vendorInventories.Maymunah = vendorInventories["Alchemists' Guild"];
 vendorInventories.Rodellieux = vendorInventories["Rodellieux's Stall"];
 vendorInventories.Olwyn = vendorInventories["Mjoll's General Goods"];
+vendorInventories.Mjoll = vendorInventories["Mjoll's General Goods"];
 
 export const shopNpcs = {
   'Brunhilde\'s Armory': ['Brunhilde the Armourer', 'Balthilda', 'Charging Chocobo'],
@@ -4367,7 +4368,7 @@ export const shopNpcs = {
   'Gunpowder Room': ['Nogga', 'Olaf'],
   "Craftsmen's Eatery": ['Tomasa'],
   'Qufim Regional Goods': ['Takiyah'],
-  "Mjoll's General Goods": ['Olwyn'],
+  "Mjoll's General Goods": ['Mjoll', 'Olwyn'],
   "Alchemists' Guild": ['Odoba', 'Maymunah'],
   "Rodellieux's Stall": ['Rodellieux'],
   'Map Vendor': ['Karine', 'Rex', 'Elesca', 'Violitte', 'Mhoji Roccoruh', 'Pehki Machumaht', 'Ludwig', 'Lombaria', 'Promurouve', 'Rusese', 'Antiqix', 'Haggleblix', 'Lootblox', 'Riyadahf']
@@ -4399,6 +4400,7 @@ export const vendorGreetings = {
   'Nogga': 'Handle these explosives with care!',
   'Olaf': 'Ammunition and powder ready to go.',
   'Olwyn': 'Take a look at our fine goods.',
+  'Mjoll': 'Take a look at our fine goods.',
   'Tomasa': 'A warm meal will do you good.',
   'Takiyah': 'Goods from distant Qufim, just in.',
   'Odoba': 'Potions brewed to perfection.',
@@ -4434,6 +4436,7 @@ export const vendorTypes = {
   'Nogga': 'explosives',
   'Olaf': 'ammunition',
   'Olwyn': 'general goods',
+  'Mjoll': 'general goods',
   'Tomasa': 'meals',
   'Takiyah': 'regional goods',
   'Odoba': 'alchemy',


### PR DESCRIPTION
## Summary
- persist recently used city sub section and restore it when revisiting a city area
- restrict job changes to residential areas
- add Mjoll as vendor at "Mjoll's General Goods"

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_688d145311588325956d6043451492cd