### PR TITLE
Add cast button and party targeting for magic

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -389,6 +389,15 @@ body.portrait .nav-row {
 .monster-btn.target {
     outline: 2px solid yellow;
 }
+
+.party-btn {
+    width: 150px;
+    margin: 1px 0;
+}
+
+.party-btn.target {
+    outline: 2px solid yellow;
+}
 #direction-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
@@ -1005,7 +1014,7 @@ body.portrait .main-layout {
     width: 100%;
 }
 
-#action-buttons .with-select button {
+#action-buttons .with-select button:first-child {
     border-bottom: none;
     border-radius: 4px 4px 0 0;
 }
@@ -1017,6 +1026,16 @@ body.portrait .main-layout {
     background: #222;
     color: #fff;
     margin-top: -1px;
+}
+
+#action-buttons .with-select.with-cast select {
+    border-bottom: none;
+    border-radius: 0;
+}
+
+#action-buttons .with-select.with-cast button:last-child {
+    border-top: none;
+    border-radius: 0 0 4px 4px;
 }
 
 #action-buttons button,
@@ -1058,7 +1077,7 @@ body.portrait .main-layout {
 }
 
 /* Item popup */
-#item-popup {
+#item-popup { 
     position: fixed;
     top: 0;
     left: 0;
@@ -1069,6 +1088,37 @@ body.portrait .main-layout {
     align-items: center;
     justify-content: center;
     z-index: 1240;
+}
+#profile-popup {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1240;
+}
+#profile-popup-content {
+    background: rgba(0,0,0,0.9);
+    padding: 10px;
+    border-radius: 4px;
+    color: #fff;
+    text-align: left;
+    max-width: 300px;
+}
+#profile-popup-close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background: rgba(0,0,0,0.7);
+    color: #fff;
+    border: none;
+    padding: 4px 8px;
+    font-size: 20px;
+    cursor: pointer;
 }
 #item-popup-content {
     background: rgba(0,0,0,0.9);

--- a/index.html
+++ b/index.html
@@ -33,6 +33,10 @@
         <button id="storage-popup-close" class="storage-popup-close">X</button>
         <div id="storage-popup-content" class="storage-popup-content"></div>
     </div>
+    <div id="profile-popup" class="hidden">
+        <button id="profile-popup-close" class="profile-popup-close">X</button>
+        <div id="profile-popup-content" class="profile-popup-content"></div>
+    </div>
 
     <script src="js/panzoom.min.js"></script>
     <script type="module" src="js/main.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls, setupLogControls, setupTimeDisplay, setupMapOverlay, setupItemPopup, setupStoragePopup, updateTimeDisplay, isLogFullscreen, adjustLogFontSize, setupPressFeedback } from './ui.js';
+import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls, setupLogControls, setupTimeDisplay, setupMapOverlay, setupItemPopup, setupStoragePopup, setupProfilePopup, updateTimeDisplay, isLogFullscreen, adjustLogFontSize, setupPressFeedback } from './ui.js';
 import { loadCharacters, initCurrentUser, initNotorious, activeCharacter, persistCharacter } from '../data/index.js';
 
 // Entry point: initialize application
@@ -83,6 +83,13 @@ function init() {
     const storagePopupClose = document.getElementById('storage-popup-close');
     if (storagePopup && storagePopupContent && storagePopupClose) {
         setupStoragePopup(storagePopup, storagePopupContent, storagePopupClose);
+    }
+
+    const profilePopup = document.getElementById('profile-popup');
+    const profilePopupContent = document.getElementById('profile-popup-content');
+    const profilePopupClose = document.getElementById('profile-popup-close');
+    if (profilePopup && profilePopupContent && profilePopupClose) {
+        setupProfilePopup(profilePopup, profilePopupContent, profilePopupClose);
     }
 
     const charBtn = document.getElementById('character-select');


### PR DESCRIPTION
## Summary
- Add cast button beneath magic selector to cast spells on chosen enemies or party members
- Expose party list so player can target themselves for support magic
- Replace HP-bar character button with "Profile" that shows a popup on long press and lists stats per line

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check js/main.js`
- `node --check js/ui.js`


------
https://chatgpt.com/codex/tasks/task_e_688d8fc55eac83258592f3b35591cdec