### PR TITLE
feat: gate learned spells by job and level

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -48,7 +48,7 @@ export { regions, regionOwner, regionBonusApplies } from './regions.js';
 export { notoriousMonsters } from './nms.js';
 export { experienceTable, expToLevel, expNeeded, experienceForKill } from './experience.js';
 export { items, vendorInventories, shopNpcs, vendorGreetings, vendorTypes, conquestRewards } from './vendors.js';
-export { spells, getSpell } from './spells.js';
+export { spells, getSpell, getAvailableSpells } from './spells.js';
 export {
   parseLevel,
   conLevel,

--- a/data/spells.js
+++ b/data/spells.js
@@ -1002,3 +1002,40 @@ export const spells = [
 export function getSpell(name) {
   return spells.find(s => s.name === name);
 }
+
+// Mapping of jobs to the types of magic they can cast
+const magicTypesByJob = {
+  'White Mage': ['White Magic'],
+  'Black Mage': ['Black Magic'],
+  'Red Mage': ['White Magic', 'Black Magic'],
+  'Paladin': ['White Magic'],
+  'Dark Knight': ['Black Magic'],
+  'Bard': ['Bard'],
+  'Summoner': ['Summoning Magic'],
+  'Scholar': ['White Magic', 'Black Magic'],
+  'Blue Mage': ['Blue Magic'],
+  'Ninja': ['Ninjutsu']
+};
+
+/**
+ * Return a list of spells the character can currently cast based on
+ * job, sub job and level requirements. Spells remain learned even if
+ * they are not currently available.
+ */
+export function getAvailableSpells(character) {
+  if (!character?.spells) return [];
+
+  const mainTypes = magicTypesByJob[character.job] || [];
+  const mainLevel = character.level || 0;
+  const subJob = character.subJob;
+  const subTypes = subJob ? (magicTypesByJob[subJob] || []) : [];
+  const subLevel = subJob ? Math.floor(mainLevel / 2) : 0;
+
+  return character.spells.filter(name => {
+    const sp = getSpell(name);
+    if (!sp) return false;
+    if (mainTypes.includes(sp.magicType) && sp.level <= mainLevel) return true;
+    if (subJob && subTypes.includes(sp.magicType) && sp.level <= subLevel) return true;
+    return false;
+  });
+}

--- a/js/ui.js
+++ b/js/ui.js
@@ -47,7 +47,9 @@ import {
     dayElements,
     changeJob,
     changeSubJob,
-    spells as spellData
+    spells as spellData,
+    getSpell,
+    getAvailableSpells
 } from '../data/index.js';
 import { randomName, raceInfo, jobInfo, cityImages, characterImages, getZoneTravelTurns, exploreEncounter, parseLevel, expNeeded, expToLevel} from '../data/index.js';
 
@@ -2227,7 +2229,7 @@ function createActionButtons(disabled = false) {
     magicBtn.textContent = 'Magic';
     const castBtn = document.createElement('button');
     castBtn.textContent = 'Cast';
-    const charSpells = activeCharacter.spells || [];
+    const charSpells = getAvailableSpells(activeCharacter);
     charSpells.forEach(s => magicSelect.appendChild(new Option(s, s)));
     if (!charSpells.length) { magicBtn.disabled = true; castBtn.disabled = true; }
 
@@ -2641,7 +2643,7 @@ function renderCombatScreen(app, mobs, destination) {
 
     const { actionDiv, attackBtn, wsBtn, wsSelect, abilityBtn, abilitySelect, magicBtn, magicSelect, castBtn, fleeBtn } = createActionButtons(false);
     actionColumn.appendChild(actionDiv);
-    const spells = activeCharacter.spells || [];
+    const spells = getAvailableSpells(activeCharacter);
 
     mobs.forEach(m => {
         m.currentHP = (m.hp ?? parseLevel(m.level) * 20);
@@ -3822,13 +3824,16 @@ function useScroll(id, root) {
     const entry = activeCharacter.inventory.find(i => i.id === id);
     if (!entry) return;
     const item = items[id];
-    const spell = item.name.replace(/^Scroll of\s+/i, '');
+    const spellName = item.name.replace(/^Scroll of\s+/i, '');
+    const spell = getSpell(spellName);
     if (!activeCharacter.spells) activeCharacter.spells = [];
-    if (activeCharacter.spells.includes(spell)) {
-        alert(`${spell} is already learned.`);
+    if (!spell) {
+        alert('Nothing happens.');
+    } else if (activeCharacter.spells.includes(spell.name)) {
+        alert(`${spell.name} is already learned.`);
     } else {
-        activeCharacter.spells.push(spell);
-        alert(`${spell} learned!`);
+        activeCharacter.spells.push(spell.name);
+        alert(`${spell.name} learned!`);
     }
     entry.qty -= 1;
     if (entry.qty <= 0) {


### PR DESCRIPTION
## Summary
- link scrolls to their spell data when used, keeping learned spells
- only show spells a character can cast based on job and level
- export helper to fetch available spells for a character

## Testing
- `node scripts/testTaruBlm.js`
- `node scripts/testBalance.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_6890e4899ed08325a63f78279cd3d516