### PR TITLE
Improve auto attack handling and UI tweaks

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -393,10 +393,23 @@ body.portrait .nav-row {
 .party-btn {
     width: 150px;
     margin: 1px 0;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    justify-content: flex-start;
 }
 
 .party-btn.target {
     outline: 2px solid yellow;
+}
+
+#party-list {
+    margin-top: 8px;
+}
+
+.auto-on {
+    background-color: #DAA520;
+    color: black;
 }
 #direction-grid {
     display: grid;

--- a/data/bestiary.js
+++ b/data/bestiary.js
@@ -491,7 +491,7 @@ export const bestiaryByZone = {
       detection: 'Sight & Scent',
       spawns: 26,
       spawnChance: 0.531,
-      areas: [null, 'Vomp Hill']
+      areas: [null]
     },
     {
       name: 'Tunnel Worm',
@@ -560,7 +560,7 @@ export const bestiaryByZone = {
       detection: 'Sight & Scent',
       spawns: 30,
       spawnChance: 0.612,
-      coords: ['D-8', 'D-9', 'E-6', 'E-7', 'E-8', 'E-9', 'F-7', 'F-8', 'F-9', 'G-7', 'G-8', 'G-9', 'H-5', 'H-6', 'H-7', 'H-8', 'H-9', 'H-10', 'I-9', 'I-10', 'J-9', 'J-10', 'L-9', 'L-10', 'M-10'],
+      coords: ['D-8', 'D-9', 'E-6', 'E-7', 'E-8', 'E-9', 'F-7', 'F-8', 'F-9', 'G-7', 'G-8', 'G-9', 'H-5', 'H-6', 'H-7', 'H-10', 'I-10', 'J-10', 'L-9', 'L-10', 'M-10'],
       areas: [null]
     },
     {


### PR DESCRIPTION
## Summary
- ensure auto attack stops on player death and offer toggleable auto combat
- support partial flee by clearing aggro per monster
- polish UI: party job icons, spacing and functional inventory/equipment popup
- correct hornet spawns: Maneating Hornets populate Vomp Hill while Huge Hornets appear elsewhere

## Testing
- `node scripts/validateZones.js`
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_688d9f2cc95c8325957df18d30cc390e