### PR TITLE
feat: refine magic damage calculation

### DIFF
--- a/data/spells.js
+++ b/data/spells.js
@@ -1,11 +1,11 @@
 export const spells = [
   // Basic elemental spells with approximate base damage and MP cost
-  { name: 'Fire', element: 'Fire', baseDamage: 30, mpCost: 8, castTime: 2.5 },
-  { name: 'Blizzard', element: 'Ice', baseDamage: 30, mpCost: 8, castTime: 2.5 },
-  { name: 'Aero', element: 'Wind', baseDamage: 30, mpCost: 8, castTime: 2.5 },
-  { name: 'Stone', element: 'Earth', baseDamage: 30, mpCost: 8, castTime: 2.5 },
-  { name: 'Thunder', element: 'Lightning', baseDamage: 35, mpCost: 10, castTime: 2.5 },
-  { name: 'Water', element: 'Water', baseDamage: 30, mpCost: 8, castTime: 2.5 }
+  { name: 'Fire', element: 'Fire', baseDamage: 30, tier: 1, mpCost: 8, castTime: 2.5 },
+  { name: 'Blizzard', element: 'Ice', baseDamage: 30, tier: 1, mpCost: 8, castTime: 2.5 },
+  { name: 'Aero', element: 'Wind', baseDamage: 30, tier: 1, mpCost: 8, castTime: 2.5 },
+  { name: 'Stone', element: 'Earth', baseDamage: 30, tier: 1, mpCost: 8, castTime: 2.5 },
+  { name: 'Thunder', element: 'Lightning', baseDamage: 35, tier: 1, mpCost: 10, castTime: 2.5 },
+  { name: 'Water', element: 'Water', baseDamage: 30, tier: 1, mpCost: 8, castTime: 2.5 }
 ];
 
 export function getSpell(name) {


### PR DESCRIPTION
## Summary
- add tiers to spell data to prepare for dINT caps
- overhaul magic damage calculation with FFXI-inspired multipliers

## Testing
- `node scripts/testBalance.js > /tmp/testBalance.log && tail -n 20 /tmp/testBalance.log`
- `node scripts/testTaruBlm.js > /tmp/testTaru.log && tail -n 20 /tmp/testTaru.log`


------
https://chatgpt.com/codex/tasks/task_e_6890d42bf3b4832593848a20520dc7d4