### PR TITLE
Fix duplicate vendor listing and clean up combat spawn handling

### DIFF
--- a/data/locations.js
+++ b/data/locations.js
@@ -13,7 +13,6 @@ export const zonesByCity = {
         "Boytz's Knickknacks",
         "Gelzerio's Stall",
         "Deegis's Armour",
-        'Zemedars',
         'Proud Beard',
         "Neigepance's Chocobo Stables",
         "Griselda's Tavern",

--- a/js/ui.js
+++ b/js/ui.js
@@ -2454,12 +2454,13 @@ function createActionPanel(root, loc) {
         updateMonsterDisplay();
         const zone = loc.name;
         const sub = getSubArea(zone, activeCharacter.coordinates);
-        const group = huntEncounter(zone, target.name, sub);
-        if (group.length) {
-            group[0] = target;
+        const rawGroup = huntEncounter(zone, target.name, sub);
+        if (rawGroup.length) {
+            rawGroup[0] = target;
         } else {
-            group.push(target);
+            rawGroup.push(target);
         }
+        const group = [...new Set(rawGroup)];
         group.forEach(m => {
             if (m.listIndex === undefined) {
                 m.listIndex = nearbyMonsters.length;
@@ -2834,7 +2835,7 @@ function renderCombatScreen(app, mobs, destination) {
     function monsterDefeated(idx) {
         const mob = mobs[idx];
         defeated.push(mob);
-        mobs.splice(idx, 1);
+        mobs = mobs.filter(m => m !== mob);
         let listIdx = mob.listIndex;
         if (listIdx === undefined) listIdx = nearbyMonsters.indexOf(mob);
         if (listIdx !== -1) {


### PR DESCRIPTION
## Summary
- Remove extra Zemedars listing from Bastok Mines points of interest
- Deduplicate linked monster groups and drop all references to a mob when it dies

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_689012162b58832597cb848c57fc3757