### PR TITLE
feat: add persistent auto-attack toggle and aggro icon

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -383,11 +383,6 @@ body.portrait .nav-row {
     color: #333;
 }
 
-.monster-btn.aggro {
-    background-color: darkred;
-}
-
-
 .monster-btn.target {
     outline: 2px solid yellow;
 }
@@ -398,6 +393,10 @@ body.portrait .nav-row {
     bottom: 0;
     height: 5px;
     background-color: darkred;
+}
+
+.monster-btn .aggro-icon {
+    margin-right: 4px;
 }
 
 .party-btn {


### PR DESCRIPTION
## Summary
- show level up stat changes using rounded integers
- add character-wide auto-attack toggle that persists across zones
- replace red aggro highlight with sword icon on monster buttons

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688e8acb9d1483259076959512787725