### PR TITLE
Align monster and party list buttons with responsive text

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -372,10 +372,11 @@ body.portrait .nav-row {
 }
 
 .monster-btn {
-    width: 150px;
+    width: 160px;
     margin: 1px 0;
     position: relative;
     padding-bottom: 5px;
+    overflow: hidden;
 }
 
 .monster-btn.defeated {
@@ -403,8 +404,9 @@ body.portrait .nav-row {
     width: 160px;
     margin: 1px 0;
     display: flex;
-    align-items: center;
-    justify-content: space-between;
+    align-items: stretch;
+    padding: 0;
+    position: relative;
 }
 
 .party-info {
@@ -412,19 +414,33 @@ body.portrait .nav-row {
     display: flex;
     align-items: center;
     gap: 4px;
+    overflow: hidden;
+}
+
+.party-name {
+    flex: 1;
+    min-width: 0;
+    white-space: nowrap;
 }
 
 .party-bars {
+    flex: 0 0 33.33%;
     display: flex;
     flex-direction: column;
-    gap: 1px;
-    width: 50px;
-    background: #000;
+    border-left: 1px solid #555;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    overflow: hidden;
 }
 
 .party-bars .bar {
+    flex: 1;
     background: #333;
-    height: 7px;
+    border-bottom: 1px solid #555;
+}
+
+.party-bars .bar:last-child {
+    border-bottom: none;
 }
 
 .party-bars .bar-fill {
@@ -651,8 +667,9 @@ body.portrait .main-layout {
 }
 
 .job-icon {
-    width: 16px;
-    height: 16px;
+    width: 32px;
+    height: 32px;
+    margin-left: 3px;
 }
 
 .race-img, .job-img, .city-img, .character-img {

--- a/js/ui.js
+++ b/js/ui.js
@@ -111,6 +111,20 @@ let monsterHpList = [];
 
 const BASE_BOTTOM_PADDING = 60;
 
+function adjustTextSize(el, maxDecrease = 4, container = el) {
+    if (!el || !container) return;
+    const baseSize = parseFloat(getComputedStyle(el).fontSize);
+    let size = baseSize;
+    el.style.whiteSpace = 'nowrap';
+    while (el.scrollWidth > container.clientWidth - 4 && size > baseSize - maxDecrease) {
+        size -= 1;
+        el.style.fontSize = `${size}px`;
+    }
+    if (el.scrollWidth > container.clientWidth - 4) {
+        el.style.whiteSpace = 'normal';
+    }
+}
+
 function itemProtected(id) {
     const presets = activeCharacter?.jobPresets || {};
     for (const set of Object.values(presets)) {
@@ -1881,6 +1895,15 @@ function createAreaGrid(root, loc) {
             });
             s.list.classList.remove('hidden');
             s.header.classList.add('expanded');
+            setTimeout(() => {
+                s.list.querySelectorAll('button').forEach(b => adjustTextSize(b));
+            });
+        });
+    });
+
+    setTimeout(() => {
+        grid.querySelectorAll('button').forEach(b => {
+            if (b.offsetParent !== null) adjustTextSize(b);
         });
     });
 
@@ -2077,6 +2100,9 @@ function createCityAreaGrid(root, loc) {
                 activeCharacter.citySections[loc.name] = s.btn.textContent;
                 persistCharacter(activeCharacter);
             }
+            setTimeout(() => {
+                s.list.querySelectorAll('button').forEach(b => adjustTextSize(b));
+            });
         });
     });
 
@@ -2087,6 +2113,11 @@ function createCityAreaGrid(root, loc) {
         initial.list.classList.remove('hidden');
         listCol.appendChild(initial.list);
     }
+    setTimeout(() => {
+        wrapper.querySelectorAll('button').forEach(b => {
+            if (b.offsetParent !== null) adjustTextSize(b);
+        });
+    });
     return wrapper;
 }
 
@@ -2386,6 +2417,7 @@ function createActionPanel(root, loc) {
                 renderParty();
             });
             partyList.appendChild(btn);
+            adjustTextSize(label);
         });
         partyListElement = partyList;
         updateTargetIndicator();
@@ -2483,6 +2515,7 @@ function createActionPanel(root, loc) {
             });
             btn.disabled = m.defeated;
             monsterList.appendChild(btn);
+            adjustTextSize(label, 4, btn);
             monsterIndexList.push(idxVal);
             monsterNameList.push(m.name);
             monsterHpList.push(m.hp);


### PR DESCRIPTION
## Summary
- Make monster list buttons match party list width
- Shift job icon left and enlarge it
- Overhaul party list bars to occupy right third with borders
- Add auto-shrinking text for area, party, and monster buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688feaac720883259b62bdb5270ae522