### PR TITLE
Implement TP-based weapon skill damage system

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -49,6 +49,7 @@ export { notoriousMonsters } from './nms.js';
 export { experienceTable, expToLevel, expNeeded, experienceForKill } from './experience.js';
 export { items, vendorInventories, shopNpcs, vendorGreetings, vendorTypes, conquestRewards } from './vendors.js';
 export { spells, getSpell, getAvailableSpells } from './spells.js';
+export { weaponSkillDetails } from './weaponskills.js';
 export {
   parseLevel,
   conLevel,

--- a/data/weaponskills.js
+++ b/data/weaponskills.js
@@ -1,0 +1,27 @@
+export const weaponSkillDetails = {
+  'Wasp Sting': {
+    hits: 1,
+    ftp: [1.0, 1.0, 1.0],
+    wsc: { dex: 0.30 }
+  },
+  'Viper Bite': {
+    hits: 1,
+    ftp: [1.5, 1.5, 1.5],
+    wsc: { dex: 0.30 }
+  },
+  'Fast Blade': {
+    hits: 1,
+    ftp: [1.0, 1.0, 1.0],
+    wsc: { str: 0.30 }
+  },
+  'Burning Blade': {
+    hits: 1,
+    ftp: [1.5, 1.5, 1.5],
+    wsc: { str: 0.30 }
+  },
+  'Savage Blade': {
+    hits: 1,
+    ftp: [4.0, 10.25, 13.75],
+    wsc: { str: 0.50, mnd: 0.50 }
+  }
+};


### PR DESCRIPTION
## Summary
- add weapon skill data with fTP anchors and stat modifiers
- compute weapon skill damage using TP, fSTR, WSC and pDIF
- consume TP when weapon skills are used and expose new weapon skills

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`


------
https://chatgpt.com/codex/tasks/task_e_68912ef7ec888325b053f3b8dec350c2