### PR TITLE
Add storage and wardrobe with popup interface

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -227,10 +227,16 @@ body.landscape #area-grid {
 }
 
 .area-header.expanded::before {
+    display: none;
+}
+
+.area-header.expanded::after,
+.city-subheader.expanded::after {
     content: '';
     display: inline-block;
-    width: 16px;
-    height: 16px;
+    width: 32px;
+    height: 32px;
+    margin-left: 8px;
     background-image: url('../img/Icons/Home%20Point%20Crystal.png');
     background-size: contain;
     background-repeat: no-repeat;
@@ -1031,6 +1037,41 @@ body.portrait .main-layout {
     max-width: 300px;
 }
 #item-popup-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: rgba(0,0,0,0.7);
+    color: #fff;
+    border: none;
+    padding: 4px 8px;
+    font-size: 20px;
+    cursor: pointer;
+}
+
+/* Storage/Wardrobe popup */
+#storage-popup {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1240;
+}
+
+#storage-popup-content {
+    background: rgba(0,0,0,0.9);
+    padding: 10px;
+    border-radius: 4px;
+    color: #fff;
+    display: flex;
+    gap: 20px;
+}
+
+#storage-popup-close {
     position: absolute;
     top: 10px;
     right: 10px;

--- a/data/characters.js
+++ b/data/characters.js
@@ -361,6 +361,8 @@ export function createCharacterObject(name, job, race, sex = 'Male') {
       ...(gear.weapon ? [{ id: gear.weapon, qty: 1 }] : []),
       ...(gear.armor ? [{ id: gear.armor, qty: 1 }] : [])
     ],
+    storage: [],
+    wardrobe: [],
     equipment,
     jobPresets: { [selectedJob]: { ...equipment } },
     buffs: [],
@@ -581,6 +583,8 @@ export function loadCharacters() {
       if (!c.citySections) c.citySections = {};
       if (!c.jobPresets) c.jobPresets = {};
       if (!c.jobPresets[c.job]) c.jobPresets[c.job] = { ...(c.equipment || {}) };
+      if (!Array.isArray(c.storage)) c.storage = [];
+      if (!Array.isArray(c.wardrobe)) c.wardrobe = [];
       characters.push(c);
       updateDerivedStats(c);
     });
@@ -605,6 +609,8 @@ export function loadCharacterSlot(index) {
     if (!characters[index].jobPresets[characters[index].job]) {
       characters[index].jobPresets[characters[index].job] = { ...(characters[index].equipment || {}) };
     }
+    if (!Array.isArray(characters[index].storage)) characters[index].storage = [];
+    if (!Array.isArray(characters[index].wardrobe)) characters[index].wardrobe = [];
     updateDerivedStats(characters[index]);
     setActiveCharacter(characters[index]);
     saveCharacters();

--- a/index.html
+++ b/index.html
@@ -29,6 +29,10 @@
         <button id="item-popup-close" class="item-popup-close">X</button>
         <div id="item-popup-content" class="item-popup-content"></div>
     </div>
+    <div id="storage-popup" class="hidden">
+        <button id="storage-popup-close" class="storage-popup-close">X</button>
+        <div id="storage-popup-content" class="storage-popup-content"></div>
+    </div>
 
     <script src="js/panzoom.min.js"></script>
     <script type="module" src="js/main.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls, setupLogControls, setupTimeDisplay, setupMapOverlay, setupItemPopup, updateTimeDisplay, isLogFullscreen, adjustLogFontSize, setupPressFeedback } from './ui.js';
+import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls, setupLogControls, setupTimeDisplay, setupMapOverlay, setupItemPopup, setupStoragePopup, updateTimeDisplay, isLogFullscreen, adjustLogFontSize, setupPressFeedback } from './ui.js';
 import { loadCharacters, initCurrentUser, initNotorious, activeCharacter, persistCharacter } from '../data/index.js';
 
 // Entry point: initialize application
@@ -76,6 +76,13 @@ function init() {
     const itemPopupClose = document.getElementById('item-popup-close');
     if (itemPopup && itemPopupContent && itemPopupClose) {
         setupItemPopup(itemPopup, itemPopupContent, itemPopupClose);
+    }
+
+    const storagePopup = document.getElementById('storage-popup');
+    const storagePopupContent = document.getElementById('storage-popup-content');
+    const storagePopupClose = document.getElementById('storage-popup-close');
+    if (storagePopup && storagePopupContent && storagePopupClose) {
+        setupStoragePopup(storagePopup, storagePopupContent, storagePopupClose);
     }
 
     const charBtn = document.getElementById('character-select');


### PR DESCRIPTION
## Summary
- add storage popup UI in HTML and JS
- allow storage/wardrobe inventory management
- show storage and wardrobe buttons in residential areas
- display Wardrobe button in equipment screen
- move subarea menu icon to right and double the size
- bump TP cap to 3000
- initialize storage/wardrobe for characters

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_688d39b4d5388325a0fabd57e5c3bb6a