### PR TITLE
chore: clarify proficiency and spell metadata

### DIFF
--- a/data/proficiencies.js
+++ b/data/proficiencies.js
@@ -1,3 +1,5 @@
+// Weapon and magic proficiency definitions based on FFXI's skill system
+// Weapon proficiencies are stored as a simple list of skill names.
 export const weaponSkills = [
   'Hand-to-Hand',
   'Dagger',
@@ -16,6 +18,8 @@ export const weaponSkills = [
   'Throwing'
 ];
 
+// Magic proficiencies are objects that specify their broader magic type and a
+// more granular subType used by spell definitions.
 export const magicSkills = [
   { name: 'Elemental Magic', magicType: 'Black Magic', subType: 'Elemental' },
   { name: 'Dark Magic', magicType: 'Black Magic', subType: 'Dark' },

--- a/data/spells.js
+++ b/data/spells.js
@@ -1,3 +1,5 @@
+// Spell definitions. Each spell includes its magicType and subType which
+// correspond to the entries in magicSkills for proficiency tracking.
 export const spells = [
   {
     name: 'Stone',


### PR DESCRIPTION
## Summary
- document FFXI weapon and magic proficiency data
- clarify spell entries with magic type and subtype comments

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_689134f278c08325b148e2ee146f5dc6