### PR TITLE
Add weapon/magic proficiencies and expand spell data

### DIFF
--- a/data/characters.js
+++ b/data/characters.js
@@ -4,9 +4,13 @@ import { zonesByCity, locations } from './locations.js';
 import { parseCoordinate } from '../js/encounter.js';
 import { bestiaryByZone } from './bestiary.js';
 import { getScale, proficiencyScale } from './scales.js';
+import { weaponSkills, magicSkills } from './proficiencies.js';
 
 const aldoScale = buildScaleFields('Hume', 'Thief');
 const shantottoScale = buildScaleFields('Tarutaru', 'Black Mage');
+
+const baseCombatSkills = Object.fromEntries(weaponSkills.map(s => [s, 0]));
+const baseMagicSkills = Object.fromEntries(magicSkills.map(s => [s.name, 0]));
 
 const startingGearByJob = {
   'Warrior': { weapon: 'bronzeSword', armor: 'leatherVest' },
@@ -145,8 +149,8 @@ export const characters = [
     abilities: [],
     jobs: { Thief: 99, Ninja: 49 },
     gil: 100000,
-    combatSkills: {},
-    magicSkills: {},
+    combatSkills: { ...baseCombatSkills },
+    magicSkills: { ...baseMagicSkills },
     crafting: {},
     spells: [],
     ...aldoScale,
@@ -231,8 +235,8 @@ export const characters = [
     abilities: [],
     jobs: { 'Black Mage': 99, 'White Mage': 49 },
     gil: 500000,
-    combatSkills: {},
-    magicSkills: {},
+    combatSkills: { ...baseCombatSkills },
+    magicSkills: { ...baseMagicSkills },
     crafting: {},
     spells: [],
     ...shantottoScale,
@@ -343,8 +347,8 @@ export function createCharacterObject(name, job, race, sex = 'Male') {
     subJob: null,
     subJobUnlocked: false,
     gil: STARTING_GIL,
-    combatSkills: {},
-    magicSkills: {},
+    combatSkills: { ...baseCombatSkills },
+    magicSkills: { ...baseMagicSkills },
     crafting: {},
     spells: [],
     ...buildScaleFields(selectedRace, selectedJob),

--- a/data/index.js
+++ b/data/index.js
@@ -1,5 +1,6 @@
 export { jobs, jobNames, baseJobNames } from './jobs.js';
 export { races, raceNames, startingCities } from './races.js';
+export { weaponSkills, magicSkills } from './proficiencies.js';
 export {
   characters,
   activeCharacter,

--- a/data/proficiencies.js
+++ b/data/proficiencies.js
@@ -1,0 +1,32 @@
+export const weaponSkills = [
+  'Hand-to-Hand',
+  'Dagger',
+  'Sword',
+  'Great Sword',
+  'Axe',
+  'Great Axe',
+  'Scythe',
+  'Polearm',
+  'Katana',
+  'Great Katana',
+  'Club',
+  'Staff',
+  'Archery',
+  'Marksmanship',
+  'Throwing'
+];
+
+export const magicSkills = [
+  { name: 'Elemental Magic', magicType: 'Black Magic', subType: 'Elemental' },
+  { name: 'Dark Magic', magicType: 'Black Magic', subType: 'Dark' },
+  { name: 'Enfeebling Magic', magicType: 'Black Magic', subType: 'Enfeebling' },
+  { name: 'Enhancing Magic', magicType: 'White Magic', subType: 'Enhancing' },
+  { name: 'Healing Magic', magicType: 'White Magic', subType: 'Healing' },
+  { name: 'Divine Magic', magicType: 'White Magic', subType: 'Divine' },
+  { name: 'Summoning Magic', magicType: 'Summoning Magic', subType: 'Summoning' },
+  { name: 'Ninjutsu', magicType: 'Ninjutsu', subType: 'Ninjutsu' },
+  { name: 'Singing', magicType: 'Bard', subType: 'Singing' },
+  { name: 'Stringed Instrument', magicType: 'Bard', subType: 'Instrument' },
+  { name: 'Wind Instrument', magicType: 'Bard', subType: 'Instrument' },
+  { name: 'Blue Magic', magicType: 'Blue Magic', subType: 'Blue Magic' }
+];

--- a/data/spells.js
+++ b/data/spells.js
@@ -1,11 +1,238 @@
 export const spells = [
-  // Basic elemental spells with approximate base damage and MP cost
-  { name: 'Fire', element: 'Fire', baseDamage: 30, tier: 1, mpCost: 8, castTime: 2.5 },
-  { name: 'Blizzard', element: 'Ice', baseDamage: 30, tier: 1, mpCost: 8, castTime: 2.5 },
-  { name: 'Aero', element: 'Wind', baseDamage: 30, tier: 1, mpCost: 8, castTime: 2.5 },
-  { name: 'Stone', element: 'Earth', baseDamage: 30, tier: 1, mpCost: 8, castTime: 2.5 },
-  { name: 'Thunder', element: 'Lightning', baseDamage: 35, tier: 1, mpCost: 10, castTime: 2.5 },
-  { name: 'Water', element: 'Water', baseDamage: 30, tier: 1, mpCost: 8, castTime: 2.5 }
+  {
+    name: 'Stone',
+    level: 1,
+    element: 'Earth',
+    target: 'ST',
+    mpCost: 4,
+    castTime: 0.5,
+    recastTime: 2,
+    magicType: 'Black Magic',
+    subType: 'Elemental',
+    proficiency: 'Elemental Magic',
+    tier: 1,
+    baseDamage: 10,
+    damage: [
+      { skill: 0, V: 10, M: 2 },
+      { skill: 50, V: 110, M: 1 },
+      { skill: 100, V: 160, M: 0 }
+    ]
+  },
+  {
+    name: 'Water',
+    level: 5,
+    element: 'Water',
+    target: 'ST',
+    mpCost: 5,
+    castTime: 0.5,
+    recastTime: 2,
+    magicType: 'Black Magic',
+    subType: 'Elemental',
+    proficiency: 'Elemental Magic',
+    tier: 1,
+    baseDamage: 25,
+    damage: [
+      { skill: 0, V: 25, M: 1.8 },
+      { skill: 50, V: 115, M: 1 },
+      { skill: 100, V: 165, M: 0 }
+    ]
+  },
+  {
+    name: 'Aero',
+    level: 9,
+    element: 'Wind',
+    target: 'ST',
+    mpCost: 6,
+    castTime: 0.5,
+    recastTime: 2,
+    magicType: 'Black Magic',
+    subType: 'Elemental',
+    proficiency: 'Elemental Magic',
+    tier: 1,
+    baseDamage: 40,
+    damage: [
+      { skill: 0, V: 40, M: 1.6 },
+      { skill: 50, V: 120, M: 1 },
+      { skill: 100, V: 170, M: 0 }
+    ]
+  },
+  {
+    name: 'Fire',
+    level: 13,
+    element: 'Fire',
+    target: 'ST',
+    mpCost: 7,
+    castTime: 0.5,
+    recastTime: 2,
+    magicType: 'Black Magic',
+    subType: 'Elemental',
+    proficiency: 'Elemental Magic',
+    tier: 1,
+    baseDamage: 55,
+    damage: [
+      { skill: 0, V: 55, M: 1.4 },
+      { skill: 50, V: 125, M: 1 },
+      { skill: 100, V: 175, M: 0 }
+    ]
+  },
+  {
+    name: 'Stonega',
+    level: 15,
+    element: 'Earth',
+    target: 'AoE',
+    mpCost: 24,
+    castTime: 2,
+    recastTime: 5,
+    magicType: 'Black Magic',
+    subType: 'Elemental',
+    proficiency: 'Elemental Magic',
+    tier: 1,
+    baseDamage: 60,
+    damage: [
+      { skill: 0, V: 60, M: 3 },
+      { skill: 50, V: 210, M: 2 },
+      { skill: 100, V: 310, M: 1 },
+      { skill: 200, V: 410, M: 0 }
+    ]
+  },
+  {
+    name: 'Blizzard',
+    level: 17,
+    element: 'Ice',
+    target: 'ST',
+    mpCost: 8,
+    castTime: 0.5,
+    recastTime: 2,
+    magicType: 'Black Magic',
+    subType: 'Elemental',
+    proficiency: 'Elemental Magic',
+    tier: 1,
+    baseDamage: 70,
+    damage: [
+      { skill: 0, V: 70, M: 1.2 },
+      { skill: 50, V: 130, M: 1 },
+      { skill: 100, V: 180, M: 0 }
+    ]
+  },
+  {
+    name: 'Waterga',
+    level: 19,
+    element: 'Water',
+    target: 'AoE',
+    mpCost: 34,
+    castTime: 2,
+    recastTime: 5,
+    magicType: 'Black Magic',
+    subType: 'Elemental',
+    proficiency: 'Elemental Magic',
+    tier: 1,
+    baseDamage: 80,
+    damage: [
+      { skill: 0, V: 80, M: 2.8 },
+      { skill: 50, V: 220, M: 1.9 },
+      { skill: 100, V: 315, M: 1 },
+      { skill: 200, V: 415, M: 0 }
+    ]
+  },
+  {
+    name: 'Thunder',
+    level: 21,
+    element: 'Lightning',
+    target: 'ST',
+    mpCost: 9,
+    castTime: 0.5,
+    recastTime: 2,
+    magicType: 'Black Magic',
+    subType: 'Elemental',
+    proficiency: 'Elemental Magic',
+    tier: 1,
+    baseDamage: 85,
+    damage: [
+      { skill: 0, V: 85, M: 1.0 },
+      { skill: 50, V: 135, M: 1 },
+      { skill: 100, V: 185, M: 0 }
+    ]
+  },
+  {
+    name: 'Aeroga',
+    level: 23,
+    element: 'Wind',
+    target: 'AoE',
+    mpCost: 45,
+    castTime: 2,
+    recastTime: 5,
+    magicType: 'Black Magic',
+    subType: 'Elemental',
+    proficiency: 'Elemental Magic',
+    tier: 1,
+    baseDamage: 100,
+    damage: [
+      { skill: 0, V: 100, M: 2.6 },
+      { skill: 50, V: 230, M: 1.8 },
+      { skill: 100, V: 320, M: 1 },
+      { skill: 200, V: 420, M: 0 }
+    ]
+  },
+  {
+    name: 'Stone II',
+    level: 26,
+    element: 'Earth',
+    target: 'ST',
+    mpCost: 16,
+    castTime: 1.5,
+    recastTime: 6,
+    magicType: 'Black Magic',
+    subType: 'Elemental',
+    proficiency: 'Elemental Magic',
+    tier: 2,
+    baseDamage: 100,
+    damage: [
+      { skill: 0, V: 100, M: 3 },
+      { skill: 50, V: 250, M: 2 },
+      { skill: 100, V: 350, M: 1 },
+      { skill: 200, V: 450, M: 0 }
+    ]
+  },
+  {
+    name: 'Firaga',
+    level: 28,
+    element: 'Fire',
+    target: 'AoE',
+    mpCost: 57,
+    castTime: 2,
+    recastTime: 5,
+    magicType: 'Black Magic',
+    subType: 'Elemental',
+    proficiency: 'Elemental Magic',
+    tier: 1,
+    baseDamage: 120,
+    damage: [
+      { skill: 0, V: 120, M: 2.4 },
+      { skill: 50, V: 240, M: 1.7 },
+      { skill: 100, V: 325, M: 1 },
+      { skill: 200, V: 425, M: 0 }
+    ]
+  },
+  {
+    name: 'Water II',
+    level: 30,
+    element: 'Water',
+    target: 'ST',
+    mpCost: 19,
+    castTime: 1.5,
+    recastTime: 6,
+    magicType: 'Black Magic',
+    subType: 'Elemental',
+    proficiency: 'Elemental Magic',
+    tier: 2,
+    baseDamage: 120,
+    damage: [
+      { skill: 0, V: 120, M: 2.8 },
+      { skill: 50, V: 260, M: 1.9 },
+      { skill: 100, V: 355, M: 1 },
+      { skill: 200, V: 455, M: 0 }
+    ]
+  }
 ];
 
 export function getSpell(name) {

--- a/scripts/testBalance.js
+++ b/scripts/testBalance.js
@@ -24,6 +24,7 @@ load('data/jobs.js', context);
 load('data/races.js', context);
 load('data/locations.js', context);
 load('data/vendors.js', context);
+load('data/proficiencies.js', context);
 load('data/characters.js', context);
 load('data/bestiary.js', context);
 load('js/encounter.js', context);

--- a/scripts/testTaruBlm.js
+++ b/scripts/testTaruBlm.js
@@ -24,6 +24,7 @@ load('data/jobs.js', context);
 load('data/races.js', context);
 load('data/locations.js', context);
 load('data/vendors.js', context);
+load('data/proficiencies.js', context);
 load('data/characters.js', context);
 load('data/bestiary.js', context);
 load('js/encounter.js', context);


### PR DESCRIPTION
## Summary
- add FFXI-style weapon and magic proficiency definitions
- initialize characters with base weapon and magic skills
- expand elemental black magic spells with type, subtype, target and damage data

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e "import('./data/spells.js').then(m=>console.log(m.spells.length)).catch(e=>console.error(e))"`
- `node -e "import('./data/proficiencies.js').then(m=>console.log(m.weaponSkills.length,m.magicSkills.length))"`


------
https://chatgpt.com/codex/tasks/task_e_6890da10c4c083259a1591d44122f74f