### PR TITLE
Update Bastok info and hornet data

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -230,6 +230,11 @@ body.landscape #area-grid {
     content: '\25BC';
 }
 
+.area-header.expanded,
+.city-subheader.expanded {
+    background-color: #444;
+}
+
 .city-area-grid {
     display: flex;
     align-items: flex-start;

--- a/data/bestiary.js
+++ b/data/bestiary.js
@@ -560,6 +560,12 @@ export const bestiaryByZone = {
       detection: 'Sight & Scent',
       spawns: 30,
       spawnChance: 0.612,
+      coords: [
+        'D-8', 'D-9', 'E-6', 'E-7', 'E-8', 'E-9', 'F-7', 'F-8', 'F-9',
+        'G-7', 'G-8', 'G-9', 'H-5', 'H-6', 'H-7', 'H-8', 'H-9', 'H-10',
+        'I-7', 'I-8', 'I-9', 'I-10', 'J-8', 'J-9', 'J-10',
+        'L-8', 'L-9', 'L-10', 'M-10'
+      ],
       areas: [null, 'Vomp Hill']
     },
     {

--- a/data/locations.js
+++ b/data/locations.js
@@ -32,7 +32,6 @@ export const zonesByCity = {
       pointsOfInterest: [
         'Auction House',
         "Goldsmiths' Guild",
-        "Blacksmiths' Guild",
         "Brunhilde's Armory",
         "Dragon's Claw Weaponry",
         "Carmelide's Jewelry Store",
@@ -73,7 +72,7 @@ export const zonesByCity = {
       distance: 0,
       subAreas: [],
       connectedAreas: ['Bastok Mines'],
-      pointsOfInterest: ["President's Office", 'Mission/Rank NPCs', 'Cid', 'Home Point Crystal'],
+      pointsOfInterest: ["President's Office", 'Mission/Rank NPCs', 'Cid', "Blacksmiths' Guild", 'Home Point Crystal'],
       importantNPCs: []
     },
     {


### PR DESCRIPTION
## Summary
- remove Blacksmiths' Guild from Bastok Markets
- add Blacksmiths' Guild to Metalworks
- list Maneating Hornet spawn coordinates
- highlight active city subarea button

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_688d17e21de08325bd2b04b9ee5b8b0c