### PR TITLE
Add weaponskill control and party status bars

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -404,8 +404,31 @@ body.portrait .nav-row {
     margin: 1px 0;
     display: flex;
     align-items: center;
+    justify-content: space-between;
+}
+
+.party-info {
+    flex: 1;
+    display: flex;
+    align-items: center;
     gap: 4px;
-    justify-content: flex-start;
+}
+
+.party-bars {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    width: 40px;
+    background: #000;
+}
+
+.party-bars .bar {
+    background: #333;
+    height: 5px;
+}
+
+.party-bars .bar-fill {
+    height: 100%;
 }
 
 .party-btn.target {


### PR DESCRIPTION
## Summary
- Display party HP/MP/TP as small bars and center member info
- Add weaponskill dropdown between auto attack and abilities
- Move Flee action beneath magic and guard autoattack by coordinates

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688e921db2b88325a7c945ef2a2781ef