### PR TITLE
UI tweaks and spawn fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -560,6 +560,7 @@ body.portrait .main-layout {
 #character-details {
     display: flex;
     flex-direction: column;
+    font-size: 0.8em;
 }
 
 #character-details button {
@@ -573,6 +574,16 @@ body.portrait .main-layout {
     align-items: center;
 }
 
+.stat-bar {
+    width: 150px;
+    margin: 1px auto;
+    padding: 2px 4px;
+    box-sizing: border-box;
+    border: 1px solid #555;
+    background-color: #333;
+    color: #fff;
+}
+
 .race-img, .job-img, .city-img, .character-img {
     width: clamp(120px, 20vw, 200px);
     height: auto;
@@ -581,7 +592,7 @@ body.portrait .main-layout {
 }
 
 .character-img {
-    width: clamp(138px, 23vw, 230px);
+    width: 150px;
 }
 
 .profile-btn {

--- a/data/bestiary.js
+++ b/data/bestiary.js
@@ -812,8 +812,11 @@ export const bestiaryByZone = {
       linking: false,
       detection: 'Sight & Magic',
       spawns: 6,
-      spawnChance: 0.122,
-      notes: 'Foggy weather only',
+      spawnChance: 0,
+      notes: 'Foggy weather only (disabled)',
+      coords: ['D-8', 'D-9', 'E-6', 'E-7', 'E-8', 'E-9', 'F-7', 'F-8', 'F-9',
+        'G-7', 'G-8', 'G-9', 'H-5', 'H-6', 'H-7', 'H-8', 'H-9', 'H-10',
+        'I-9', 'I-10', 'J-9', 'J-10', 'L-8', 'L-9', 'L-10', 'M-10'],
       areas: [null]
     },
     {

--- a/data/jobs.js
+++ b/data/jobs.js
@@ -1,6 +1,7 @@
 export const jobs = [
   {
     name: 'Warrior',
+    abbr: 'WAR',
     proficiencies: { hp: 'B', mp: 'X', str: 'A', dex: 'C', vit: 'D', agi: 'C', int: 'F', mnd: 'F', chr: 'E' },
     verified: { traits: true, abilities: true },
     traits: [
@@ -62,6 +63,7 @@ export const jobs = [
   },
   {
     name: 'Monk',
+    abbr: 'MNK',
     proficiencies: { hp: 'A', mp: 'X', str: 'C', dex: 'B', vit: 'A', agi: 'F', int: 'G', mnd: 'D', chr: 'E' },
     verified: { traits: true, abilities: true },
     traits: [
@@ -122,6 +124,7 @@ export const jobs = [
   },
   {
     name: 'White Mage',
+    abbr: 'WHM',
     proficiencies: { hp: 'E', mp: 'C', str: 'D', dex: 'F', vit: 'D', agi: 'E', int: 'E', mnd: 'A', chr: 'C' },
     verified: { traits: true, abilities: true },
     traits: [
@@ -161,6 +164,7 @@ export const jobs = [
   },
   {
     name: 'Black Mage',
+    abbr: 'BLM',
     proficiencies: { hp: 'F', mp: 'B', str: 'F', dex: 'C', vit: 'F', agi: 'C', int: 'A', mnd: 'E', chr: 'D' },
     verified: { traits: true, abilities: true },
     traits: [
@@ -203,6 +207,7 @@ export const jobs = [
   },
   {
     name: 'Red Mage',
+    abbr: 'RDM',
     proficiencies: { hp: 'D', mp: 'D', str: 'D', dex: 'D', vit: 'E', agi: 'E', int: 'C', mnd: 'C', chr: 'D' },
     verified: { traits: true, abilities: true },
     traits: [
@@ -242,6 +247,7 @@ export const jobs = [
   },
   {
     name: 'Thief',
+    abbr: 'THF',
     proficiencies: { hp: 'D', mp: 'X', str: 'D', dex: 'A', vit: 'D', agi: 'B', int: 'C', mnd: 'G', chr: 'G' },
     verified: { traits: true, abilities: true },
     traits: [
@@ -294,6 +300,7 @@ export const jobs = [
   },
   {
     name: 'Paladin',
+    abbr: 'PLD',
     proficiencies: { hp: 'C', mp: 'F', str: 'B', dex: 'E', vit: 'A', agi: 'G', int: 'G', mnd: 'C', chr: 'C' },
     verified: { traits: true, abilities: true },
     traits: [
@@ -344,6 +351,7 @@ export const jobs = [
   },
   {
     name: 'Dark Knight',
+    abbr: 'DRK',
     proficiencies: { hp: 'C', mp: 'F', str: 'A', dex: 'C', vit: 'C', agi: 'D', int: 'C', mnd: 'G', chr: 'G' },
     traits: [
       { name: 'Attack Bonus I', effect: 'Increases attack', level: 10 },
@@ -370,6 +378,7 @@ export const jobs = [
   },
   {
     name: 'Beastmaster',
+    abbr: 'BST',
     proficiencies: { hp: 'C', mp: 'X', str: 'D', dex: 'C', vit: 'D', agi: 'F', int: 'E', mnd: 'E', chr: 'A' },
     traits: [
       { name: 'Resist Slow I', effect: 'Reduces duration of Slow', level: 15 },
@@ -395,6 +404,7 @@ export const jobs = [
   },
   {
     name: 'Bard',
+    abbr: 'BRD',
     proficiencies: { hp: 'D', mp: 'X', str: 'D', dex: 'D', vit: 'D', agi: 'F', int: 'D', mnd: 'D', chr: 'B' },
     verified: { traits: true, abilities: true },
     traits: [
@@ -422,6 +432,7 @@ export const jobs = [
   },
   {
     name: 'Ranger',
+    abbr: 'RNG',
     proficiencies: { hp: 'E', mp: 'X', str: 'E', dex: 'D', vit: 'D', agi: 'A', int: 'E', mnd: 'D', chr: 'E' },
     traits: [
       { name: 'Wide Scan III', effect: 'Allows tracking of distant foes', level: 1 },
@@ -450,6 +461,7 @@ export const jobs = [
   },
   {
     name: 'Samurai',
+    abbr: 'SAM',
     proficiencies: { hp: 'B', mp: 'X', str: 'C', dex: 'C', vit: 'C', agi: 'D', int: 'E', mnd: 'E', chr: 'D' },
     traits: [
       { name: 'Resist Blind I', effect: 'Improves blind resistance', level: 5 },
@@ -477,6 +489,7 @@ export const jobs = [
   },
   {
     name: 'Ninja',
+    abbr: 'NIN',
     proficiencies: { hp: 'D', mp: 'X', str: 'C', dex: 'B', vit: 'C', agi: 'B', int: 'D', mnd: 'G', chr: 'F' },
     traits: [
       { name: 'Stealth I', effect: 'Reduces sound detection', level: 5 },
@@ -529,6 +542,7 @@ export const jobs = [
   },
   {
     name: 'Dragoon',
+    abbr: 'DRG',
     proficiencies: { hp: 'C', mp: 'X', str: 'C', dex: 'E', vit: 'C', agi: 'E', int: 'F', mnd: 'E', chr: 'C' },
     traits: [
       { name: 'Attack Bonus I', effect: 'Increases attack', level: 10 },
@@ -556,6 +570,7 @@ export const jobs = [
   },
   {
     name: 'Summoner',
+    abbr: 'SMN',
     proficiencies: { hp: 'G', mp: 'A', str: 'G', dex: 'D', vit: 'G', agi: 'D', int: 'B', mnd: 'C', chr: 'C' },
     traits: [
       { name: 'Max MP Boost I', effect: 'Raises maximum MP', level: 10 },
@@ -574,6 +589,7 @@ export const jobs = [
   },
   {
     name: 'Blue Mage',
+    abbr: 'BLU',
     proficiencies: { hp: 'C', mp: 'D', str: 'C', dex: 'C', vit: 'C', agi: 'D', int: 'D', mnd: 'D', chr: 'C' },
     traits: [
       { name: 'Blue Magic Attack Bonus', effect: 'Boosts blue magic', level: 30 },
@@ -593,6 +609,7 @@ export const jobs = [
   },
   {
     name: 'Corsair',
+    abbr: 'COR',
     proficiencies: { hp: 'D', mp: 'E', str: 'E', dex: 'C', vit: 'D', agi: 'B', int: 'D', mnd: 'D', chr: 'B' },
     traits: [
       { name: 'Resist Paralyze I', effect: 'Improves paralyze resistance', level: 5 },
@@ -616,6 +633,7 @@ export const jobs = [
   },
   {
     name: 'Puppetmaster',
+    abbr: 'PUP',
     proficiencies: { hp: 'C', mp: 'E', str: 'D', dex: 'C', vit: 'D', agi: 'C', int: 'D', mnd: 'D', chr: 'C' },
     traits: [
       { name: 'Resist Slow I', effect: 'Improves Slow resistance', level: 10 },
@@ -636,6 +654,7 @@ export const jobs = [
   },
   {
     name: 'Dancer',
+    abbr: 'DNC',
     proficiencies: { hp: 'D', mp: 'X', str: 'D', dex: 'A', vit: 'C', agi: 'C', int: 'C', mnd: 'G', chr: 'C' },
     traits: [
       { name: 'Resist Slow I', effect: 'Improves Slow resistance', level: 20 },
@@ -656,6 +675,7 @@ export const jobs = [
   },
   {
     name: 'Scholar',
+    abbr: 'SCH',
     proficiencies: { hp: 'E', mp: 'B', str: 'E', dex: 'D', vit: 'D', agi: 'D', int: 'B', mnd: 'A', chr: 'D' },
     traits: [
       { name: 'Resist Silence I', effect: 'Improves silence resistance', level: 10 },
@@ -677,6 +697,7 @@ export const jobs = [
   },
   {
     name: 'Geomancer',
+    abbr: 'GEO',
     proficiencies: { hp: 'E', mp: 'B', str: 'E', dex: 'D', vit: 'D', agi: 'D', int: 'C', mnd: 'A', chr: 'D' },
     traits: [
       { name: 'Conserve MP', effect: 'Chance to use less MP', level: 10 },
@@ -701,6 +722,7 @@ export const jobs = [
   },
   {
     name: 'Rune Fencer',
+    abbr: 'RUN',
     proficiencies: { hp: 'B', mp: 'D', str: 'C', dex: 'C', vit: 'B', agi: 'D', int: 'C', mnd: 'D', chr: 'C' },
     traits: [
       { name: 'Tenacity', effect: 'Reduces physical damage taken', level: 1 },

--- a/js/ui.js
+++ b/js/ui.js
@@ -646,15 +646,43 @@ function createImageContainer() {
 
 function updateHPDisplay() {
     if (!activeCharacter) return;
-    const hpLine = document.getElementById('hp-line');
-    const hpBar = document.getElementById('char-hp-bar');
-    if (hpLine) {
-        hpLine.textContent = `HP: ${activeCharacter.hp} MP: ${activeCharacter.mp} TP: ${activeCharacter.tp}`;
-    }
+    const hpBar = document.getElementById('hp-bar');
+    const mpBar = document.getElementById('mp-bar');
+    const tpBar = document.getElementById('tp-bar');
+    const charHpBar = document.getElementById('char-hp-bar');
+    const xpBar = document.getElementById('xp-bar');
+
     if (hpBar) {
         const maxHp = activeCharacter.raceHP + activeCharacter.jobHP + activeCharacter.sJobHP;
         const pct = Math.max(0, Math.min(100, Math.round((activeCharacter.hp / maxHp) * 100)));
-        hpBar.style.backgroundImage = `linear-gradient(to right, green ${pct}%, #333 ${pct}%)`;
+        hpBar.textContent = `HP ${activeCharacter.hp}/${maxHp}`;
+        hpBar.style.backgroundImage = `linear-gradient(to right, darkred ${pct}%, #333 ${pct}%)`;
+    }
+
+    if (mpBar) {
+        const maxMp = activeCharacter.raceMP + activeCharacter.jobMP + activeCharacter.sJobMP;
+        const pct = maxMp > 0 ? Math.max(0, Math.min(100, Math.round((activeCharacter.mp / maxMp) * 100))) : 0;
+        mpBar.textContent = `MP ${activeCharacter.mp}/${maxMp}`;
+        mpBar.style.backgroundImage = `linear-gradient(to right, lightblue ${pct}%, #333 ${pct}%)`;
+    }
+
+    if (tpBar) {
+        const maxTp = 3000;
+        const pct = Math.max(0, Math.min(100, Math.round((activeCharacter.tp / maxTp) * 100)));
+        tpBar.textContent = `TP ${activeCharacter.tp}/${maxTp}`;
+        tpBar.style.backgroundImage = `linear-gradient(to right, yellowgreen ${pct}%, #333 ${pct}%)`;
+    }
+
+    if (charHpBar) {
+        const maxHp = activeCharacter.raceHP + activeCharacter.jobHP + activeCharacter.sJobHP;
+        const pct = Math.max(0, Math.min(100, Math.round((activeCharacter.hp / maxHp) * 100)));
+        charHpBar.style.backgroundImage = `linear-gradient(to right, green ${pct}%, #333 ${pct}%)`;
+    }
+
+    if (xpBar && activeCharacter.xpMode === 'EXP') {
+        const next = expToLevel[activeCharacter.level + 1] || activeCharacter.experience;
+        const pct = next > 0 ? Math.max(0, Math.min(100, Math.round((activeCharacter.experience / next) * 100))) : 0;
+        xpBar.style.backgroundImage = `linear-gradient(to right, orange ${pct}%, #333 ${pct}%)`;
     }
 }
 
@@ -939,39 +967,51 @@ export function renderMainMenu() {
 
         const subJob = Object.keys(activeCharacter.jobs || {}).find(j => j !== activeCharacter.job);
         const subLvl = subJob ? activeCharacter.jobs[subJob] : 0;
-        let jobText = `${activeCharacter.job} Lv.${activeCharacter.level}`;
+        const mainAbbr = jobs.find(j => j.name === activeCharacter.job)?.abbr || activeCharacter.job.slice(0,3).toUpperCase();
+        let jobText = `${mainAbbr} Lv.${activeCharacter.level}`;
         if (subJob) {
-            jobText = `${activeCharacter.job}/${subJob} ${activeCharacter.level}/${subLvl}`;
+            const subAbbr = jobs.find(j => j.name === subJob)?.abbr || subJob.slice(0,3).toUpperCase();
+            jobText = `${mainAbbr}/${subAbbr} ${activeCharacter.level}/${subLvl}`;
         }
         line2.textContent = jobText;
 
-        const line3 = document.createElement('div');
-        line3.id = 'hp-line';
-        line3.textContent = `HP: ${activeCharacter.hp} MP: ${activeCharacter.mp} TP: ${activeCharacter.tp}`;
+        const hpLine = document.createElement('div');
+        hpLine.id = 'hp-bar';
+        hpLine.className = 'stat-bar hp';
+
+        const mpLine = document.createElement('div');
+        mpLine.id = 'mp-bar';
+        mpLine.className = 'stat-bar mp';
+
+        const tpLine = document.createElement('div');
+        tpLine.id = 'tp-bar';
+        tpLine.className = 'stat-bar tp';
 
         const line4 = document.createElement('div');
         line4.textContent = `ATK: ${getAttack(activeCharacter)} DEF: ${getDefense(activeCharacter)}`;
         const line5 = document.createElement('div');
         line5.textContent = `Gil: ${activeCharacter.gil}`;
 
-        const lineTime = document.createElement('div');
-        lineTime.textContent = `Time: ${formatVanaTime(currentVanaTime())}`;
-
         const lineCp = document.createElement('div');
-        lineCp.textContent = `Conquest Points: ${activeCharacter.conquestPoints || 0}`;
+        lineCp.textContent = `CP: ${activeCharacter.conquestPoints || 0}`;
 
-        const line6 = document.createElement('div');
+        const xpLine = document.createElement('div');
+        xpLine.id = 'xp-bar';
+        xpLine.className = 'stat-bar xp';
         let progressText;
         if (activeCharacter.level >= 99 && activeCharacter.xpMode === 'CP') {
             const needed = 30000 - ((activeCharacter.capacityPoints || 0) % 30000);
-            progressText = `CP to Next Job Point: ${needed}`;
+            progressText = `CP to Next JP: ${needed}`;
         } else if (activeCharacter.level >= 75 && activeCharacter.xpMode === 'LP') {
             const needed = 10000 - ((activeCharacter.limitPoints || 0) % 10000);
             progressText = `LP to Next Merit: ${needed}`;
         } else {
-            progressText = `EXP to Next Level: ${expNeeded(activeCharacter)}`;
+            const next = expToLevel[activeCharacter.level + 1];
+            const pct = next ? Math.max(0, Math.min(100, Math.round((activeCharacter.experience / next) * 100))) : 0;
+            progressText = `XP: ${activeCharacter.experience}/${next}`;
+            xpLine.style.backgroundImage = `linear-gradient(to right, orange ${pct}%, #333 ${pct}%)`;
         }
-        line6.textContent = progressText;
+        xpLine.textContent = progressText;
 
         let modeBtn = null;
         if (activeCharacter.level >= 75) {
@@ -1047,12 +1087,13 @@ export function renderMainMenu() {
         });
 
         details.appendChild(line2);
-        details.appendChild(line3);
+        details.appendChild(hpLine);
+        details.appendChild(mpLine);
+        details.appendChild(tpLine);
         details.appendChild(line4);
         details.appendChild(line5);
-        details.appendChild(lineTime);
         details.appendChild(lineCp);
-        details.appendChild(line6);
+        details.appendChild(xpLine);
         if (modeBtn) details.appendChild(modeBtn);
         group.appendChild(invBtn);
         group.appendChild(equipBtn);


### PR DESCRIPTION
## Summary
- prevent Shrapnel from spawning when weather isn't implemented
- add job abbreviations in data and show them in profile
- shrink character images and profile fonts
- display HP/MP/TP/XP with colored bars

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_688d3c51b9cc8325b951554794af8c1a