### PR TITLE
Fix auto attack initialization bug

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -2609,6 +2609,11 @@ function renderCombatScreen(app, mobs, destination) {
         activeCharacter.targetIndex = selectedMonsterIndex;
         persistCharacter(activeCharacter);
     }
+    let battleEnded = false;
+    const defeated = [];
+    let playerTimer = null;
+    const monsterTimers = new Map();
+
     monsterSelectHandler = idx => {
         let mob = mobs.find(m => m.listIndex === idx);
         if (!mob) mob = nearbyMonsters[idx];
@@ -2626,11 +2631,6 @@ function renderCombatScreen(app, mobs, destination) {
     if (autoAttacking && currentTargetMonster) {
         schedulePlayerAttack();
     }
-    
-    let battleEnded = false;
-    const defeated = [];
-    let playerTimer = null;
-    const monsterTimers = new Map();
 
     function weaponDelayMs() {
         const weaponDelay = items[activeCharacter.equipment?.mainHand]?.delay || 240;


### PR DESCRIPTION
## Summary
- prevent `playerTimer` reference error by declaring timers before scheduling auto attacks

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_688fbf6ed44c8325850538ff5428f69e