### PR TITLE
Fix duplicate spawn and targeting for goblin linkers

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -2456,7 +2456,9 @@ function createActionPanel(root, loc) {
                 m.listIndex = nearbyMonsters.length;
                 m.hp = m.hp ?? parseLevel(m.level) * 20;
                 nearbyMonsters.push(m);
-                if (activeCharacter) activeCharacter.monsters.push(m);
+                if (activeCharacter && activeCharacter.monsters !== nearbyMonsters) {
+                    activeCharacter.monsters.push(m);
+                }
             }
         });
         renderCombatScreen(root.parentElement, group);


### PR DESCRIPTION
## Summary
- prevent extra linked monsters from being added twice to the monster list

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_68900c37d0d48325a21d64510006bc11