### PR TITLE
Fix bar sizing and implement job-specific XP

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -569,13 +569,14 @@ body.portrait .main-layout {
 
 #character-details button {
     margin: 1px auto;
-    width: 128px;
+    width: 150px;
 }
 
 .profile-group {
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: stretch;
+    width: 150px;
 }
 
 .stat-bar {

--- a/data/characters.js
+++ b/data/characters.js
@@ -134,7 +134,7 @@ export const characters = [
     mp: 200,
     tp: 0,
     storeTp: 0,
-    experience: 0,
+    jobExp: { Thief: 0, Ninja: 0 },
     xpMode: 'EXP',
     limitPoints: 0,
     meritPoints: 0,
@@ -220,7 +220,7 @@ export const characters = [
     mp: 1500,
     tp: 0,
     storeTp: 0,
-    experience: 0,
+    jobExp: { 'Black Mage': 0, 'White Mage': 0 },
     xpMode: 'EXP',
     limitPoints: 0,
     meritPoints: 0,
@@ -330,7 +330,7 @@ export function createCharacterObject(name, job, race, sex = 'Male') {
     mp: 30,
     tp: 0,
     storeTp: 0,
-    experience: 0,
+    jobExp: { [selectedJob]: 0 },
     xpMode: 'EXP',
     limitPoints: 0,
     meritPoints: 0,
@@ -588,6 +588,13 @@ export function loadCharacters() {
       if (!c.jobPresets[c.job]) c.jobPresets[c.job] = { ...(c.equipment || {}) };
       if (!Array.isArray(c.storage)) c.storage = [];
       if (!Array.isArray(c.wardrobe)) c.wardrobe = [];
+      if (!c.jobExp) {
+        c.jobExp = {};
+        if (c.job && c.experience !== undefined) {
+          c.jobExp[c.job] = c.experience;
+          delete c.experience;
+        }
+      }
       characters.push(c);
       updateDerivedStats(c);
     });
@@ -611,6 +618,13 @@ export function loadCharacterSlot(index) {
     if (!characters[index].jobPresets) characters[index].jobPresets = {};
     if (!characters[index].jobPresets[characters[index].job]) {
       characters[index].jobPresets[characters[index].job] = { ...(characters[index].equipment || {}) };
+    }
+    if (!characters[index].jobExp) {
+      characters[index].jobExp = {};
+      if (characters[index].job && characters[index].experience !== undefined) {
+        characters[index].jobExp[characters[index].job] = characters[index].experience;
+        delete characters[index].experience;
+      }
     }
     if (!Array.isArray(characters[index].storage)) characters[index].storage = [];
     if (!Array.isArray(characters[index].wardrobe)) characters[index].wardrobe = [];
@@ -840,6 +854,8 @@ export function changeJob(character, job) {
   character.job = job;
   if (!character.jobs) character.jobs = { [job]: 1 };
   if (!character.jobs[job]) character.jobs[job] = 1;
+  if (!character.jobExp) character.jobExp = {};
+  if (character.jobExp[job] === undefined) character.jobExp[job] = 0;
   if (character.subJob === job) character.subJob = null;
   equipJobPreset(character, job);
   updateDerivedStats(character);
@@ -855,6 +871,8 @@ export function changeSubJob(character, job) {
     if (job) {
       if (!character.jobs) character.jobs = { [job]: 1 };
       if (!character.jobs[job]) character.jobs[job] = 1;
+      if (!character.jobExp) character.jobExp = {};
+      if (character.jobExp[job] === undefined) character.jobExp[job] = 0;
     }
   }
   updateDerivedStats(character);

--- a/data/experience.js
+++ b/data/experience.js
@@ -1366,8 +1366,12 @@ export const expToLevel = (() => {
   return table;
 })();
 
-export function expNeeded(character) {
-  const next = expToLevel[character.level + 1];
+export function expNeeded(character, jobName = character.job) {
+  const level = jobName === character.job
+    ? character.level
+    : character.jobs?.[jobName] || 1;
+  const next = expToLevel[level + 1];
   if (next === undefined) return 0;
-  return Math.max(next - (character.experience || 0), 0);
+  const current = character.jobExp?.[jobName] || 0;
+  return Math.max(next - current, 0);
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -683,8 +683,9 @@ function updateHPDisplay() {
     }
 
     if (xpBar && activeCharacter.xpMode === 'EXP') {
-        const next = expToLevel[activeCharacter.level + 1] || activeCharacter.experience;
-        const pct = next > 0 ? Math.max(0, Math.min(100, Math.round((activeCharacter.experience / next) * 100))) : 0;
+        const current = activeCharacter.jobExp?.[activeCharacter.job] || 0;
+        const next = expToLevel[activeCharacter.level + 1] || current;
+        const pct = next > 0 ? Math.max(0, Math.min(100, Math.round((current / next) * 100))) : 0;
         xpBar.style.backgroundImage = `linear-gradient(to right, orange ${pct}%, #333 ${pct}%)`;
     }
 }
@@ -1012,9 +1013,10 @@ export function renderMainMenu() {
             const needed = 10000 - ((activeCharacter.limitPoints || 0) % 10000);
             progressText = `LP to Next Merit: ${needed}`;
         } else {
+            const current = activeCharacter.jobExp?.[activeCharacter.job] || 0;
             const next = expToLevel[activeCharacter.level + 1];
-            const pct = next ? Math.max(0, Math.min(100, Math.round((activeCharacter.experience / next) * 100))) : 0;
-            progressText = `XP: ${activeCharacter.experience}/${next}`;
+            const pct = next ? Math.max(0, Math.min(100, Math.round((current / next) * 100))) : 0;
+            progressText = `XP: ${current}/${next}`;
             xpLine.style.backgroundImage = `linear-gradient(to right, orange ${pct}%, #333 ${pct}%)`;
         }
         xpLine.textContent = progressText;
@@ -2382,9 +2384,11 @@ function renderCombatScreen(app, mobs, destination) {
             mp: activeCharacter.mp,
             ...activeCharacter.stats
         };
+        const current = activeCharacter.jobExp?.[activeCharacter.job] || 0;
         while (activeCharacter.level < 99 &&
-            activeCharacter.experience >= expToLevel[activeCharacter.level + 1]) {
+            current >= expToLevel[activeCharacter.level + 1]) {
             activeCharacter.level++;
+            activeCharacter.jobs[activeCharacter.job] = activeCharacter.level;
             leveled = true;
         }
         if (leveled) {
@@ -2433,7 +2437,9 @@ function renderCombatScreen(app, mobs, destination) {
                     activeCharacter.meritPoints = (activeCharacter.meritPoints || 0) + 1;
                 }
             } else {
-                activeCharacter.experience = (activeCharacter.experience || 0) + exp;
+                const job = activeCharacter.job;
+                if (!activeCharacter.jobExp) activeCharacter.jobExp = {};
+                activeCharacter.jobExp[job] = (activeCharacter.jobExp[job] || 0) + exp;
                 checkLevelUp();
             }
         }


### PR DESCRIPTION
## Summary
- Ensure HP/MP/TP bars and menu buttons use consistent widths with the XP bar and Rest button
- Track experience per job and award XP only to the active job
- Use job-specific XP for level progression

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_688d7fd0fa688325aa33bc38ff1a6f36