### PR TITLE
Populate comprehensive weapon skill data

### DIFF
--- a/data/weaponskills.js
+++ b/data/weaponskills.js
@@ -1,27 +1,7793 @@
+
 export const weaponSkillDetails = {
-  'Wasp Sting': {
-    hits: 1,
-    ftp: [1.0, 1.0, 1.0],
-    wsc: { dex: 0.30 }
+  "Apex Arrow": {
+    "name": "Apex Arrow",
+    "type": "Archery",
+    "class": "Physical",
+    "tpMod": "Defense ignored",
+    "ftp": [],
+    "wsc": {
+      "agi": 0.85
+    },
+    "sc": [
+      "Light",
+      "Fragmentation",
+      "Transfixion"
+    ],
+    "reqSkill": 357,
+    "quest": "Martial Mastery",
+    "jobs": {
+      "RNG": 91,
+      "SAM": 96
+    },
+    "hits": 1,
+    "description": "Delivers a 4x attack that ignores target's defense. Amount ignored varies with [[TP]]."
   },
-  'Viper Bite': {
-    hits: 1,
-    ftp: [1.5, 1.5, 1.5],
-    wsc: { dex: 0.30 }
+  "Arching Arrow": {
+    "name": "Arching Arrow",
+    "type": "Archery",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [],
+    "wsc": {
+      "agi": 0.5,
+      "str": 0.2
+    },
+    "sc": [
+      "Fusion"
+    ],
+    "reqSkill": 225,
+    "jobs": {
+      "RNG": 99,
+      "WAR": 99,
+      "RDM": 99,
+      "THF": 99,
+      "PLD": 99,
+      "DRK": 99,
+      "BST": 99,
+      "SAM": 99,
+      "NINviaExaltedBow/ExaltedBow+1": 99
+    },
+    "hits": 1,
+    "description": "Delivers a single-hit attack. Chance of critical varies with TP."
   },
-  'Fast Blade': {
-    hits: 1,
-    ftp: [1.0, 1.0, 1.0],
-    wsc: { str: 0.30 }
+  "Blast Arrow": {
+    "name": "Blast Arrow",
+    "type": "Archery",
+    "class": "Physical",
+    "tpMod": "Ranged Accuracy",
+    "ftp": [],
+    "wsc": {
+      "agi": 0.5,
+      "str": 0.2
+    },
+    "sc": [
+      "Induration",
+      "Transfixion"
+    ],
+    "reqSkill": 200,
+    "jobs": {
+      "RNG": 60
+    },
+    "hits": 1,
+    "description": "Delivers a melee-distance ranged attack. Accuracy varies with TP."
   },
-  'Burning Blade': {
-    hits: 1,
-    ftp: [1.5, 1.5, 1.5],
-    wsc: { str: 0.30 }
+  "Dulling Arrow": {
+    "name": "Dulling Arrow",
+    "type": "Archery",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [],
+    "wsc": {
+      "agi": 0.5,
+      "str": 0.2
+    },
+    "sc": [
+      "Liquefaction",
+      "Transfixion"
+    ],
+    "reqSkill": 80,
+    "jobs": {
+      "RNG": 26,
+      "THF": 28,
+      "SAM": 28,
+      "WAR": 30,
+      "RDM": 30,
+      "NIN": 32
+    },
+    "hits": 1,
+    "description": "Lowers enemy's INT. Chance of critical varies with TP."
   },
-  'Savage Blade': {
-    hits: 1,
-    ftp: [4.0, 10.25, 13.75],
-    wsc: { str: 0.50, mnd: 0.50 }
+  "Empyreal Arrow": {
+    "name": "Empyreal Arrow",
+    "type": "Archery",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1.5,
+      2.5,
+      5
+    ],
+    "wsc": {
+      "agi": 0.5,
+      "str": 0.2
+    },
+    "sc": [
+      "Fusion",
+      "Transfixion"
+    ],
+    "reqSkill": 250,
+    "quest": "From Saplings Grow",
+    "jobs": {
+      "RNG": 99,
+      "WAR": 99,
+      "RDM": 99,
+      "THF": 99,
+      "PLD": 99,
+      "DRK": 99,
+      "BST": 99,
+      "SAM": 99,
+      "NINviaKajaBow/Ullr": 99
+    },
+    "hits": 1,
+    "description": "Delivers a single attack. Damage varies with [[TP]]."
+  },
+  "Flaming Arrow": {
+    "name": "Flaming Arrow",
+    "type": "Archery",
+    "class": "Hybrid",
+    "element": "{{fire}}",
+    "tpMod": "fTP",
+    "ftp": [
+      0.5,
+      1.55,
+      2.1
+    ],
+    "wsc": {
+      "agi": 0.5,
+      "str": 0.2
+    },
+    "sc": [
+      "Liquefaction",
+      "Transfixion"
+    ],
+    "reqSkill": 5,
+    "jobs": {
+      "THF": 1,
+      "RNG": 1,
+      "SAM": 1,
+      "WAR": 2,
+      "RDM": 2,
+      "NIN": 2
+    },
+    "hits": 1,
+    "description": "Deals fire elemental damage to enemy. Damage varies with TP."
+  },
+  "Jishnu's Radiance": {
+    "name": "Jishnu's Radiance",
+    "type": "Archery",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [],
+    "wsc": {
+      "dex": 0.8
+    },
+    "sc": [
+      "Light",
+      "Fusion"
+    ],
+    "quest": "Kupofried's Weapon Skill Moogle Magic",
+    "jobs": {
+      "RNGviaGandiva": 85,
+      "Harrier": 85,
+      "Harrier+1": 85
+    },
+    "hits": 1,
+    "description": "Delivers a threefold attack, ammunition permitting. [[Critical Hit Rate"
+  },
+  "Namas Arrow": {
+    "name": "Namas Arrow",
+    "type": "Archery",
+    "class": "Physical",
+    "tpMod": "Aftermath<br />(+30 Ranged Accuracy)",
+    "ftp": [
+      20,
+      40,
+      60
+    ],
+    "wsc": {
+      "str": 0.4,
+      "agi": 0.4
+    },
+    "sc": [
+      "Light",
+      "Distortion"
+    ],
+    "jobs": {
+      "RNGorSAMviaFutatokorotoorYoichinoyumi": 75,
+      "RNGorSAMviaMurtiBow": 85
+    },
+    "hits": 1,
+    "description": "[[Futatokoroto]]/[[Yoichinoyumi]]: Additional Effect: Temporarily increases [[Ranged Accuracy]]."
+  },
+  "Piercing Arrow": {
+    "name": "Piercing Arrow",
+    "type": "Archery",
+    "class": "Physical",
+    "tpMod": "Defense Ignored",
+    "ftp": [
+      0,
+      35,
+      50
+    ],
+    "wsc": {
+      "agi": 0.5,
+      "str": 0.2
+    },
+    "sc": [
+      "Reverberation",
+      "Transfixion"
+    ],
+    "reqSkill": 40,
+    "jobs": {
+      "RNG": 13,
+      "THF": 14,
+      "SAM": 14,
+      "WAR": 15,
+      "RDM": 15,
+      "NIN": 16
+    },
+    "hits": 1,
+    "description": "Ignores enemy's [[defense]]. Amount ignored varies with TP."
+  },
+  "Refulgent Arrow": {
+    "name": "Refulgent Arrow",
+    "type": "Archery",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      3,
+      4.25,
+      7
+    ],
+    "wsc": {
+      "str": 0.6
+    },
+    "sc": [
+      "Reverberation",
+      "Transfixion"
+    ],
+    "reqSkill": 290,
+    "jobs": {
+      "RNG": 80,
+      "SAM": 86,
+      "THF": 90,
+      "WAR": 92,
+      "RDM": 92,
+      "NIN": 98
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack. Damage varies with TP."
+  },
+  "Sarv": {
+    "name": "Sarv",
+    "type": "Archery",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      2.75,
+      5.5,
+      8.25
+    ],
+    "wsc": {
+      "str": 0.65,
+      "agi": 0.65
+    },
+    "sc": [
+      "Transfixion",
+      "Scission",
+      "Gravitation"
+    ],
+    "jobs": {
+      "RNGviaPinaka(Level119)orhigher": 99
+    },
+    "hits": 1,
+    "description": "Damage varies with TP."
+  },
+  "Sidewinder": {
+    "name": "Sidewinder",
+    "type": "Archery",
+    "class": "Physical",
+    "tpMod": "Ranged Accuracy",
+    "ftp": [],
+    "wsc": {
+      "agi": 0.5,
+      "str": 0.2
+    },
+    "sc": [
+      "Reverberation",
+      "Transfixion",
+      "Detonation"
+    ],
+    "reqSkill": 175,
+    "jobs": {
+      "RNG": 55,
+      "THF": 57,
+      "SAM": 57,
+      "WAR": 59,
+      "RDM": 59,
+      "NIN": 63
+    },
+    "hits": 1,
+    "description": "Delivers a powerful but inaccurate attack. Accuracy varies with TP."
+  },
+  "Stellar Arrow": {
+    "name": "Stellar Arrow",
+    "type": "Archery",
+    "class": "Magical",
+    "element": "Dark",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Darkness",
+      "Gravitation"
+    ],
+    "jobs": {
+      ":Category:Trust": 60
+    },
+    "hits": 1,
+    "description": "Delivers a threefold attack in an area around the target. Additional effect: [[Evasion Down]]."
+  },
+  "Typhonic Arrow": {
+    "name": "Typhonic Arrow",
+    "type": "Archery",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light",
+      "Distortion"
+    ],
+    "jobs": {
+      ":Category:Trust": 50
+    },
+    "hits": 1,
+    "description": "Deals damage in a fan-shaped area in front of the user. Additional effect: [[Bind]]."
+  },
+  "Arrow of Apathy": {
+    "name": "Arrow of Apathy",
+    "type": "Archery",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "{{question}}",
+      "{{question}}",
+      "{{question}}"
+    ],
+    "jobs": {
+      "LaisavieXBerlends": 73
+    },
+    "hits": 1,
+    "description": "{{question}}"
+  },
+  "Arcuballista": {
+    "name": "Arcuballista",
+    "type": "Automaton",
+    "class": "Physical {{ranged}}",
+    "tpMod": "fTP",
+    "ftp": [
+      7,
+      10,
+      13
+    ],
+    "wsc": {
+      "dex": 0.6
+    },
+    "sc": [
+      "Liquefaction",
+      "Transfixion"
+    ],
+    "jobs": {
+      "Sharpshotframe": 1
+    },
+    "hits": 1,
+    "description": "Delivers a single attack. Damage varies with [[TP]]."
+  },
+  "Armor Piercer": {
+    "name": "Armor Piercer",
+    "type": "Automaton",
+    "class": "Physical {{ranged}}",
+    "tpMod": "fTP",
+    "ftp": [
+      4,
+      5.5,
+      7
+    ],
+    "wsc": {
+      "dex": 0.6
+    },
+    "sc": [
+      "Gravitation"
+    ],
+    "reqSkill": 245,
+    "jobs": {
+      "Sharpshotframe": 71
+    },
+    "hits": 1,
+    "description": "Delivers a single hit attack. Damage varies with [[TP]]. Ignores 50% of targets defence during weapon skill."
+  },
+  "Armor Shatterer": {
+    "name": "Armor Shatterer",
+    "type": "Automaton",
+    "class": "Physical {{ranged}}",
+    "tpMod": "Defense Down Duration",
+    "ftp": [
+      0,
+      33,
+      66
+    ],
+    "wsc": {
+      "dex": 0.5
+    },
+    "sc": [
+      "Fusion",
+      "Impaction"
+    ],
+    "reqSkill": 324,
+    "jobs": {
+      "SharpshotFrame": 85
+    },
+    "hits": 1,
+    "description": "Delivers a fourfold attack. Additional Effect: Defense Down. Effect duration varies with TP."
+  },
+  "Bone Crusher": {
+    "name": "Bone Crusher",
+    "type": "Automaton",
+    "class": "Physical {{blunt}}",
+    "tpMod": "N/A",
+    "ftp": [
+      2.66,
+      2.66,
+      2.66
+    ],
+    "wsc": {
+      "vit": 0.6
+    },
+    "sc": [
+      "Fragmentation"
+    ],
+    "reqSkill": 245,
+    "jobs": {
+      "Valoredgeframe": 71
+    },
+    "hits": 1,
+    "description": "Delivers a threefold attack. Additional Effect: Stun."
+  },
+  "Cannibal Blade": {
+    "name": "Cannibal Blade",
+    "type": "Automaton",
+    "class": "Physical {{slashing}}",
+    "tpMod": "fTP",
+    "ftp": [
+      16,
+      23.5,
+      31.5
+    ],
+    "wsc": {
+      "mnd": 1
+    },
+    "sc": [
+      "Compression",
+      "Reverberation"
+    ],
+    "reqSkill": 145,
+    "jobs": {
+      "Valoredgeframe": 49
+    },
+    "hits": 1,
+    "description": "Delivers a single hit attack. Additional Effect: Convert damage dealt to HP."
+  },
+  "Chimera Ripper": {
+    "name": "Chimera Ripper",
+    "type": "Automaton",
+    "class": "Physical {{slashing}}",
+    "tpMod": "fTP",
+    "ftp": [
+      6,
+      8.5,
+      11
+    ],
+    "wsc": {
+      "str": 0.5
+    },
+    "sc": [
+      "Detonation",
+      "Induration"
+    ],
+    "jobs": {
+      "Valoredgeframe": 1
+    },
+    "hits": 1,
+    "description": "Delivers a single hit attack."
+  },
+  "Daze (Weaponskill)": {
+    "name": "Daze (Weaponskill)",
+    "type": "Automaton",
+    "class": "Physical {{ranged}}",
+    "tpMod": "fTP",
+    "ftp": [
+      6,
+      8.5,
+      11
+    ],
+    "wsc": {
+      "dex": 0.6
+    },
+    "sc": [
+      "Impaction",
+      "Transfixion"
+    ],
+    "reqSkill": 150,
+    "jobs": {
+      "Sharpshotframe": 49
+    },
+    "hits": 1,
+    "description": "Delivers a single attack. Damage varies with [[TP]]. Additional Effect: Stun"
+  },
+  "Knockout": {
+    "name": "Knockout",
+    "type": "Automaton",
+    "class": "Physical {{blunt}}",
+    "tpMod": "fTP",
+    "ftp": [
+      6,
+      8.5,
+      11
+    ],
+    "wsc": {
+      "agi": 1
+    },
+    "sc": [
+      "Scission",
+      "Detonation"
+    ],
+    "reqSkill": 145,
+    "jobs": {
+      "HarlequinandStormwakerframes": 51
+    },
+    "hits": 1,
+    "description": "Delivers a single hit attack. Damage varies with TP. Additional Effect: [[Evasion]] down."
+  },
+  "Magic Mortar": {
+    "name": "Magic Mortar",
+    "type": "Automaton",
+    "class": "Magical",
+    "element": "{{none}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1.5,
+      1.75,
+      2.5
+    ],
+    "wsc": {},
+    "sc": [
+      "Fusion"
+    ],
+    "reqSkill": 225,
+    "jobs": {
+      "Harlequinframeandhead": 74,
+      "Stormwakerframeandhead": 75,
+      "SoulsootherandSpiritreaverhead": 76
+    },
+    "hits": 1,
+    "description": "Damage varies with [[Automaton]] HP."
+  },
+  "Shield Subverter": {
+    "name": "Shield Subverter",
+    "type": "Automaton",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light",
+      "Fusion"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Deals damage. Additional effect: Silence."
+  },
+  "Sixth Element": {
+    "name": "Sixth Element",
+    "type": "Automaton",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Gravitation"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Deals damage to a target."
+  },
+  "Slapstick": {
+    "name": "Slapstick",
+    "type": "Automaton",
+    "class": "Physical {{blunt}}",
+    "tpMod": "Accuracy",
+    "ftp": [
+      0,
+      40,
+      80
+    ],
+    "wsc": {
+      "str": 0.3,
+      "dex": 0.3
+    },
+    "sc": [
+      "Reverberation",
+      "Impaction"
+    ],
+    "jobs": {
+      "HarlequinandStormwakerframes": 1
+    },
+    "hits": 1,
+    "description": "Delivers a threefold attack. Accuracy varies with [[TP]]."
+  },
+  "String Clipper": {
+    "name": "String Clipper",
+    "type": "Automaton",
+    "class": "Physical {{slashing}}",
+    "tpMod": "Accuracy",
+    "ftp": [
+      0,
+      50,
+      100
+    ],
+    "wsc": {
+      "str": 0.3,
+      "dex": 0.3
+    },
+    "sc": [
+      "Scission"
+    ],
+    "jobs": {
+      "Valoredgeframe": 1
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack. Accuracy varies with [[TP]]."
+  },
+  "String Shredder": {
+    "name": "String Shredder",
+    "type": "Automaton",
+    "class": "Physical {{slashing}}",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [
+      20,
+      40,
+      70
+    ],
+    "wsc": {
+      "vit": 0.5
+    },
+    "sc": [
+      "Distortion",
+      "Scission"
+    ],
+    "reqSkill": 324,
+    "jobs": {
+      "Valoredgeframe": 84
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack. Critical hit rate varies with [[TP]]."
+  },
+  "Avalanche Axe": {
+    "name": "Avalanche Axe",
+    "type": "Axe",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1.5,
+      3,
+      5.5
+    ],
+    "wsc": {
+      "str": 0.6
+    },
+    "sc": [
+      "Scission",
+      "Impaction"
+    ],
+    "reqSkill": 100,
+    "jobs": {
+      "WAR": 33,
+      "BST": 33,
+      "DRK": 34,
+      "RNG": 34,
+      "RUN": 34
+    },
+    "hits": 1,
+    "description": "Delivers a single-hit attack. Damage varies with [[TP]]."
+  },
+  "Blitz": {
+    "name": "Blitz",
+    "type": "Axe",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1.5,
+      7,
+      12.5
+    ],
+    "wsc": {
+      "str": 0.32,
+      "dex": 0.32
+    },
+    "sc": [
+      "Liquefaction",
+      "Impaction",
+      "Fragmentation"
+    ],
+    "jobs": {
+      "BSTviaSpalirisos(Level119)orhigher": 99
+    },
+    "hits": 1,
+    "description": "Delivers a fivefold attack. Damage varies with TP."
+  },
+  "Bora Axe": {
+    "name": "Bora Axe",
+    "type": "Axe",
+    "class": "Physical",
+    "tpMod": "Effect accuracy",
+    "ftp": [],
+    "wsc": {
+      "dex": 1
+    },
+    "sc": [
+      "Scission",
+      "Detonation"
+    ],
+    "reqSkill": 290,
+    "jobs": {
+      "WAR": 80,
+      "BST": 80,
+      "DRK": 85,
+      "RNG": 85,
+      "RUN": 85
+    },
+    "hits": 1,
+    "description": "Binds target. Chance of binding varies with [[TP]]."
+  },
+  "Calamity": {
+    "name": "Calamity",
+    "type": "Axe",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      2.5,
+      6.5,
+      10.375
+    ],
+    "wsc": {
+      "str": 0.5,
+      "vit": 0.5
+    },
+    "sc": [
+      "Scission",
+      "Impaction"
+    ],
+    "reqSkill": 200,
+    "jobs": {
+      "WAR": 60,
+      "BST": 60
+    },
+    "hits": 1,
+    "description": "Delivers a single-hit attack. Damage varies with [[TP]]."
+  },
+  "Cloudsplitter": {
+    "name": "Cloudsplitter",
+    "type": "Axe",
+    "class": "Magical",
+    "element": "{{lightning}}",
+    "tpMod": "fTP",
+    "ftp": [
+      3.75,
+      6.69921875,
+      8.5
+    ],
+    "wsc": {
+      "str": 0.4,
+      "mnd": 0.4
+    },
+    "sc": [
+      "Darkness",
+      "Fragmentation"
+    ],
+    "quest": "Kupofried's Weapon Skill Moogle Magic",
+    "jobs": {
+      "WARorBSTviaFarsha": 85,
+      "AlardsAxe": 85,
+      "AlardsAxe+1": 85
+    },
+    "hits": 1,
+    "description": "Deals lightning elemental damage. Damage varies with [[TP]]."
+  },
+  "Decimation": {
+    "name": "Decimation",
+    "type": "Axe",
+    "class": "Physical",
+    "tpMod": "Accuracy",
+    "ftp": [],
+    "wsc": {
+      "str": 0.5
+    },
+    "sc": [
+      "Fusion",
+      "Reverberation"
+    ],
+    "reqSkill": 240,
+    "quest": "Axe the Competition",
+    "jobs": {
+      "WAR": 99,
+      "BST": 99,
+      "DRK": 99,
+      "RNG": 99,
+      "RUN": 75,
+      "RUNviaKajaAxe/Dolichenusinthemainhandonly": 99
+    },
+    "hits": 3,
+    "description": "Delivers an aerial attack comprised of three hits. Accuracy varies with [[TP]]."
+  },
+  "Gale Axe": {
+    "name": "Gale Axe",
+    "type": "Axe",
+    "class": "Physical",
+    "tpMod": "Effect duration",
+    "ftp": [
+      60,
+      60,
+      60
+    ],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Detonation"
+    ],
+    "reqSkill": 70,
+    "jobs": {
+      "WAR": 23,
+      "BST": 23,
+      "DRK": 24,
+      "RNG": 24,
+      "RUN": 24
+    },
+    "hits": 1,
+    "description": "[[Choke]]s target. Chance of choking varies with [[TP]]."
+  },
+  "Mistral Axe": {
+    "name": "Mistral Axe",
+    "type": "Axe",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      4,
+      10.5,
+      13.625
+    ],
+    "wsc": {
+      "str": 0.5
+    },
+    "sc": [
+      "Fusion"
+    ],
+    "reqSkill": 225,
+    "jobs": {
+      "WAR": 99,
+      "BST": 99,
+      "DRK": 99,
+      "RUNviaBerylliumPick/BerylliumPick+1": 99
+    },
+    "hits": 1,
+    "description": "Delivers a single-hit attack. Damage varies with [[TP]]."
+  },
+  "Onslaught": {
+    "name": "Onslaught",
+    "type": "Axe",
+    "class": "Physical",
+    "tpMod": "Aftermath<br />(+10% Attack)",
+    "ftp": [
+      20,
+      40,
+      60
+    ],
+    "wsc": {
+      "dex": 0.8
+    },
+    "sc": [
+      "Darkness",
+      "Gravitation"
+    ],
+    "jobs": {
+      "BSTviaOgreKillerorGuttler": 75,
+      "BSTviaCleofunAxe": 85
+    },
+    "hits": 1,
+    "description": "Lowers target Accuracy. [[Ogre Killer]]/[[Guttler]]: Additional Effect: temporarily improves [[Attack]]"
+  },
+  "Primal Rend": {
+    "name": "Primal Rend",
+    "type": "Axe",
+    "class": "Magical",
+    "element": "{{light}}",
+    "tpMod": "fTP",
+    "ftp": [
+      3.0625,
+      5.8359375,
+      7.5625
+    ],
+    "wsc": {
+      "chr": 0.6,
+      "dex": 0.3
+    },
+    "sc": [
+      "Gravitation",
+      "Reverberation"
+    ],
+    "quest": "Unlocking a Myth (Beastmaster)",
+    "jobs": {
+      "BST": 75
+    },
+    "hits": 1,
+    "description": "Deals [[light]] elemental damage.  Damage varies with [[TP]]."
+  },
+  "Raging Axe": {
+    "name": "Raging Axe",
+    "type": "Axe",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      3,
+      6
+    ],
+    "wsc": {
+      "str": 0.6
+    },
+    "sc": [
+      "Detonation",
+      "Impaction"
+    ],
+    "reqSkill": 5,
+    "jobs": {
+      "WAR": 1,
+      "DRK": 1,
+      "BST": 1,
+      "RNG": 1,
+      "RUN": 1
+    },
+    "hits": 1,
+    "description": "Delivers a two-hit attack. Damage varies with [[TP]]."
+  },
+  "Rampage": {
+    "name": "Rampage",
+    "type": "Axe",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [
+      0,
+      20,
+      40
+    ],
+    "wsc": {
+      "str": 0.5
+    },
+    "sc": [
+      "Scission"
+    ],
+    "reqSkill": 175,
+    "jobs": {
+      "WAR": 55,
+      "BST": 55,
+      "DRK": 56,
+      "RNG": 56,
+      "RUN": 56
+    },
+    "hits": 1,
+    "description": "Delivers a five-hit attack.  Chance of critical varies with [[TP]]."
+  },
+  "Ruinator": {
+    "name": "Ruinator",
+    "type": "Axe",
+    "class": "Physical",
+    "tpMod": "Accuracy",
+    "ftp": [],
+    "wsc": {
+      "str": 0.85
+    },
+    "sc": [
+      "Darkness",
+      "Distortion",
+      "Detonation"
+    ],
+    "reqSkill": 357,
+    "quest": "Martial Mastery",
+    "jobs": {
+      "WAR": 91,
+      "BST": 91,
+      "DRK": 95,
+      "RNG": 95,
+      "RUN": 95
+    },
+    "hits": 1,
+    "description": "Delivers a fourfold attack. Accuracy varies with TP."
+  },
+  "Smash Axe": {
+    "name": "Smash Axe",
+    "type": "Axe",
+    "class": "Physical",
+    "tpMod": "Effect accuracy",
+    "ftp": [],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Induration",
+      "Reverberation"
+    ],
+    "reqSkill": 40,
+    "jobs": {
+      "WAR": 13,
+      "BST": 13,
+      "DRK": 14,
+      "RNG": 14,
+      "RUN": 14
+    },
+    "hits": 1,
+    "description": "[[Stun]]s enemy.  Chance of [[stun]] varies with [[TP]]."
+  },
+  "Spinning Axe": {
+    "name": "Spinning Axe",
+    "type": "Axe",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      2,
+      4,
+      6.5
+    ],
+    "wsc": {
+      "str": 0.6
+    },
+    "sc": [
+      "Liquefaction",
+      "Scission",
+      "Impaction"
+    ],
+    "reqSkill": 150,
+    "jobs": {
+      "WAR": 49,
+      "BST": 49,
+      "DRK": 51,
+      "RNG": 51,
+      "RUN": 51
+    },
+    "hits": 1,
+    "description": "Double-hit attack. Damage varies with [[TP]]."
+  },
+  "Bloody Quarrel": {
+    "name": "Bloody Quarrel",
+    "type": "Marksmanship",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "{{question}}",
+      "{{question}}",
+      "{{question}}"
+    ],
+    "jobs": {
+      "HajaZhwan": 73
+    },
+    "hits": 1,
+    "description": "{{question}}"
+  },
+  "Bloody Tomahawk": {
+    "name": "Bloody Tomahawk",
+    "type": "Axe",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "{{question}}",
+      "{{question}}",
+      "{{question}}"
+    ],
+    "jobs": {
+      "StrikingBull": 73
+    },
+    "hits": 1,
+    "description": "{{question}}"
+  },
+  "Black Halo": {
+    "name": "Black Halo",
+    "type": "Club",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      3,
+      7.25,
+      9.75
+    ],
+    "wsc": {
+      "mnd": 0.7,
+      "str": 0.3
+    },
+    "sc": [
+      "Fragmentation",
+      "Compression"
+    ],
+    "reqSkill": 230,
+    "quest": "Orastery Woes",
+    "jobs": {
+      "PLD": 67,
+      "WHM": 99,
+      "GEO": 99,
+      "WAR": 73,
+      "BLU": 99,
+      "MNK": 75,
+      "BLM": 99,
+      "SMN": 99,
+      "RDM": 99,
+      "SCHviaKajaRod/Maxentiusinthemainhandonly": 99
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack. Damage varies with [[TP]]."
+  },
+  "Brainshaker": {
+    "name": "Brainshaker",
+    "type": "Club",
+    "class": "Physical",
+    "tpMod": "Effect accuracy",
+    "ftp": [],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Reverberation"
+    ],
+    "reqSkill": 70,
+    "jobs": {
+      "PLD": 23,
+      "WAR": 24,
+      "WHM": 24,
+      "BLU": 24,
+      "GEO": 24,
+      "MNK": 25,
+      "BLM": 25,
+      "DRK": 25,
+      "SMN": 25,
+      "SCH": 25,
+      "RUN": 25,
+      "RDM": 26,
+      "BST": 26,
+      "BRD": 26,
+      "PUP": 26,
+      "THF": 28,
+      "SAM": 28,
+      "NIN": 28,
+      "DRG": 28
+    },
+    "hits": 1,
+    "description": "Stuns target.  Chance of stunning varies with [[TP]]."
+  },
+  "Dagan": {
+    "name": "Dagan",
+    "type": "Club",
+    "class": "None",
+    "tpMod": "HP/MP Restored",
+    "ftp": [
+      15,
+      22,
+      35
+    ],
+    "wsc": {},
+    "sc": [],
+    "quest": "Kupofried's Weapon Skill Moogle Magic",
+    "jobs": {
+      "WHMviaGambanteinn": 85,
+      "CannedeCombat": 85,
+      "CannedeCombat+1": 85
+    },
+    "hits": 1,
+    "description": "Restores [[HP]] and [[MP]]. Amount restored varies with [[TP]]."
+  },
+  "Dagda": {
+    "name": "Dagda",
+    "type": "Club",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Transfixion",
+      "Scission",
+      "Gravitation"
+    ],
+    "jobs": {
+      "WHMandGEOviaLorgMor(Level119)orhigher": 99
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack. Damage varies with TP."
+  },
+  "Exudation": {
+    "name": "Exudation",
+    "type": "Club",
+    "class": "Physical",
+    "tpMod": "Attack",
+    "ftp": [
+      50,
+      262.5,
+      375
+    ],
+    "wsc": {
+      "int": 0.5,
+      "mnd": 0.5
+    },
+    "sc": [
+      "Darkness",
+      "Fragmentation"
+    ],
+    "quest": "Geomancerrific",
+    "jobs": {
+      "GEO": 99
+    },
+    "hits": 1,
+    "description": "Attack varies with [[TP]]. [[Idris]]: Aftermath effect varies with [[TP]]."
+  },
+  "Flash Nova": {
+    "name": "Flash Nova",
+    "type": "Club",
+    "class": "Magical",
+    "element": "{{light}}",
+    "tpMod": "Effect accuracy",
+    "ftp": [],
+    "wsc": {
+      "str": 0.5,
+      "mnd": 0.5
+    },
+    "sc": [
+      "Reverberation",
+      "Induration"
+    ],
+    "reqSkill": 290,
+    "jobs": {
+      "PLD": 80,
+      "WHM": 82,
+      "GEO": 82,
+      "WAR": 85,
+      "BLU": 85,
+      "MNK": 86,
+      "BLM": 86,
+      "SMN": 86,
+      "SCH": 86,
+      "RUN": 86,
+      "DRK": 88,
+      "RDM": 92,
+      "BST": 92,
+      "BRD": 92,
+      "PUP": 92,
+      "THF": 97,
+      "RNG": 97,
+      "SAM": 97,
+      "NIN": 97,
+      "DRG": 97
+    },
+    "hits": 1,
+    "description": "Delivers light elemental damage. Additional effect: [[Flash]]. Chance of effect varies with TP."
+  },
+  "Hexa Strike": {
+    "name": "Hexa Strike",
+    "type": "Club",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [],
+    "wsc": {
+      "str": 0.3,
+      "mnd": 0.3
+    },
+    "sc": [
+      "Fusion"
+    ],
+    "reqSkill": 220,
+    "jobs": {
+      "WHM": 99,
+      "GEO": 99,
+      "WAR": 99,
+      "PLDviaBerylliumMace/BerylliumMace+1": 99
+    },
+    "hits": 1,
+    "description": "Delivers a sixfold attack. Critical hit chance varies with [[TP]]."
+  },
+  "Judgment": {
+    "name": "Judgment",
+    "type": "Club",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      3.5,
+      8.75,
+      12
+    ],
+    "wsc": {
+      "str": 0.5,
+      "mnd": 0.5
+    },
+    "sc": [
+      "Impaction"
+    ],
+    "reqSkill": 200,
+    "jobs": {
+      "PLD": 60,
+      "WAR": 62,
+      "WHM": 62,
+      "BLU": 62,
+      "GEO": 62,
+      "MNK": 64,
+      "BLM": 64,
+      "SMN": 64,
+      "SCH": 64,
+      "RUN": 64,
+      "DRK": 65,
+      "RDM": 70,
+      "BST": 70,
+      "BRD": 70,
+      "PUP": 70,
+      "THF": 75,
+      "RNG": 75,
+      "SAM": 75,
+      "NIN": 75,
+      "DRG": 75
+    },
+    "hits": 1,
+    "description": "Delivers a single hit attack. Damage varies with [[TP]]."
+  },
+  "Justicebreaker": {
+    "name": "Justicebreaker",
+    "type": "Club",
+    "class": "Physical",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Darkness",
+      "Gravitation"
+    ],
+    "jobs": {
+      "BGWiki:Trusts#Naja_Salaheem_(UC)": 70
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack that reduces defense and magic defense."
+  },
+  "Moonlight": {
+    "name": "Moonlight",
+    "type": "Club",
+    "class": "None",
+    "tpMod": "MP Multiplier",
+    "ftp": [
+      2.25,
+      3.5,
+      4.75
+    ],
+    "wsc": {},
+    "sc": [],
+    "reqSkill": 125,
+    "jobs": {
+      "PLD": 41,
+      "WAR": 43,
+      "WHM": 43,
+      "BLU": 43,
+      "GEO": 43,
+      "MNK": 44,
+      "BLM": 44,
+      "DRK": 44,
+      "SMN": 44,
+      "SCH": 44,
+      "RUN": 44,
+      "RDM": 46,
+      "BST": 46,
+      "BRD": 46,
+      "PUP": 46,
+      "THF": 50,
+      "RNG": 50,
+      "SAM": 50,
+      "NIN": 50,
+      "DRG": 50
+    },
+    "hits": 1,
+    "description": "Restores [[MP]] for party members in range.  Amount varies with [[TP]]."
+  },
+  "Mystic Boon": {
+    "name": "Mystic Boon",
+    "type": "Club",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      2.5,
+      4,
+      7
+    ],
+    "wsc": {
+      "mnd": 0.7,
+      "str": 0.3
+    },
+    "sc": [],
+    "quest": "Unlocking a Myth (White Mage)",
+    "jobs": {
+      "WHM": 75
+    },
+    "hits": 1,
+    "description": "Converts damage dealt to own [[MP]]. Damage varies with [[TP]]."
+  },
+  "Nott": {
+    "name": "Nott",
+    "type": "Club",
+    "class": "None",
+    "tpMod": "HP/MP Restored",
+    "ftp": [
+      15,
+      22,
+      35
+    ],
+    "wsc": {},
+    "sc": [],
+    "jobs": {
+      "Apururu(UC)": 50,
+      "NajaSalaheem(UC)": 50,
+      "Pieuje(UC)": 50,
+      "andSylvie(UC)": 50
+    },
+    "hits": 1,
+    "description": "Restores [[HP]] and [[MP]]. Amount restored varies with [[TP]]."
+  },
+  "Peacebreaker": {
+    "name": "Peacebreaker",
+    "type": "Club",
+    "class": "Physical",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Distortion",
+      "Reverberation"
+    ],
+    "jobs": {
+      "BGWiki:Trusts#Naja_Salaheem_(UC)": 5,
+      "BGWiki:Trusts#Naja_Salaheem": null
+    },
+    "hits": 1,
+    "description": "Delivers a attack that reduces defense and magic defense."
+  },
+  "Pocket Sand": {
+    "name": "Pocket Sand",
+    "type": "Club",
+    "class": "Magical",
+    "element": "{{dark}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Conal dark damage and blind."
+  },
+  "Randgrith": {
+    "name": "Randgrith",
+    "type": "Club",
+    "class": "Physical",
+    "tpMod": "Aftermath<br />(+20 Accuracy)",
+    "ftp": [
+      20,
+      40,
+      60
+    ],
+    "wsc": {
+      "str": 0.4,
+      "mnd": 0.4
+    },
+    "sc": [
+      "Light",
+      "Fragmentation"
+    ],
+    "jobs": {
+      "WHMviaGullintaniorMjollnir": 75,
+      "WHM": 85,
+      "GEO": 85,
+      "orSCHviaMolvaMaul": 85
+    },
+    "hits": 1,
+    "description": "Lowers target's [[evasion]] [[Gullintani]]/[[Mjollnir]]"
+  },
+  "Realmrazer": {
+    "name": "Realmrazer",
+    "type": "Club",
+    "class": "Physical",
+    "tpMod": "Accuracy",
+    "ftp": [],
+    "wsc": {
+      "mnd": 0.85
+    },
+    "sc": [
+      "Light",
+      "Fusion",
+      "Impaction"
+    ],
+    "reqSkill": 357,
+    "quest": "Martial Mastery",
+    "jobs": {
+      "PLD": 92,
+      "WHM": 93,
+      "GEO": 93,
+      "WAR": 95,
+      "BLU": 95,
+      "MNK": 96,
+      "BLM": 96,
+      "SMN": 96,
+      "RUN": 96
+    },
+    "hits": 1,
+    "description": "Delivers a sevenfold attack. [[Accuracy]] varies with [[TP]]."
+  },
+  "Scouring Bubbles": {
+    "name": "Scouring Bubbles",
+    "type": "Club",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Darkness",
+      "Distortion"
+    ],
+    "jobs": {
+      ":Category:Trust": 50
+    },
+    "hits": 1,
+    "description": "Deals damage in a fan-shaped area in front of the user. Additional effect: [[Dispel]]."
+  },
+  "Seraph Strike": {
+    "name": "Seraph Strike",
+    "type": "Club",
+    "class": "Magical",
+    "element": "{{light}}",
+    "tpMod": "fTP",
+    "ftp": [
+      2.125,
+      3.675,
+      6.125
+    ],
+    "wsc": {
+      "str": 0.4,
+      "mnd": 0.4
+    },
+    "sc": [
+      "Impaction"
+    ],
+    "reqSkill": 40,
+    "jobs": {
+      "PLD": 13,
+      "WAR": 14,
+      "MNK": 14,
+      "WHM": 14,
+      "BLM": 14,
+      "DRK": 14,
+      "SMN": 14,
+      "BLU": 14,
+      "SCH": 14,
+      "GEO": 14,
+      "RUN": 14,
+      "RDM": 15,
+      "BST": 15,
+      "BRD": 15,
+      "PUP": 15,
+      "THF": 16,
+      "RNG": 16,
+      "SAM": 16,
+      "NIN": 16,
+      "DRG": 16
+    },
+    "hits": 1,
+    "description": "Deals light elemental damage. Damage varies with [[TP]]."
+  },
+  "Sharp Eye": {
+    "name": "Sharp Eye",
+    "type": "Club",
+    "class": "Magical",
+    "ftp": [],
+    "wsc": {},
+    "sc": [],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Inflicts Gravity on targets in front of Chacharoon."
+  },
+  "Shining Strike": {
+    "name": "Shining Strike",
+    "type": "Club",
+    "class": "Magical",
+    "element": "{{light}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1.625,
+      3,
+      4.625
+    ],
+    "wsc": {
+      "str": 0.4,
+      "mnd": 0.4
+    },
+    "sc": [
+      "Impaction"
+    ],
+    "reqSkill": 5,
+    "jobs": {
+      "PLD": 1,
+      "WAR": 3,
+      "MNK": 3,
+      "WHM": 3,
+      "BLM": 3,
+      "DRK": 3,
+      "SMN": 3,
+      "BLU": 3,
+      "SCH": 3,
+      "RUN": 3,
+      "GEO": 3,
+      "RDM": 4,
+      "THF": 4,
+      "BST": 4,
+      "BRD": 4,
+      "SAM": 4,
+      "NIN": 4,
+      "DRG": 4,
+      "PUP": 4
+    },
+    "hits": 1,
+    "description": "Deals light elemental damage. Damage varies with [[TP]]."
+  },
+  "Skullbreaker": {
+    "name": "Skullbreaker",
+    "type": "Club",
+    "class": "Physical",
+    "tpMod": "Effect accuracy",
+    "ftp": [],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Induration",
+      "Reverberation"
+    ],
+    "reqSkill": 150,
+    "jobs": {
+      "PLD": 49,
+      "WAR": 51,
+      "WHM": 51,
+      "BLU": 51,
+      "GEO": 51,
+      "MNK": 52,
+      "BLM": 52,
+      "DRK": 52,
+      "SMN": 52,
+      "SCH": 52,
+      "RUN": 52,
+      "RDM": 53,
+      "BST": 53,
+      "BRD": 53,
+      "PUP": 53,
+      "THF": 56,
+      "SAM": 56,
+      "NIN": 56,
+      "DRG": 56
+    },
+    "hits": 1,
+    "description": "Lowers target's [[INT]].  Chance of lowering INT varies with [[TP]]."
+  },
+  "Starlight": {
+    "name": "Starlight",
+    "type": "Club",
+    "class": "None",
+    "tpMod": "MP Multiplier",
+    "ftp": [
+      2,
+      3,
+      4
+    ],
+    "wsc": {},
+    "sc": [],
+    "reqSkill": 100,
+    "jobs": {
+      "PLD": 33,
+      "WAR": 34,
+      "WHM": 34,
+      "BLU": 34,
+      "GEO": 34,
+      "MNK": 35,
+      "BLM": 35,
+      "DRK": 35,
+      "SMN": 35,
+      "SCH": 35,
+      "RUN": 35,
+      "RDM": 37,
+      "BST": 37,
+      "BRD": 37,
+      "PUP": 37,
+      "THF": 40,
+      "SAM": 40,
+      "NIN": 40,
+      "DRG": 40
+    },
+    "hits": 1,
+    "description": "Restores [[MP]].  Amount restored varies with [[TP]]."
+  },
+  "Tripe Gripe": {
+    "name": "Tripe Gripe",
+    "type": "Club",
+    "class": "Magical",
+    "ftp": [],
+    "wsc": {},
+    "sc": [],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Inflicts Amnesia and [[Attack Boost]] on the target."
+  },
+  "True Strike": {
+    "name": "True Strike",
+    "type": "Club",
+    "class": "Physical",
+    "tpMod": "Accuracy",
+    "ftp": [],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Detonation",
+      "Impaction"
+    ],
+    "reqSkill": 175,
+    "jobs": {
+      "PLD": 55,
+      "WAR": 56,
+      "WHM": 56,
+      "BLU": 56,
+      "GEO": 56,
+      "MNK": 57,
+      "BLM": 57,
+      "DRK": 57,
+      "SMN": 57,
+      "SCH": 57,
+      "RUN": 57,
+      "RDM": 59,
+      "BST": 59,
+      "BRD": 59,
+      "PUP": 59,
+      "THF": 63,
+      "SAM": 63,
+      "NIN": 63,
+      "DRG": 63
+    },
+    "hits": 1,
+    "description": "Deals critical damage.  Accuracy varies with [[TP]]."
+  },
+  "Cobra Clamp": {
+    "name": "Cobra Clamp",
+    "type": "Sword",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Fragmentation",
+      "Distortion"
+    ],
+    "jobs": {
+      "RomaaMihgo(S)": 73
+    },
+    "hits": 1,
+    "description": "Deals area damage and stuns target."
+  },
+  "Cruel Riposte": {
+    "name": "Cruel Riposte",
+    "type": "Sword",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "{{question}}",
+      "{{question}}",
+      "{{question}}"
+    ],
+    "jobs": {
+      "MieuseloirBEnchelles": 73
+    },
+    "hits": 1,
+    "description": "{{question}}"
+  },
+  "Aeolian Edge": {
+    "name": "Aeolian Edge",
+    "type": "Dagger",
+    "class": "Magical",
+    "element": "{{wind}}",
+    "tpMod": "fTP",
+    "ftp": [
+      2,
+      3,
+      4.5
+    ],
+    "wsc": {
+      "dex": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Scission",
+      "Detonation",
+      "Impaction"
+    ],
+    "reqSkill": 290,
+    "jobs": {
+      "THF": 78,
+      "DNC": 78,
+      "COR": 82,
+      "RDM": 83,
+      "WAR": 85,
+      "BRD": 85,
+      "RNG": 85,
+      "BST": 86,
+      "NIN": 86,
+      "DRK": 87,
+      "PLD": 88,
+      "PUP": 88,
+      "GEO": 88,
+      "BLM": 92,
+      "SCH": 92,
+      "SAM": 97,
+      "DRG": 97,
+      "SMN": 97
+    },
+    "hits": 1,
+    "description": "Delivers an area attack that deals wind elemental damage. Damage varies with [[TP]]."
+  },
+  "Cyclone": {
+    "name": "Cyclone",
+    "type": "Dagger",
+    "class": "Magical",
+    "element": "{{wind}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      2.375,
+      3.75
+    ],
+    "wsc": {
+      "dex": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Detonation",
+      "Impaction"
+    ],
+    "reqSkill": 125,
+    "jobs": {
+      "THF": 41,
+      "WAR": 43,
+      "RDM": 43,
+      "BRD": 43,
+      "RNG": 43,
+      "COR": 43,
+      "DNC": 43,
+      "PLD": 44,
+      "DRK": 44,
+      "BST": 44,
+      "NIN": 44,
+      "PUP": 44,
+      "GEO": 44,
+      "BLM": 46,
+      "SCH": 46,
+      "SAM": 50,
+      "DRG": 50,
+      "SMN": 50
+    },
+    "hits": 1,
+    "description": "Delivers an area of effect [[Wind"
+  },
+  "Dancing Edge": {
+    "name": "Dancing Edge",
+    "type": "Dagger",
+    "class": "Physical",
+    "tpMod": "Accuracy",
+    "ftp": [],
+    "wsc": {
+      "dex": 0.4,
+      "chr": 0.4
+    },
+    "sc": [
+      "Scission",
+      "Detonation"
+    ],
+    "reqSkill": 200,
+    "jobs": {
+      "THF": 60,
+      "DNC": 62
+    },
+    "hits": 1,
+    "description": "Delivers a fivefold attack. [[Accuracy]] varies with [[TP]]."
+  },
+  "Debonair Rush": {
+    "name": "Debonair Rush",
+    "type": "Dagger",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Scission",
+      "Detonation"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Deals damage."
+  },
+  "Energy Drain": {
+    "name": "Energy Drain",
+    "type": "Dagger",
+    "class": "Magical",
+    "element": "{{dark}}",
+    "tpMod": "MP Multiplier",
+    "ftp": [
+      1.25,
+      2.5,
+      4.125
+    ],
+    "wsc": {
+      "mnd": 1
+    },
+    "sc": [],
+    "reqSkill": 175,
+    "jobs": {
+      "THF": 55,
+      "WAR": 56,
+      "RDM": 56,
+      "BRD": 56,
+      "RNG": 56,
+      "COR": 56,
+      "DNC": 56,
+      "PLD": 57,
+      "DRK": 57,
+      "BST": 57,
+      "NIN": 57,
+      "PUP": 57,
+      "GEO": 57,
+      "BLM": 59,
+      "SCH": 59,
+      "SAM": 63,
+      "DRG": 63,
+      "SMN": 63
+    },
+    "hits": 1,
+    "description": "Steals enemy's [[MP]]. Amount stolen varies with [[TP]]."
+  },
+  "Energy Steal": {
+    "name": "Energy Steal",
+    "type": "Dagger",
+    "class": "Magical",
+    "element": "{{dark}}",
+    "tpMod": "MP Multiplier",
+    "ftp": [
+      1,
+      2.1,
+      3.4
+    ],
+    "wsc": {
+      "mnd": 1
+    },
+    "sc": [],
+    "reqSkill": 150,
+    "jobs": {
+      "THF": 49,
+      "WAR": 51,
+      "RDM": 51,
+      "BRD": 51,
+      "RNG": 51,
+      "COR": 51,
+      "DNC": 51,
+      "PLD": 52,
+      "DRK": 52,
+      "BST": 52,
+      "NIN": 52,
+      "PUP": 52,
+      "GEO": 52,
+      "BLM": 53,
+      "SAM": 56,
+      "DRG": 56,
+      "SMN": 56
+    },
+    "hits": 1,
+    "description": "Steals enemy's [[MP]]. Amount stolen varies with [[TP]]."
+  },
+  "Evisceration": {
+    "name": "Evisceration",
+    "type": "Dagger",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [
+      10,
+      25,
+      50
+    ],
+    "wsc": {
+      "dex": 0.5
+    },
+    "sc": [
+      "Gravitation",
+      "Transfixion"
+    ],
+    "reqSkill": 230,
+    "quest": "Cloak and Dagger",
+    "jobs": {
+      "THF": 99,
+      "COR": 99,
+      "DNC": 99,
+      "RDM": 99,
+      "WAR": 73,
+      "BRD": 99,
+      "RNG": 99,
+      "BST": 99,
+      "NIN": 99,
+      "PUPviaKajaKnife/Tauretinthemainhandonly": 99
+    },
+    "hits": 5,
+    "description": "Delivers an attack comprised of five hits. Critical hit rate varies with [[TP]]."
+  },
+  "Exenterator": {
+    "name": "Exenterator",
+    "type": "Dagger",
+    "class": "Physical",
+    "tpMod": "Effect duration",
+    "ftp": [
+      90,
+      180,
+      270
+    ],
+    "wsc": {
+      "agi": 0.85
+    },
+    "sc": [
+      "Light",
+      "Fragmentation",
+      "Scission"
+    ],
+    "reqSkill": 357,
+    "quest": "Martial Mastery",
+    "jobs": {
+      "THF": 91,
+      "COR": 93,
+      "DNC": 93,
+      "RDM": 94,
+      "WAR": 95,
+      "BRD": 95,
+      "RNG": 95,
+      "BST": 96,
+      "NIN": 96
+    },
+    "hits": 1,
+    "description": "Delivers a fourfold attack that decreases target's accuracy. Duration of effect varies with [[TP]]."
+  },
+  "Gust Slash": {
+    "name": "Gust Slash",
+    "type": "Dagger",
+    "class": "Magical",
+    "element": "{{wind}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      2,
+      3
+    ],
+    "wsc": {
+      "dex": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Detonation"
+    ],
+    "reqSkill": 40,
+    "jobs": {
+      "THF": 13,
+      "WAR": 14,
+      "RDM": 14,
+      "PLD": 14,
+      "DRK": 14,
+      "BST": 14,
+      "BRD": 14,
+      "RNG": 14,
+      "NIN": 14,
+      "COR": 14,
+      "PUP": 14,
+      "DNC": 14,
+      "GEO": 14,
+      "BLM": 15,
+      "SAM": 16,
+      "DRG": 16,
+      "SMN": 16
+    },
+    "hits": 1,
+    "description": "Deals [[Wind"
+  },
+  "Inspirit": {
+    "name": "Inspirit",
+    "type": "Dagger",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Recovers HP and MP and removes status ailments for party members in range."
+  },
+  "Iridal Pierce": {
+    "name": "Iridal Pierce",
+    "type": "Dagger",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light",
+      "Fragmentation"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Deals area damage."
+  },
+  "King Cobra Clamp": {
+    "name": "King Cobra Clamp",
+    "type": "Dagger",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Fragmentation",
+      "Distortion"
+    ],
+    "jobs": {
+      "NanaaMihgo": null
+    },
+    "hits": 1,
+    "description": "Deals area damage and stuns target."
+  },
+  "Lunar Revolution": {
+    "name": "Lunar Revolution",
+    "type": "Dagger",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Gravitation",
+      "Reverberation"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Deals area damage."
+  },
+  "Mandalic Stab": {
+    "name": "Mandalic Stab",
+    "type": "Dagger",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      4,
+      6.09,
+      8.5
+    ],
+    "wsc": {
+      "dex": 0.6
+    },
+    "sc": [
+      "Fusion",
+      "Compression"
+    ],
+    "quest": "Unlocking a Myth (Thief)",
+    "jobs": {
+      "THF": 75
+    },
+    "hits": 1,
+    "description": "Damage varies with [[TP]]."
+  },
+  "Mercy Stroke": {
+    "name": "Mercy Stroke",
+    "type": "Dagger",
+    "class": "Physical",
+    "tpMod": "Aftermath<br />(+5% Critical Hit Rate)",
+    "ftp": [
+      20,
+      40,
+      60
+    ],
+    "wsc": {
+      "str": 0.8
+    },
+    "sc": [
+      "Darkness",
+      "Gravitation"
+    ],
+    "jobs": {
+      "RDM": 85,
+      "THF": 85,
+      "BRDviaBatardeauorMandau": 75,
+      "BRD": 85,
+      "DNCviaClementSkean": 85
+    },
+    "hits": 1,
+    "description": "[[Batardeau]]/[[Mandau]]: Temporarily improves critical hit rate."
+  },
+  "Mordant Rime": {
+    "name": "Mordant Rime",
+    "type": "Dagger",
+    "class": "Physical",
+    "tpMod": "Effect accuracy",
+    "ftp": [],
+    "wsc": {
+      "chr": 0.7,
+      "dex": 0.3
+    },
+    "sc": [
+      "Fragmentation",
+      "Distortion"
+    ],
+    "quest": "Unlocking a Myth (Bard)",
+    "jobs": {
+      "BRD": 75
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack that decreases target's movement speed. Chance of decreases movement speed varies with [[TP]]."
+  },
+  "Pyrrhic Kleos": {
+    "name": "Pyrrhic Kleos",
+    "type": "Dagger",
+    "class": "Physical",
+    "tpMod": "Effect duration",
+    "ftp": [
+      60,
+      120,
+      180
+    ],
+    "wsc": {
+      "str": 0.4,
+      "dex": 0.4
+    },
+    "sc": [
+      "Distortion",
+      "Scission"
+    ],
+    "quest": "Unlocking a Myth (Dancer)",
+    "jobs": {
+      "DNC": 75
+    },
+    "hits": 1,
+    "description": "Delivers a fourfold attack that lowers target's evasion. Duration of effect varies with [[TP]]."
+  },
+  "Rudra's Storm": {
+    "name": "Rudra's Storm",
+    "type": "Dagger",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      5,
+      10.19,
+      13
+    ],
+    "wsc": {
+      "dex": 0.8
+    },
+    "sc": [
+      "Darkness",
+      "Distortion"
+    ],
+    "quest": "Kupofried's Weapon Skill Moogle Magic",
+    "jobs": {
+      "THF": 85,
+      "BRD": 85,
+      "DNCviaTwashtar": 85,
+      "Daka": 85,
+      "Daka+1": 85
+    },
+    "hits": 1,
+    "description": "Deals quintuple damage and weighs target down. Damage varies with TP."
+  },
+  "Ruthless Stroke": {
+    "name": "Ruthless Stroke",
+    "type": "Dagger",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      5.375,
+      14,
+      23
+    ],
+    "wsc": {
+      "dex": 0.25,
+      "agi": 0.25
+    },
+    "sc": [
+      "Liquefaction",
+      "Impaction",
+      "Fragmentation"
+    ],
+    "jobs": {
+      "RDM": 99,
+      "THF": 99,
+      "BRDandDNCviaMpuGandring(Level119)orhigher": 99
+    },
+    "hits": 1,
+    "description": "Delivers a fourfold attack. Damage varies with TP."
+  },
+  "Sarva's Storm": {
+    "name": "Sarva's Storm",
+    "type": "Dagger",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      5,
+      10.19,
+      13
+    ],
+    "wsc": {
+      "dex": 0.8
+    },
+    "sc": [
+      "Darkness",
+      "Distortion"
+    ],
+    "jobs": {
+      "Aldo(UC)andJakohWahcondalo(UC)": null
+    },
+    "hits": 1,
+    "description": "Deals quintuple damage and weighs target down. Damage varies with TP."
+  },
+  "Shadowstitch": {
+    "name": "Shadowstitch",
+    "type": "Dagger",
+    "class": "Physical",
+    "tpMod": "Effect accuracy",
+    "ftp": [],
+    "wsc": {
+      "chr": 1
+    },
+    "sc": [
+      "Reverberation"
+    ],
+    "reqSkill": 70,
+    "jobs": {
+      "THF": 23,
+      "WAR": 24,
+      "RDM": 24,
+      "BRD": 24,
+      "RNG": 24,
+      "COR": 24,
+      "DNC": 24,
+      "PLD": 25,
+      "DRK": 25,
+      "BST": 25,
+      "NIN": 25,
+      "PUP": 25,
+      "GEO": 25,
+      "BLM": 26,
+      "SAM": 28,
+      "DRG": 28,
+      "SMN": 28
+    },
+    "hits": 1,
+    "description": "[[Bind (Status)"
+  },
+  "Shark Bite": {
+    "name": "Shark Bite",
+    "type": "Dagger",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      4.5,
+      6.8,
+      8.5
+    ],
+    "wsc": {
+      "dex": 0.4,
+      "agi": 0.4
+    },
+    "sc": [
+      "Fragmentation"
+    ],
+    "reqSkill": 225,
+    "jobs": {
+      "THF": 66,
+      "DNC": 68,
+      "BLM": 99,
+      "SMN": 99,
+      "SCH": 99,
+      "GEOviaBerylliumKris/BerylliumKris+1": 99
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack. Damage varies with [[TP]]."
+  },
+  "Viper Bite": {
+    "name": "Viper Bite",
+    "type": "Dagger",
+    "class": "Physical",
+    "tpMod": "Effect duration",
+    "ftp": [
+      90,
+      120,
+      180
+    ],
+    "wsc": {
+      "dex": 1
+    },
+    "sc": [
+      "Scission"
+    ],
+    "reqSkill": 100,
+    "jobs": {
+      "THF": 33,
+      "WAR": 34,
+      "RDM": 34,
+      "BRD": 34,
+      "RNG": 34,
+      "COR": 34,
+      "DNC": 34,
+      "PLD": 35,
+      "DRK": 35,
+      "BST": 35,
+      "NIN": 35,
+      "PUP": 35,
+      "GEO": 35,
+      "BLM": 37,
+      "SCH": 37,
+      "SAM": 40,
+      "DRG": 40,
+      "SMN": 40
+    },
+    "hits": 1,
+    "description": "Strikes with twice the attack power. [[Poison"
+  },
+  "Wasp Sting": {
+    "name": "Wasp Sting",
+    "type": "Dagger",
+    "class": "Physical",
+    "tpMod": "Effect duration",
+    "ftp": [
+      90,
+      105,
+      135
+    ],
+    "wsc": {
+      "dex": 1
+    },
+    "sc": [
+      "Scission"
+    ],
+    "reqSkill": 5,
+    "jobs": {
+      "THF": 1,
+      "DNC": 1,
+      "WAR": 3,
+      "RDM": 3,
+      "PLD": 3,
+      "DRK": 3,
+      "BST": 3,
+      "BRD": 3,
+      "RNG": 3,
+      "NIN": 3,
+      "COR": 3,
+      "PUP": 3,
+      "GEO": 3,
+      "BLM": 4,
+      "SAM": 4,
+      "DRG": 4,
+      "SMN": 4
+    },
+    "hits": 1,
+    "description": "[[Poison (Status)"
+  },
+  "Death Knell": {
+    "name": "Death Knell",
+    "type": "Staff",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "{{question}}",
+      "{{question}}",
+      "{{question}}"
+    ],
+    "jobs": {
+      "Zolku-Azolku": 73
+    },
+    "hits": 1,
+    "description": "{{question}}"
+  },
+  "Drakesbane": {
+    "name": "Drakesbane",
+    "type": "Polearm",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [
+      10,
+      25,
+      40
+    ],
+    "wsc": {
+      "str": 0.5
+    },
+    "sc": [
+      "Fusion",
+      "Transfixion"
+    ],
+    "quest": "Unlocking a Myth (Dragoon)",
+    "jobs": {
+      "DRG": 75
+    },
+    "hits": 1,
+    "description": "Delivers a fourfold attack. [[Critical Hit Rate"
+  },
+  "Glory Slash": {
+    "name": "Glory Slash",
+    "type": "Sword",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light",
+      "Fusion"
+    ],
+    "jobs": {
+      "WAR": 73,
+      "RDM": 73,
+      "THF": 73,
+      "PLD": 73,
+      "DRK": 73,
+      "BST": 73,
+      "BRD": 73,
+      "RNG": 73,
+      "SAM": 73,
+      "NIN": 73,
+      "DRG": 73,
+      "BLU": 73,
+      "COR": 73,
+      "DNC": 73,
+      "RUN": 73
+    },
+    "hits": 1,
+    "description": "Delivers an area attack that deals triple damage. Additional effect: Stun. Damage varies with TP."
+  },
+  "12 Blades of Remorse": {
+    "name": "12 Blades of Remorse",
+    "type": "Great Axe",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light",
+      "Distortion"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Single target attack."
+  },
+  "Arduous Decision": {
+    "name": "Arduous Decision",
+    "type": "Great Axe",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Fragmentation",
+      "Compression"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Single target attack. Additional effect: Silence"
+  },
+  "Armor Break": {
+    "name": "Armor Break",
+    "type": "Great Axe",
+    "class": "Physical",
+    "tpMod": "Effect duration",
+    "ftp": [
+      180,
+      360,
+      540
+    ],
+    "wsc": {
+      "str": 0.6,
+      "vit": 0.6
+    },
+    "sc": [
+      "Impaction"
+    ],
+    "reqSkill": 100,
+    "jobs": {
+      "WAR": 33,
+      "DRK": 34,
+      "RUN": 34
+    },
+    "hits": 1,
+    "description": "Lowers enemy's defense. Duration of effect varies with TP."
+  },
+  "Camaraderie of the Crevasse": {
+    "name": "Camaraderie of the Crevasse",
+    "type": "Great Axe",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Detonation",
+      "Impaction"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Single target attack."
+  },
+  "Disaster": {
+    "name": "Disaster",
+    "type": "Great Axe",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [],
+    "wsc": {
+      "str": 0.6,
+      "vit": 0.6
+    },
+    "sc": [
+      "Transfixion",
+      "Scission",
+      "Gravitation"
+    ],
+    "jobs": {
+      "WARviaLaphria(Level119)orhigher": 99
+    },
+    "hits": 1,
+    "description": "Damage varies with TP."
+  },
+  "Fell Cleave": {
+    "name": "Fell Cleave",
+    "type": "Great Axe",
+    "class": "Physical",
+    "tpMod": "Attack Radius",
+    "ftp": [
+      4,
+      4,
+      5
+    ],
+    "wsc": {
+      "str": 0.6
+    },
+    "sc": [
+      "Scission",
+      "Detonation",
+      "Impaction"
+    ],
+    "reqSkill": 300,
+    "jobs": {
+      "WAR": 80,
+      "RUN": 85,
+      "DRK": 86
+    },
+    "hits": 1,
+    "description": "Delivers an area attack. Radius varies with TP."
+  },
+  "Full Break": {
+    "name": "Full Break",
+    "type": "Great Axe",
+    "class": "Physical",
+    "tpMod": "Effect duration",
+    "ftp": [
+      180,
+      360,
+      720
+    ],
+    "wsc": {
+      "str": 0.5,
+      "vit": 0.5
+    },
+    "sc": [
+      "Distortion"
+    ],
+    "reqSkill": 225,
+    "jobs": {
+      "WAR": 99,
+      "DRK": 99,
+      "RUNviaHepatizonAxe/HepatizonAxe+1": 99
+    },
+    "hits": 1,
+    "description": "Lowers target's attack, defense, accuracy and evasion."
+  },
+  "Into the Light": {
+    "name": "Into the Light",
+    "type": "Great Axe",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Fusion",
+      "Impaction"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Single target attack."
+  },
+  "Iron Tempest": {
+    "name": "Iron Tempest",
+    "type": "Great Axe",
+    "class": "Physical",
+    "tpMod": "Attack",
+    "ftp": [
+      0,
+      100,
+      250
+    ],
+    "wsc": {
+      "str": 0.6
+    },
+    "sc": [
+      "Scission"
+    ],
+    "reqSkill": 40,
+    "jobs": {
+      "WAR": 13,
+      "DRK": 14,
+      "RUN": 14
+    },
+    "hits": 1,
+    "description": "Delivers a single-hit attack. Attack varies with TP."
+  },
+  "Keen Edge": {
+    "name": "Keen Edge",
+    "type": "Great Axe",
+    "class": "Physical",
+    "tpMod": "Critical hit rate",
+    "ftp": [],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Compression"
+    ],
+    "reqSkill": 150,
+    "jobs": {
+      "WAR": 49,
+      "DRK": 51,
+      "RUN": 51
+    },
+    "hits": 1,
+    "description": "Delivers a single hit attack. Chance of critical varies with TP."
+  },
+  "King's Justice": {
+    "name": "King's Justice",
+    "type": "Great Axe",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      3,
+      5
+    ],
+    "wsc": {
+      "str": 0.5
+    },
+    "sc": [
+      "Fragmentation",
+      "Scission"
+    ],
+    "quest": "Unlocking a Myth (Warrior)",
+    "jobs": {
+      "WAR": 75
+    },
+    "hits": 1,
+    "description": "Delivers a threefold attack. Damage varies with [[TP]]."
+  },
+  "Metatron Torment": {
+    "name": "Metatron Torment",
+    "type": "Great Axe",
+    "class": "Physical",
+    "tpMod": "Aftermath<br />(-20% Damage Taken)",
+    "ftp": [
+      20,
+      40,
+      60
+    ],
+    "wsc": {
+      "str": 0.8
+    },
+    "sc": [
+      "Light",
+      "Fusion"
+    ],
+    "jobs": {
+      "WARviaAbaddonKillerorBravura": 75,
+      "WARviaBarbarusBhuj": 85
+    },
+    "hits": 1,
+    "description": "Lowers target defense. [[Abaddon Killer]]/[[Bravura]]: Additional Effect: temporarily lowers damage taken from enemies."
+  },
+  "Raging Rush": {
+    "name": "Raging Rush",
+    "type": "Great Axe",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [
+      15,
+      30,
+      50
+    ],
+    "wsc": {
+      "str": 0.5
+    },
+    "sc": [
+      "Induration",
+      "Reverberation"
+    ],
+    "reqSkill": 200,
+    "jobs": {
+      "WAR": 60
+    },
+    "hits": 1,
+    "description": "Delivers a three-hit attack.  Chance of critical hit varies with [[TP]]."
+  },
+  "Shield Break": {
+    "name": "Shield Break",
+    "type": "Great Axe",
+    "class": "Physical",
+    "tpMod": "Effect duration",
+    "ftp": [
+      180,
+      240,
+      300
+    ],
+    "wsc": {
+      "str": 0.6,
+      "vit": 0.6
+    },
+    "sc": [
+      "Impaction"
+    ],
+    "reqSkill": 5,
+    "jobs": {
+      "WAR": 1,
+      "DRK": 3,
+      "RUN": 3
+    },
+    "hits": 1,
+    "description": "Lowers enemy's Evasion. Duration of effect varies by TP."
+  },
+  "Soturi's Fury": {
+    "name": "Soturi's Fury",
+    "type": "Great Axe",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [
+      20,
+      35,
+      55
+    ],
+    "wsc": {
+      "str": 0.8
+    },
+    "sc": [
+      "Light",
+      "Fragmentation"
+    ],
+    "jobs": {
+      "InvincibleShield(UC)": null
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack that slows target. [[Critical Hit Rate"
+  },
+  "Steel Cyclone": {
+    "name": "Steel Cyclone",
+    "type": "Great Axe",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1.5,
+      2.5,
+      4
+    ],
+    "wsc": {
+      "str": 0.6,
+      "vit": 0.6
+    },
+    "sc": [
+      "Distortion",
+      "Detonation"
+    ],
+    "reqSkill": 240,
+    "quest": "The Weight of Your Limits",
+    "jobs": {
+      "WAR": 99,
+      "RUN": 73,
+      "DRK": 99,
+      "RUNviaKajaChopper/Lycurgos": 99
+    },
+    "hits": 1,
+    "description": "Delivers a single attack. Damage varies with [[TP]]."
+  },
+  "Sturmwind": {
+    "name": "Sturmwind",
+    "type": "Great Axe",
+    "class": "Physical",
+    "tpMod": "Attack",
+    "ftp": [
+      0,
+      100,
+      250
+    ],
+    "wsc": {
+      "str": 0.6
+    },
+    "sc": [
+      "Reverberation",
+      "Scission"
+    ],
+    "reqSkill": 70,
+    "jobs": {
+      "WAR": 23,
+      "DRK": 24,
+      "RUN": 24
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack. Attack varies with TP."
+  },
+  "Ukko's Fury": {
+    "name": "Ukko's Fury",
+    "type": "Great Axe",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [
+      20,
+      35,
+      65
+    ],
+    "wsc": {
+      "str": 0.8
+    },
+    "sc": [
+      "Light",
+      "Fragmentation"
+    ],
+    "quest": "Kupofried's Weapon Skill Moogle Magic",
+    "jobs": {
+      "WARviaUkonvasara": 85,
+      "Maschu": 85,
+      "Maschu+1": 85
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack that slows target. [[Critical Hit Rate"
+  },
+  "Upheaval": {
+    "name": "Upheaval",
+    "type": "Great Axe",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      3.5,
+      6.5
+    ],
+    "wsc": {
+      "vit": 0.85
+    },
+    "sc": [
+      "Light",
+      "Fusion",
+      "Compression"
+    ],
+    "reqSkill": 357,
+    "quest": "Martial Mastery",
+    "jobs": {
+      "WAR": 90,
+      "RUN": 94,
+      "DRK": 95
+    },
+    "hits": 1,
+    "description": "Delivers a fourfold attack. Damage varies with [[TP]]."
+  },
+  "Weapon Break": {
+    "name": "Weapon Break",
+    "type": "Great Axe",
+    "class": "Physical",
+    "tpMod": "Effect duration",
+    "ftp": [
+      180,
+      240,
+      300
+    ],
+    "wsc": {
+      "str": 0.6,
+      "vit": 0.6
+    },
+    "sc": [
+      "Impaction"
+    ],
+    "reqSkill": 175,
+    "jobs": {
+      "WAR": 55,
+      "DRK": 56,
+      "RUN": 56
+    },
+    "hits": 1,
+    "description": "Lowers enemy's attack. Duration of effect varies with TP."
+  },
+  "Tachi: Ageha": {
+    "name": "Tachi: Ageha",
+    "type": "Great Katana",
+    "class": "Physical",
+    "tpMod": "Effect accuracy",
+    "ftp": [],
+    "wsc": {
+      "chr": 0.6,
+      "str": 0.4
+    },
+    "sc": [
+      "Compression",
+      "Scission"
+    ],
+    "reqSkill": 300,
+    "jobs": {
+      "SAM": 80,
+      "NIN": 90
+    },
+    "hits": 1,
+    "description": "Lowers target's defense. Chance of lowering target's defense varies with TP."
+  },
+  "Tachi: Enpi": {
+    "name": "Tachi: Enpi",
+    "type": "Great Katana",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      2,
+      4
+    ],
+    "wsc": {
+      "str": 0.6
+    },
+    "sc": [
+      "Transfixion",
+      "Scission"
+    ],
+    "reqSkill": 5,
+    "jobs": {
+      "SAM": 1,
+      "NIN": 3
+    },
+    "hits": 1,
+    "description": "A two-fold attack. Damage varies with [[TP]]."
+  },
+  "Tachi: Fudo": {
+    "name": "Tachi: Fudo",
+    "type": "Great Katana",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      3.75,
+      5.75,
+      8
+    ],
+    "wsc": {
+      "str": 0.8
+    },
+    "sc": [
+      "Light",
+      "Distortion"
+    ],
+    "quest": "Kupofried's Weapon Skill Moogle Magic",
+    "jobs": {
+      "SAMviaMasamune": 85,
+      "Hiradennotachi": 85,
+      "Hiradennotachi+1": 85
+    },
+    "hits": 1,
+    "description": "Deals double damage. Damage varies with [[TP]]."
+  },
+  "Tachi: Gekko": {
+    "name": "Tachi: Gekko",
+    "type": "Great Katana",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1.5625,
+      2.6875,
+      4.125
+    ],
+    "wsc": {
+      "str": 0.75
+    },
+    "sc": [
+      "Distortion",
+      "Reverberation"
+    ],
+    "reqSkill": 225,
+    "jobs": {
+      "SAM": 99,
+      "NINviaBerylliumTachi/BerylliumTachi+1": 99
+    },
+    "hits": 1,
+    "description": "Silences target. Damage varies with [[TP]]."
+  },
+  "Tachi: Goten": {
+    "name": "Tachi: Goten",
+    "type": "Great Katana",
+    "class": "Hybrid",
+    "element": "{{lightning}}",
+    "tpMod": "fTP",
+    "ftp": [
+      0.5,
+      1.5,
+      2.5
+    ],
+    "wsc": {
+      "str": 0.6
+    },
+    "sc": [
+      "Transfixion",
+      "Impaction"
+    ],
+    "reqSkill": 70,
+    "jobs": {
+      "SAM": 23,
+      "NIN": 25
+    },
+    "hits": 1,
+    "description": "Deals lightning elemental damage to an enemy. Damage varies with [[TP]]."
+  },
+  "Tachi: Hobaku": {
+    "name": "Tachi: Hobaku",
+    "type": "Great Katana",
+    "class": "Physical",
+    "tpMod": "Effect accuracy",
+    "ftp": [],
+    "wsc": {
+      "str": 0.6
+    },
+    "sc": [
+      "Induration"
+    ],
+    "reqSkill": 30,
+    "jobs": {
+      "SAM": 9,
+      "NIN": 10
+    },
+    "hits": 1,
+    "description": "[[Stun]]s target. Chance of stunning varies with [[TP]]."
+  },
+  "Tachi: Jinpu": {
+    "name": "Tachi: Jinpu",
+    "type": "Great Katana",
+    "class": "Hybrid",
+    "element": "{{wind}}",
+    "tpMod": "fTP",
+    "ftp": [
+      0.5,
+      1.5,
+      2.5
+    ],
+    "wsc": {
+      "str": 0.3
+    },
+    "sc": [
+      "Scission",
+      "Detonation"
+    ],
+    "reqSkill": 150,
+    "jobs": {
+      "SAM": 49,
+      "NIN": 52
+    },
+    "hits": 1,
+    "description": "Delivers a two-fold attack that deals [[wind]] elemental damage. Damage varies with [[TP]]."
+  },
+  "Tachi: Kagero": {
+    "name": "Tachi: Kagero",
+    "type": "Great Katana",
+    "class": "Hybrid",
+    "element": "{{fire}}",
+    "tpMod": "fTP",
+    "ftp": [
+      0.5,
+      1.5,
+      2.5
+    ],
+    "wsc": {
+      "str": 0.75
+    },
+    "sc": [
+      "Liquefaction"
+    ],
+    "reqSkill": 100,
+    "jobs": {
+      "SAM": 33,
+      "NIN": 35
+    },
+    "hits": 1,
+    "description": "Deals fire elemental damage to an enemy. Damage varies with [[TP]]."
+  },
+  "Tachi: Kaiten": {
+    "name": "Tachi: Kaiten",
+    "type": "Great Katana",
+    "class": "Physical",
+    "tpMod": "Aftermath<br />(+7 Store TP)",
+    "ftp": [
+      20,
+      40,
+      60
+    ],
+    "wsc": {
+      "str": 0.8
+    },
+    "sc": [
+      "Light",
+      "Fragmentation"
+    ],
+    "jobs": {
+      "SAMviaTotsukanotsurugiorAmanomurakumo": 75,
+      "SAMviaAme-no-ohabari": 85,
+      "SAMviaFusenaikyoWhileusingSekkanokiandgivesAftermath": 99
+    },
+    "hits": 1,
+    "description": "[[Totsukanotsurugi]]/[[Amanomurakumo]]: Additional Effect: Temporarily increases [[Store TP"
+  },
+  "Tachi: Kamai": {
+    "name": "Tachi: Kamai",
+    "type": "Great Katana",
+    "class": "Magical",
+    "element": "Wind",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Gravitation",
+      "Scission"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Deals area damage. Additional effect: Defense Down"
+  },
+  "Tachi: Kasha": {
+    "name": "Tachi: Kasha",
+    "type": "Great Katana",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1.5625,
+      2.6875,
+      4.125
+    ],
+    "wsc": {
+      "str": 0.75
+    },
+    "sc": [
+      "Fusion",
+      "Compression"
+    ],
+    "reqSkill": 250,
+    "quest": "The Potential Within",
+    "jobs": {
+      "SAM": 99,
+      "NINviaKajaTachi/Hachimonji": 99
+    },
+    "hits": 1,
+    "description": "Paralyzes target. Damage varies with [[TP]]."
+  },
+  "Tachi: Koki": {
+    "name": "Tachi: Koki",
+    "type": "Great Katana",
+    "class": "Hybrid",
+    "element": "{{light}}",
+    "tpMod": "fTP",
+    "ftp": [
+      0.5,
+      1.5,
+      2.5
+    ],
+    "wsc": {
+      "str": 0.5,
+      "mnd": 0.3
+    },
+    "sc": [
+      "Reverberation",
+      "Impaction"
+    ],
+    "reqSkill": 175,
+    "jobs": {
+      "SAM": 55,
+      "NIN": 57
+    },
+    "hits": 1,
+    "description": "Deals light elemental damage. Damage varies with [[TP]]."
+  },
+  "Tachi: Mudo": {
+    "name": "Tachi: Mudo",
+    "type": "Great Katana",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      3.75,
+      5.75,
+      8
+    ],
+    "wsc": {
+      "str": 0.8
+    },
+    "sc": [
+      "Light",
+      "Distortion"
+    ],
+    "jobs": {
+      "Ayame(UC)": null
+    },
+    "hits": 1,
+    "description": "Deals double damage. Damage varies with [[TP]]."
+  },
+  "Tachi: Mumei": {
+    "name": "Tachi: Mumei",
+    "type": "Great Katana",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      3.66,
+      7.33,
+      11
+    ],
+    "wsc": {
+      "str": 0.5,
+      "dex": 0.5
+    },
+    "sc": [
+      "Detonation",
+      "Compression",
+      "Distortion"
+    ],
+    "jobs": {
+      "SAMviaKusanagi(Level119)orhigher": 99
+    },
+    "hits": 1,
+    "description": "Damage varies with TP."
+  },
+  "Tachi: Rana": {
+    "name": "Tachi: Rana",
+    "type": "Great Katana",
+    "class": "Physical",
+    "tpMod": "Accuracy",
+    "ftp": [],
+    "wsc": {
+      "str": 0.5
+    },
+    "sc": [
+      "Gravitation",
+      "Induration"
+    ],
+    "quest": "Unlocking a Myth (Samurai)",
+    "jobs": {
+      "SAM": 75
+    },
+    "hits": 1,
+    "description": "Delivers a threefold attack.  Accuracy varies with [[TP]]."
+  },
+  "Tachi: Shoha": {
+    "name": "Tachi: Shoha",
+    "type": "Great Katana",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1.375,
+      3.25,
+      4.625
+    ],
+    "wsc": {
+      "str": 0.85
+    },
+    "sc": [
+      "Light",
+      "Fragmentation",
+      "Compression"
+    ],
+    "reqSkill": 357,
+    "quest": "Martial Mastery",
+    "jobs": {
+      "SAM": 90
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack. Damage varies with [[TP]]."
+  },
+  "Tachi: Suikawari": {
+    "name": "Tachi: Suikawari",
+    "type": "Great Katana",
+    "class": "Physical",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Fusion"
+    ],
+    "jobs": {
+      "AllJobsviaMelonSlicer": 1
+    },
+    "hits": 1,
+    "description": "Number of watermelons sliced varies with TP."
+  },
+  "Tachi: Yukikaze": {
+    "name": "Tachi: Yukikaze",
+    "type": "Great Katana",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1.5625,
+      2.6875,
+      4.125
+    ],
+    "wsc": {
+      "str": 0.75
+    },
+    "sc": [
+      "Induration",
+      "Detonation"
+    ],
+    "reqSkill": 200,
+    "jobs": {
+      "SAM": 60
+    },
+    "hits": 1,
+    "description": "Blinds target. Damage varies with [[TP]]."
+  },
+  "Abyssal Drain": {
+    "name": "Abyssal Drain",
+    "type": "Great Sword",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Drains HP from target."
+  },
+  "Abyssal Strike": {
+    "name": "Abyssal Strike",
+    "type": "Great Sword",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Deals physical damage and stuns target."
+  },
+  "Crescent Moon": {
+    "name": "Crescent Moon",
+    "type": "Great Sword",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      2.25,
+      4
+    ],
+    "wsc": {
+      "str": 0.8
+    },
+    "sc": [
+      "Scission"
+    ],
+    "reqSkill": 175,
+    "jobs": {
+      "DRK": 55,
+      "RUN": 55,
+      "WAR": 56,
+      "PLD": 56
+    },
+    "hits": 1,
+    "description": "Delivers a single-hit attack. Damage varies with [[TP]]."
+  },
+  "Dimidiation": {
+    "name": "Dimidiation",
+    "type": "Great Sword",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      2.25,
+      4.5,
+      6.75
+    ],
+    "wsc": {
+      "dex": 0.8
+    },
+    "sc": [
+      "Light",
+      "Fragmentation"
+    ],
+    "quest": "Rune Fencing the Night Away",
+    "jobs": {
+      "RUN": 99
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack. Damage varies with [[TP]]. [[Epeolatry]]: Aftermath effect varies with [[TP]]."
+  },
+  "Fimbulvetr": {
+    "name": "Fimbulvetr",
+    "type": "Great Sword",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      3.3,
+      6.6,
+      9.9
+    ],
+    "wsc": {
+      "str": 0.6,
+      "vit": 0.6
+    },
+    "sc": [
+      "Detonation",
+      "Compression",
+      "Distortion"
+    ],
+    "jobs": {
+      "WAR": 99,
+      "PLD": 99,
+      "DRKandRUNviaHelheim(Level119)orhigher": 99
+    },
+    "hits": 1,
+    "description": "Damage varies with TP."
+  },
+  "Freezebite": {
+    "name": "Freezebite",
+    "type": "Great Sword",
+    "class": "Magical",
+    "element": "{{ice}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1.5,
+      3.5,
+      6
+    ],
+    "wsc": {
+      "str": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Induration",
+      "Detonation"
+    ],
+    "reqSkill": 100,
+    "jobs": {
+      "DRK": 33,
+      "RUN": 33,
+      "WAR": 34,
+      "PLD": 34
+    },
+    "hits": 1,
+    "description": "Delivers an [[ice]] elemental attack. Damage varies with [[TP]]."
+  },
+  "Frostbite": {
+    "name": "Frostbite",
+    "type": "Great Sword",
+    "class": "Magical",
+    "element": "{{ice}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1.5,
+      3.25,
+      5
+    ],
+    "wsc": {
+      "str": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Induration"
+    ],
+    "reqSkill": 70,
+    "jobs": {
+      "DRK": 23,
+      "RUN": 23,
+      "WAR": 24,
+      "PLD": 24
+    },
+    "hits": 1,
+    "description": "Delivers an [[ice]] elemental attack. Damage varies with [[TP]]."
+  },
+  "Ground Strike": {
+    "name": "Ground Strike",
+    "type": "Great Sword",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1.5,
+      3,
+      5
+    ],
+    "wsc": {
+      "str": 0.5,
+      "int": 0.5
+    },
+    "sc": [
+      "Fragmentation",
+      "Distortion"
+    ],
+    "reqSkill": 250,
+    "quest": "Inheritance",
+    "jobs": {
+      "RUN": 70,
+      "DRK": 99,
+      "WAR": 99,
+      "PLD": 99,
+      "RUNviaKajaClaymore/Nandaka": 99
+    },
+    "hits": 1,
+    "description": "Delivers a single attack. Damage varies with [[TP]]."
+  },
+  "Hard Slash": {
+    "name": "Hard Slash",
+    "type": "Great Sword",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1.5,
+      2.5,
+      3.5
+    ],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Scission"
+    ],
+    "reqSkill": 5,
+    "jobs": {
+      "WAR": 1,
+      "PLD": 1,
+      "DRK": 1,
+      "RUN": 1
+    },
+    "hits": 1,
+    "description": "Delivers a single-hit attack. Damage varies with [[TP]]."
+  },
+  "Herculean Slash": {
+    "name": "Herculean Slash",
+    "type": "Great Sword",
+    "class": "Magical",
+    "element": "{{ice}}",
+    "tpMod": "Effect duration",
+    "ftp": [
+      60,
+      120,
+      180
+    ],
+    "wsc": {
+      "vit": 0.8
+    },
+    "sc": [
+      "Induration",
+      "Impaction",
+      "Detonation"
+    ],
+    "reqSkill": 290,
+    "jobs": {
+      "RUN": 78,
+      "DRK": 80,
+      "WAR": 82,
+      "PLD": 83
+    },
+    "hits": 1,
+    "description": "Paralyzes target. Duration of effect varies with [[TP]]."
+  },
+  "Power Slash": {
+    "name": "Power Slash",
+    "type": "Great Sword",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [],
+    "wsc": {
+      "str": 0.6,
+      "vit": 0.6
+    },
+    "sc": [
+      "Transfixion"
+    ],
+    "reqSkill": 30,
+    "jobs": {
+      "DRK": 9,
+      "RUN": 9,
+      "WAR": 10,
+      "PLD": 10
+    },
+    "hits": 1,
+    "description": "Delivers a single-hit attack. [[Critical Hit Rate"
+  },
+  "Resolution": {
+    "name": "Resolution",
+    "type": "Great Sword",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      0.71875,
+      1.5,
+      2.25
+    ],
+    "wsc": {
+      "str": 0.85
+    },
+    "sc": [
+      "Light",
+      "Fragmentation",
+      "Scission"
+    ],
+    "reqSkill": 357,
+    "quest": "Martial Mastery",
+    "jobs": {
+      "WAR": 96,
+      "PLD": 96,
+      "DRK": 96,
+      "RUN": 96
+    },
+    "hits": 1,
+    "description": "Delivers a fivefold attack. Damage varies with [[TP]]."
+  },
+  "Scourge": {
+    "name": "Scourge",
+    "type": "Great Sword",
+    "class": "Physical",
+    "tpMod": "Aftermath<br />(+5% Critical Hit Rate)",
+    "ftp": [
+      20,
+      40,
+      60
+    ],
+    "wsc": {
+      "str": 0.4,
+      "vit": 0.4
+    },
+    "sc": [
+      "Light",
+      "Fusion"
+    ],
+    "jobs": {
+      "WAR": 85,
+      "PLD": 85,
+      "orDRKviaValhallaorRagnarok": 75,
+      "orDRKviaKhlorosBlade": 85
+    },
+    "hits": 1,
+    "description": "[[Valhalla]]/[[Ragnarok]]: Additional Effect: temporarily improves [[Critical Hit Rate]]"
+  },
+  "Shockwave": {
+    "name": "Shockwave",
+    "type": "Great Sword",
+    "class": "Physical",
+    "tpMod": "Effect duration",
+    "ftp": [],
+    "wsc": {
+      "str": 0.3,
+      "mnd": 0.3
+    },
+    "sc": [
+      "Reverberation"
+    ],
+    "reqSkill": 150,
+    "jobs": {
+      "DRK": 49,
+      "RUN": 49,
+      "WAR": 51,
+      "PLD": 51
+    },
+    "hits": 1,
+    "description": "Delivers an area of effect attack. [[Sleep]]s enemies. Duration varies with [[TP]]."
+  },
+  "Sickle Moon": {
+    "name": "Sickle Moon",
+    "type": "Great Sword",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1.5,
+      3.5,
+      6.5
+    ],
+    "wsc": {
+      "str": 0.4,
+      "agi": 0.4
+    },
+    "sc": [
+      "Scission",
+      "Impaction"
+    ],
+    "reqSkill": 200,
+    "jobs": {
+      "DRK": 60,
+      "RUN": 60,
+      "PLD": 62
+    },
+    "hits": 1,
+    "description": "Delivers a two-hit attack. Damage varies with [[TP]]."
+  },
+  "Spinning Slash": {
+    "name": "Spinning Slash",
+    "type": "Great Sword",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      2.5,
+      5,
+      7.5
+    ],
+    "wsc": {
+      "str": 0.3,
+      "int": 0.3
+    },
+    "sc": [
+      "Fragmentation"
+    ],
+    "reqSkill": 225,
+    "jobs": {
+      "RUN": 99,
+      "DRK": 99,
+      "PLD": 99,
+      "WARviaBerylliumSword/BerylliumSword+1": 99
+    },
+    "hits": 1,
+    "description": "Damage varies with [[TP]]."
+  },
+  "Torcleaver": {
+    "name": "Torcleaver",
+    "type": "Great Sword",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [],
+    "wsc": {
+      "vit": 0.8
+    },
+    "sc": [
+      "Light",
+      "Distortion"
+    ],
+    "quest": "Kupofried's Weapon Skill Moogle Magic",
+    "jobs": {
+      "PLD": 85,
+      "DRKviaCaladbolg": 85,
+      "Espafut": 85,
+      "Espafut+1": 85
+    },
+    "hits": 1,
+    "description": "Deals triple damage. Damage varies with [[TP]]."
+  },
+  "Victory Beacon": {
+    "name": "Victory Beacon",
+    "type": "Great Sword",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light",
+      "Distortion"
+    ],
+    "jobs": {
+      ":Category:Trust": 50
+    },
+    "hits": 1,
+    "description": "Deals damage in a fan-shaped area in front of the user. Additional effect: [[Flash]]."
+  },
+  "Ascetic's Fury": {
+    "name": "Ascetic's Fury",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [
+      20,
+      30,
+      50
+    ],
+    "wsc": {
+      "str": 0.5,
+      "vit": 0.5
+    },
+    "sc": [
+      "Fusion",
+      "Transfixion"
+    ],
+    "quest": "Unlocking a Myth (Monk)",
+    "jobs": {
+      "MNK": 75
+    },
+    "hits": 1,
+    "description": "Chance of critical hit varies with [[TP]]."
+  },
+  "Asuran Fists": {
+    "name": "Asuran Fists",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "Accuracy",
+    "ftp": [],
+    "wsc": {
+      "str": 0.15,
+      "vit": 0.15
+    },
+    "sc": [
+      "Gravitation",
+      "Liquefaction"
+    ],
+    "reqSkill": 250,
+    "quest": "The Walls of Your Mind",
+    "jobs": {
+      "MNK": 99,
+      "PUP": 99,
+      "WAR": 99,
+      "RDM": 99,
+      "THF": 99,
+      "DRK": 99,
+      "BST": 99,
+      "NIN": 99,
+      "DNCviaKajaKnuckles/Karambit": 99
+    },
+    "hits": 8,
+    "description": "Delivers an attack comprised of eight hits. Accuracy varies with [[TP]]."
+  },
+  "Auroral Uppercut": {
+    "name": "Auroral Uppercut",
+    "type": "Hand-to-Hand",
+    "class": "Magical",
+    "element": "{{Light}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light",
+      "Fragmentation"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Deals light elemental damage."
+  },
+  "Aurous Charge": {
+    "name": "Aurous Charge",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Distortion",
+      "Transfixion"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Single target attack."
+  },
+  "Backhand Blow": {
+    "name": "Backhand Blow",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [],
+    "wsc": {
+      "str": 0.5,
+      "dex": 0.5
+    },
+    "sc": [
+      "Detonation"
+    ],
+    "reqSkill": 100,
+    "jobs": {
+      "MNK": 33,
+      "PUP": 35,
+      "WAR": 37,
+      "DNC": 37,
+      "THF": 40,
+      "NIN": 40
+    },
+    "hits": 1,
+    "description": "Chance of critical varies with [[TP]]."
+  },
+  "Bear Killer": {
+    "name": "Bear Killer",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Reverberation",
+      "Impaction"
+    ],
+    "jobs": {
+      "Maat(S)": null
+    },
+    "hits": 1,
+    "description": "Deals substantial conal damage."
+  },
+  "Combo": {
+    "name": "Combo",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      3.75,
+      5.5
+    ],
+    "wsc": {
+      "str": 0.3,
+      "dex": 0.3
+    },
+    "sc": [
+      "Impaction"
+    ],
+    "reqSkill": 5,
+    "jobs": {
+      "MNK": 1,
+      "PUP": 1,
+      "WAR": 2,
+      "THF": 2,
+      "NIN": 2,
+      "DNC": 2
+    },
+    "hits": 1,
+    "description": "Delivers a three-fold attack. Damage varies with TP."
+  },
+  "Dragon Blow": {
+    "name": "Dragon Blow",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      3.675,
+      7,
+      10.4375
+    ],
+    "wsc": {
+      "dex": 0.85
+    },
+    "sc": [
+      "Distortion"
+    ],
+    "jobs": {
+      "MNK": 99,
+      "PUP": 99
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack. Damage varies with [[TP]]."
+  },
+  "Dragon Kick": {
+    "name": "Dragon Kick",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1.7,
+      3,
+      5
+    ],
+    "wsc": {
+      "str": 0.5,
+      "vit": 0.5
+    },
+    "sc": [
+      "Fragmentation"
+    ],
+    "reqSkill": 225,
+    "jobs": {
+      "MNK": 99,
+      "PUP": 99,
+      "WAR": 99,
+      "RDM": 99,
+      "THF": 99,
+      "DRK": 99,
+      "BST": 99,
+      "NIN": 99,
+      "DNCviaHepatizonBaghnakhs/HepatizonBaghnakhs+1": 99
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack. Damage varies with [[TP]]."
+  },
+  "Final Heaven": {
+    "name": "Final Heaven",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "Aftermath<br />(+10 Subtle Blow)",
+    "ftp": [
+      20,
+      40,
+      60
+    ],
+    "wsc": {
+      "vit": 0.8
+    },
+    "sc": [
+      "Light",
+      "Fusion"
+    ],
+    "jobs": {
+      "MNKviaCaestusorSpharai": 75,
+      "MNKorPUPviaHeofonKnuckles": 85
+    },
+    "hits": 1,
+    "description": "Additional effect: temporarily enhances [[Subtle Blow]] effect."
+  },
+  "Final Paradise": {
+    "name": "Final Paradise",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light"
+    ],
+    "jobs": {
+      "jobs": 1
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack. Paradise varies with TP."
+  },
+  "Hollow Smite": {
+    "name": "Hollow Smite",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [
+      10,
+      25,
+      45
+    ],
+    "wsc": {
+      "str": 0.8
+    },
+    "sc": [
+      "Light",
+      "Fragmentation"
+    ],
+    "jobs": {
+      "Maat(UC)": null
+    },
+    "hits": 1,
+    "description": "Delivers a fourfold attack. Chance of critical hit varies with TP."
+  },
+  "Howling Fist": {
+    "name": "Howling Fist",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      2.05,
+      3.55,
+      5.75
+    ],
+    "wsc": {
+      "vit": 0.5,
+      "str": 0.2
+    },
+    "sc": [
+      "Transfixion",
+      "Impaction"
+    ],
+    "reqSkill": 200,
+    "jobs": {
+      "MNK": 60,
+      "PUP": 62
+    },
+    "hits": 1,
+    "description": "Delivers a two-fold attack. Damage varies with [[TP]]."
+  },
+  "Howling Gust": {
+    "name": "Howling Gust",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Fragmentation",
+      "Compression"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Single target attack."
+  },
+  "Knuckle Sandwich": {
+    "name": "Knuckle Sandwich",
+    "type": "Hand-to-Hand",
+    "class": "Magical",
+    "element": "{{Light}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Fusion",
+      "Compression"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Deals light elemental damage."
+  },
+  "Maru Kala": {
+    "name": "Maru Kala",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Detonation",
+      "Compression",
+      "Distortion"
+    ],
+    "jobs": {
+      "MNKandPUPviaVargaPurnikawa(Level119)orhigher": 99
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack. Damage varies with TP."
+  },
+  "Meteoric Impact": {
+    "name": "Meteoric Impact",
+    "type": "Hand-to-Hand",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Darkness",
+      "Fragmentation"
+    ],
+    "jobs": {
+      ":Category:Trust": 50
+    },
+    "hits": 1,
+    "description": "Deals damage in an area around the user. Additional effect: [[Petrification]]."
+  },
+  "Nullifying Dropkick": {
+    "name": "Nullifying Dropkick",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Impaction",
+      "Induration"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Damage varies with TP."
+  },
+  "One Inch Punch": {
+    "name": "One Inch Punch",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "Ignored Defense",
+    "ftp": [
+      0,
+      25,
+      50
+    ],
+    "wsc": {
+      "vit": 1
+    },
+    "sc": [
+      "Compression"
+    ],
+    "reqSkill": 75,
+    "jobs": {
+      "MNK": 24,
+      "PUP": 26,
+      "WAR": 28,
+      "DNC": 28,
+      "THF": 30,
+      "NIN": 30
+    },
+    "hits": 1,
+    "description": "Ignores target defense. Amount ignored varies with [[TP]]."
+  },
+  "Raging Fists": {
+    "name": "Raging Fists",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      2.1875,
+      3.75
+    ],
+    "wsc": {
+      "str": 0.3,
+      "dex": 0.3
+    },
+    "sc": [
+      "Impaction"
+    ],
+    "reqSkill": 125,
+    "jobs": {
+      "MNK": 41,
+      "PUP": 44,
+      "WAR": 46,
+      "DNC": 46,
+      "THF": 50,
+      "NIN": 50
+    },
+    "hits": 1,
+    "description": "Delivers a five-fold attack. Damage varies with [[TP]]."
+  },
+  "Righteous Rasp": {
+    "name": "Righteous Rasp",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Fusion",
+      "Transfixion"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Single target attack."
+  },
+  "Shijin Spiral": {
+    "name": "Shijin Spiral",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "Effect Accuracy",
+    "ftp": [],
+    "wsc": {
+      "dex": 0.85
+    },
+    "sc": [
+      "Light",
+      "Fusion",
+      "Reverberation"
+    ],
+    "reqSkill": 357,
+    "quest": "Martial Mastery",
+    "jobs": {
+      "MNK": 90,
+      "PUP": 93
+    },
+    "hits": 1,
+    "description": "Delivers a fivefold attack that [[plague]]s the target. Chance of additional effect varies with [[TP]]."
+  },
+  "Shoulder Tackle": {
+    "name": "Shoulder Tackle",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "Effect Accuracy",
+    "ftp": [],
+    "wsc": {
+      "vit": 1
+    },
+    "sc": [
+      "Impaction",
+      "Reverberation"
+    ],
+    "reqSkill": 40,
+    "jobs": {
+      "MNK": 13,
+      "PUP": 14,
+      "WAR": 15,
+      "DNC": 15,
+      "THF": 16,
+      "NIN": 16
+    },
+    "hits": 1,
+    "description": "[[Stun (Status)"
+  },
+  "Spinning Attack": {
+    "name": "Spinning Attack",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "Radius of Attack",
+    "ftp": [
+      4,
+      4,
+      5
+    ],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Liquefaction",
+      "Impaction"
+    ],
+    "reqSkill": 150,
+    "jobs": {
+      "MNK": 49,
+      "PUP": 51,
+      "WAR": 53,
+      "DNC": 53,
+      "THF": 56,
+      "NIN": 56
+    },
+    "hits": 1,
+    "description": "Delivers a twofold area attack. Radius varies with [[TP]]."
+  },
+  "Stalking Prey": {
+    "name": "Stalking Prey",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light",
+      "Fragmentation"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Area of effect attack. Additional effect: terror."
+  },
+  "Starward Yowl": {
+    "name": "Starward Yowl",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Gravitation"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Single target attack."
+  },
+  "Stringing Pummel": {
+    "name": "Stringing Pummel",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [],
+    "wsc": {
+      "str": 0.32,
+      "vit": 0.32
+    },
+    "sc": [
+      "Gravitation",
+      "Liquefaction"
+    ],
+    "quest": "Unlocking a Myth (Puppetmaster)",
+    "jobs": {
+      "PUP": 75
+    },
+    "hits": 1,
+    "description": "Delivers a sixfold attack.  Chance of critical hit varies with [[TP]]."
+  },
+  "Tornado Kick": {
+    "name": "Tornado Kick",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1.7,
+      2.8,
+      4.5
+    ],
+    "wsc": {
+      "str": 0.4,
+      "vit": 0.4
+    },
+    "sc": [
+      "Induration",
+      "Impaction",
+      "Detonation"
+    ],
+    "reqSkill": 300,
+    "jobs": {
+      "MNK": 80,
+      "PUP": 84,
+      "WAR": 94,
+      "DNC": 94,
+      "THF": 99,
+      "NIN": 99
+    },
+    "hits": 1,
+    "description": "Delivers a threefold attack. Damage varies with TP"
+  },
+  "Victory Smite": {
+    "name": "Victory Smite",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [
+      10,
+      25,
+      45
+    ],
+    "wsc": {
+      "str": 0.8
+    },
+    "sc": [
+      "Light",
+      "Fragmentation"
+    ],
+    "quest": "Kupofried's Weapon Skill Moogle Magic",
+    "jobs": {
+      "MNKorPUPviaVerethragna": 85,
+      "RevenantFists": 85,
+      "RevenantFists+1": 85
+    },
+    "hits": 1,
+    "description": "Delivers a fourfold attack. Chance of critical hit varies with TP."
+  },
+  "Iainuki": {
+    "name": "Iainuki",
+    "type": "Great Katana",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light",
+      "Fragmentation",
+      "Scission"
+    ],
+    "jobs": {
+      "Kurt": 73,
+      "Gilgamesh": null
+    },
+    "hits": 1,
+    "description": "(Campaign) Delivers an area of effect attack. Additional effect: Knockback.<br>(Trust) Deals damage to target."
+  },
+  "Imperial Authority": {
+    "name": "Imperial Authority",
+    "type": "Hand-to-Hand",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Fragmentation",
+      "Distortion"
+    ],
+    "jobs": {
+      ":Category:Trust": 50
+    },
+    "hits": 1,
+    "description": "Deals damage to a single target. Additional effect: Stun {{verification}}."
+  },
+  "Inexorable Strike": {
+    "name": "Inexorable Strike",
+    "type": "Club",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light",
+      "Fusion"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "A six?-hit attack that stuns the target."
+  },
+  "Blade: Chi": {
+    "name": "Blade: Chi",
+    "type": "Katana",
+    "class": "Hybrid",
+    "element": "{{earth}}",
+    "tpMod": "fTP",
+    "ftp": [
+      0.5,
+      1.375,
+      2.25
+    ],
+    "wsc": {
+      "str": 0.3,
+      "int": 0.3
+    },
+    "sc": [
+      "Impaction",
+      "Transfixion"
+    ],
+    "reqSkill": 150,
+    "jobs": {
+      "NIN": 49
+    },
+    "hits": 1,
+    "description": "Delivers a two-hit [[earth]] elemental attack. Damage varies with [[TP]]."
+  },
+  "Blade: Ei": {
+    "name": "Blade: Ei",
+    "type": "Katana",
+    "class": "Magical",
+    "element": "{{dark}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      3,
+      5
+    ],
+    "wsc": {
+      "str": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Compression"
+    ],
+    "reqSkill": 175,
+    "jobs": {
+      "NIN": 55
+    },
+    "hits": 1,
+    "description": "Delivers a [[dark]] elemental attack. Damage varies with [[TP]]."
+  },
+  "Blade: Hi": {
+    "name": "Blade: Hi",
+    "type": "Katana",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [
+      15,
+      20,
+      25
+    ],
+    "wsc": {
+      "agi": 0.8
+    },
+    "sc": [
+      "Darkness",
+      "Gravitation"
+    ],
+    "quest": "Kupofried's Weapon Skill Moogle Magic",
+    "jobs": {
+      "NINviaKannagi": 85,
+      "Tobi": 85,
+      "Tobi+1": 85
+    },
+    "hits": 1,
+    "description": "Deals quadruple damage. [[Critical Hit Rate"
+  },
+  "Blade: Jin": {
+    "name": "Blade: Jin",
+    "type": "Katana",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [],
+    "wsc": {
+      "str": 0.3,
+      "dex": 0.3
+    },
+    "sc": [
+      "Impaction",
+      "Detonation"
+    ],
+    "reqSkill": 200,
+    "jobs": {
+      "NIN": 60
+    },
+    "hits": 1,
+    "description": "Delivers a three-hit attack.  Chance of critical varies with [[TP]]."
+  },
+  "Blade: Kamu": {
+    "name": "Blade: Kamu",
+    "type": "Katana",
+    "class": "Physical",
+    "tpMod": "Effect duration",
+    "ftp": [
+      60,
+      120,
+      180
+    ],
+    "wsc": {
+      "str": 0.6,
+      "int": 0.6
+    },
+    "sc": [
+      "Fragmentation",
+      "Compression"
+    ],
+    "quest": "Unlocking a Myth (Ninja)",
+    "jobs": {
+      "NIN": 75
+    },
+    "hits": 1,
+    "description": "Lowers target's [[accuracy]].  Duration of the effect varies with [[TP]]."
+  },
+  "Blade: Ku": {
+    "name": "Blade: Ku",
+    "type": "Katana",
+    "class": "Physical",
+    "tpMod": "Accuracy",
+    "ftp": [],
+    "wsc": {
+      "str": 0.3,
+      "dex": 0.3
+    },
+    "sc": [
+      "Gravitation",
+      "Transfixion"
+    ],
+    "reqSkill": 250,
+    "quest": "Bugi Soden",
+    "jobs": {
+      "NIN": 72,
+      "NINviaKajaKatana/Gokotaiinthemainhandonly": 99
+    },
+    "hits": 5,
+    "description": "Delivers an attack comprised of five hits. [[Accuracy]] varies with [[TP]]."
+  },
+  "Blade: Metsu": {
+    "name": "Blade: Metsu",
+    "type": "Katana",
+    "class": "Physical",
+    "tpMod": "Aftermath<br />(+10 Subtle Blow)",
+    "ftp": [
+      20,
+      40,
+      60
+    ],
+    "wsc": {
+      "dex": 0.8
+    },
+    "sc": [
+      "Darkness",
+      "Fragmentation"
+    ],
+    "jobs": {
+      "NINviaYoshimitsuorKikoku": 75,
+      "NINviaSekirei": 85
+    },
+    "hits": 1,
+    "description": "[[Yoshimitsu]]/[[Kikoku]]: Additional Effect: Temporarily enhances Subtle Blow effect."
+  },
+  "Blade: Retsu": {
+    "name": "Blade: Retsu",
+    "type": "Katana",
+    "class": "Physical",
+    "tpMod": "Effect duration",
+    "ftp": [
+      30,
+      60,
+      120
+    ],
+    "wsc": {
+      "dex": 0.6,
+      "str": 0.2
+    },
+    "sc": [
+      "Scission"
+    ],
+    "reqSkill": 30,
+    "jobs": {
+      "NIN": 9
+    },
+    "hits": 1,
+    "description": "Delivers a two-fold attack that [[paralyze]]s target.  Duration of paralysis varies with [[TP]]."
+  },
+  "Blade: Rin": {
+    "name": "Blade: Rin",
+    "type": "Katana",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [],
+    "wsc": {
+      "str": 0.6,
+      "dex": 0.6
+    },
+    "sc": [
+      "Transfixion"
+    ],
+    "reqSkill": 5,
+    "jobs": {
+      "NIN": 1
+    },
+    "hits": 1,
+    "description": "Delivers a single-hit attack.  Chance of critical varies with [[TP]]."
+  },
+  "Blade: Shun": {
+    "name": "Blade: Shun",
+    "type": "Katana",
+    "class": "Physical",
+    "tpMod": "Attack",
+    "ftp": [
+      0,
+      100,
+      200
+    ],
+    "wsc": {
+      "dex": 0.85
+    },
+    "sc": [
+      "Light",
+      "Fusion",
+      "Impaction"
+    ],
+    "reqSkill": 357,
+    "quest": "Martial Mastery",
+    "jobs": {
+      "NIN": 91
+    },
+    "hits": 1,
+    "description": "Delivers a fivefold attack. Attack power varies with [[TP]]."
+  },
+  "Blade: Teki": {
+    "name": "Blade: Teki",
+    "type": "Katana",
+    "class": "Hybrid",
+    "element": "{{water}}",
+    "tpMod": "fTP",
+    "ftp": [
+      0.5,
+      1.375,
+      2.25
+    ],
+    "wsc": {
+      "str": 0.3,
+      "int": 0.3
+    },
+    "sc": [
+      "Reverberation"
+    ],
+    "reqSkill": 70,
+    "jobs": {
+      "NIN": 23
+    },
+    "hits": 1,
+    "description": "Delivers a [[water]] elemental attack. Damage varies with [[TP]]."
+  },
+  "Blade: Ten": {
+    "name": "Blade: Ten",
+    "type": "Katana",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      4.5,
+      11.5,
+      15.5
+    ],
+    "wsc": {
+      "str": 0.3,
+      "dex": 0.3
+    },
+    "sc": [
+      "Gravitation"
+    ],
+    "reqSkill": 225,
+    "jobs": {
+      "NIN": 66
+    },
+    "hits": 1,
+    "description": "Delivers a single-hit attack.  Damage varies with [[TP]]."
+  },
+  "Blade: To": {
+    "name": "Blade: To",
+    "type": "Katana",
+    "class": "Hybrid",
+    "element": "{{ice}}",
+    "tpMod": "fTP",
+    "ftp": [
+      0.5,
+      1.5,
+      2.5
+    ],
+    "wsc": {
+      "str": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Induration",
+      "Detonation"
+    ],
+    "reqSkill": 100,
+    "jobs": {
+      "NIN": 33
+    },
+    "hits": 1,
+    "description": "Delivers an [[ice]] elemental attack. Damage varies with [[TP]]."
+  },
+  "Blade: Yu": {
+    "name": "Blade: Yu",
+    "type": "Katana",
+    "class": "Magical",
+    "element": "{{water}}",
+    "tpMod": "Effect duration",
+    "ftp": [
+      90,
+      180,
+      270
+    ],
+    "wsc": {
+      "dex": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Reverberation",
+      "Scission"
+    ],
+    "reqSkill": 290,
+    "jobs": {
+      "NIN": 80
+    },
+    "hits": 1,
+    "description": "Delivers water elemental damage. Additional effect: Poison. Duration of effect varies with [[TP]]."
+  },
+  "Zesho Meppo": {
+    "name": "Zesho Meppo",
+    "type": "Katana",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [],
+    "wsc": {
+      "dex": 0.25,
+      "agi": 0.25
+    },
+    "sc": [
+      "Induration",
+      "Reverberation",
+      "Fusion"
+    ],
+    "jobs": {
+      "NINviaDokoku(Level119)orhigher": 99
+    },
+    "hits": 1,
+    "description": "Delivers a fourfold attack. Damage varies with TP."
+  },
+  "Luminous Lance": {
+    "name": "Luminous Lance",
+    "type": "Hand-to-Hand",
+    "class": "Magical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Deals light damage to a single target."
+  },
+  "Blast Shot": {
+    "name": "Blast Shot",
+    "type": "Marksmanship",
+    "class": "Physical",
+    "tpMod": "Ranged Accuracy",
+    "ftp": [],
+    "wsc": {
+      "agi": 0.7
+    },
+    "sc": [
+      "Induration",
+      "Transfixion"
+    ],
+    "reqSkill": 200,
+    "jobs": {
+      "RNG": 60
+    },
+    "hits": 1,
+    "description": "Delivers a melee-distance ranged attack. [[Accuracy]] varies with [[TP]]."
+  },
+  "Coronach": {
+    "name": "Coronach",
+    "type": "Marksmanship",
+    "class": "Physical",
+    "tpMod": "Aftermath<br />(-20 Enmity)",
+    "ftp": [
+      20,
+      40,
+      60
+    ],
+    "wsc": {
+      "dex": 0.4,
+      "agi": 0.4
+    },
+    "sc": [
+      "Darkness",
+      "Fragmentation"
+    ],
+    "jobs": {
+      "RNGviaFerdinandorAnnihilator": 75,
+      "RNGorCORviaExequyGun": 85
+    },
+    "hits": 1,
+    "description": "[[Ferdinand]]/[[Annihilator]]: Additional Effect: Temporarily lowers [[Enmity]]."
+  },
+  "Critical Mass": {
+    "name": "Critical Mass",
+    "type": "Marksmanship",
+    "class": "Magical",
+    "element": "{{fire}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Fusion",
+      "Impaction"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Single target fire damage."
+  },
+  "Detonator": {
+    "name": "Detonator",
+    "type": "Marksmanship",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1.5,
+      2.5,
+      5
+    ],
+    "wsc": {
+      "agi": 0.7
+    },
+    "sc": [
+      "Fusion",
+      "Transfixion"
+    ],
+    "reqSkill": 250,
+    "quest": "Shoot First, Ask Questions Later",
+    "jobs": {
+      "RNG": 72,
+      "COR": 75
+    },
+    "hits": 1,
+    "description": "Delivers a single attack. Damage varies with [[TP]]."
+  },
+  "Fiery Tailings": {
+    "name": "Fiery Tailings",
+    "type": "Marksmanship",
+    "class": "Magical",
+    "element": "{{fire}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light",
+      "Fusion"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Area of effect fire damage."
+  },
+  "Heavy Shot": {
+    "name": "Heavy Shot",
+    "type": "Marksmanship",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [],
+    "wsc": {
+      "agi": 0.7
+    },
+    "sc": [
+      "Fusion"
+    ],
+    "reqSkill": 225,
+    "jobs": {
+      "RNG": 99,
+      "WAR": 99,
+      "THF": 99,
+      "DRKviaExaltedCrossbow/ExaltedCrossbow+1": 99
+    },
+    "hits": 1,
+    "description": "Delivers a single-hit attack.  Chance of critical varies with [[TP]]."
+  },
+  "Hot Shot": {
+    "name": "Hot Shot",
+    "type": "Marksmanship",
+    "class": "Hybrid",
+    "element": "{{fire}}",
+    "tpMod": "fTP",
+    "ftp": [
+      0.5,
+      1.55,
+      2.1
+    ],
+    "wsc": {
+      "agi": 0.7
+    },
+    "sc": [
+      "Liquefaction",
+      "Transfixion"
+    ],
+    "reqSkill": 5,
+    "jobs": {
+      "THF": 1,
+      "RNG": 1,
+      "NIN": 1,
+      "COR": 1,
+      "WAR": 2,
+      "DRK": 2
+    },
+    "hits": 1,
+    "description": "Deals [[fire]] elemental damage to an enemy."
+  },
+  "Last Stand": {
+    "name": "Last Stand",
+    "type": "Marksmanship",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      2,
+      3,
+      4
+    ],
+    "wsc": {
+      "agi": 0.85
+    },
+    "sc": [
+      "Light",
+      "Fusion",
+      "Reverberation"
+    ],
+    "reqSkill": 357,
+    "quest": "Martial Mastery",
+    "jobs": {
+      "RNG": 91,
+      "COR": 94,
+      "THF": 96
+    },
+    "hits": 1,
+    "description": "Damage varies with [[TP]]. Delivers a twofold attack, ammunition permitting."
+  },
+  "Leaden Salute": {
+    "name": "Leaden Salute",
+    "type": "Marksmanship",
+    "class": "Magical",
+    "element": "{{dark}}",
+    "tpMod": "fTP",
+    "ftp": [
+      4,
+      6.7,
+      10
+    ],
+    "wsc": {
+      "agi": 1
+    },
+    "sc": [
+      "Gravitation",
+      "Transfixion"
+    ],
+    "quest": "Unlocking a Myth (Corsair)",
+    "jobs": {
+      "COR": 75
+    },
+    "hits": 1,
+    "description": "Deals [[dark]] elemental damage.  Damage varies with [[TP]]."
+  },
+  "Numbing Shot": {
+    "name": "Numbing Shot",
+    "type": "Marksmanship",
+    "class": "Physical",
+    "tpMod": "Effect Duration",
+    "ftp": [
+      60,
+      120,
+      180
+    ],
+    "wsc": {
+      "agi": 0.8
+    },
+    "sc": [
+      "Induration",
+      "Detonation",
+      "Impaction"
+    ],
+    "reqSkill": 290,
+    "jobs": {
+      "RNG": 80,
+      "COR": 83,
+      "THF": 86,
+      "NIN": 87,
+      "WAR": 92,
+      "DRK": 97
+    },
+    "hits": 1,
+    "description": "Delivers a short-ranged attack that deals triple damage. Additional effect: [[Paralysis]]. Duration of effect varies with TP."
+  },
+  "Slug Shot": {
+    "name": "Slug Shot",
+    "type": "Marksmanship",
+    "class": "Physical",
+    "tpMod": "Ranged Accuracy",
+    "ftp": [],
+    "wsc": {
+      "agi": 0.7
+    },
+    "sc": [
+      "Reverberation",
+      "Transfixion",
+      "Detonation"
+    ],
+    "reqSkill": 175,
+    "jobs": {
+      "RNG": 55,
+      "COR": 56,
+      "THF": 57,
+      "NIN": 57,
+      "WAR": 59,
+      "DRK": 63
+    },
+    "hits": 1,
+    "description": "Delivers a powerful but inaccurate attack. [[Accuracy]] varies with [[TP]]."
+  },
+  "Sniper Shot": {
+    "name": "Sniper Shot",
+    "type": "Marksmanship",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [],
+    "wsc": {
+      "agi": 0.7
+    },
+    "sc": [
+      "Liquefaction",
+      "Transfixion"
+    ],
+    "reqSkill": 80,
+    "jobs": {
+      "RNG": 26,
+      "COR": 27,
+      "THF": 28,
+      "NIN": 28,
+      "WAR": 30,
+      "DRK": 32
+    },
+    "hits": 1,
+    "description": "Lowers enemy's [[INT]]. Chance of critical varies with [[TP]]."
+  },
+  "Split Shot": {
+    "name": "Split Shot",
+    "type": "Marksmanship",
+    "class": "Physical",
+    "tpMod": "Defense Ignored",
+    "ftp": [
+      0,
+      35,
+      50
+    ],
+    "wsc": {
+      "agi": 0.7
+    },
+    "sc": [
+      "Reverberation",
+      "Transfixion"
+    ],
+    "reqSkill": 40,
+    "jobs": {
+      "RNG": 13,
+      "THF": 14,
+      "NIN": 14,
+      "COR": 14,
+      "WAR": 15,
+      "DRK": 16
+    },
+    "hits": 1,
+    "description": "Ignores enemy's [[defense]]. Amount ignored varies with [[TP]]."
+  },
+  "Terminus": {
+    "name": "Terminus",
+    "type": "Marksmanship",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      2.5,
+      5,
+      7.5
+    ],
+    "wsc": {
+      "dex": 0.7,
+      "agi": 0.7
+    },
+    "sc": [
+      "Induration",
+      "Reverberation",
+      "Fusion"
+    ],
+    "jobs": {
+      "RNGandCORviaEarp(Level119)orhigher": 99
+    },
+    "hits": 1,
+    "description": "Damage varies with TP."
+  },
+  "Trueflight": {
+    "name": "Trueflight",
+    "type": "Marksmanship",
+    "class": "Magical",
+    "element": "{{light}}",
+    "tpMod": "fTP",
+    "ftp": [
+      3.890625,
+      6.4921875,
+      9.671875
+    ],
+    "wsc": {
+      "agi": 1
+    },
+    "sc": [
+      "Fragmentation",
+      "Scission"
+    ],
+    "quest": "Unlocking a Myth (Ranger)",
+    "jobs": {
+      "RNG": 75
+    },
+    "hits": 1,
+    "description": "Deals [[light]] elemental damage.  Damage varies with [[TP]]."
+  },
+  "Wildfire": {
+    "name": "Wildfire",
+    "type": "Marksmanship",
+    "class": "Magical",
+    "element": "{{fire}}",
+    "tpMod": "Enmity",
+    "ftp": [
+      -10,
+      -40,
+      -75
+    ],
+    "wsc": {
+      "agi": 0.6
+    },
+    "sc": [
+      "Darkness",
+      "Gravitation"
+    ],
+    "quest": "Kupofried's Weapon Skill Moogle Magic",
+    "jobs": {
+      "RNGorCORviaArmageddon": 85,
+      "Bedlam": 85,
+      "Bedlam+1": 85
+    },
+    "hits": 1,
+    "description": "Deals fire elemental damage. [[Enmity]] generation varies with [[TP]]."
+  },
+  "Napalm Tomahawk": {
+    "name": "Napalm Tomahawk",
+    "type": "Axe",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "{{question}}",
+      "{{question}}",
+      "{{question}}"
+    ],
+    "jobs": {
+      "InvincibleShield": 73
+    },
+    "hits": 1,
+    "description": "{{question}}"
+  },
+  "Oppresive Embrace": {
+    "name": "Oppresive Embrace",
+    "type": "Polearm",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "{{question}}",
+      "{{question}}",
+      "{{question}}"
+    ],
+    "jobs": {
+      "Else": 73
+    },
+    "hits": 1,
+    "description": "{{question}}"
+  },
+  "Orbital Earthrend": {
+    "name": "Orbital Earthrend",
+    "type": "Hand-to-Hand",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "{{question}}",
+      "{{question}}",
+      "{{question}}"
+    ],
+    "jobs": {
+      "Zazarg(S)": 73
+    },
+    "hits": 1,
+    "description": "{{question}}"
+  },
+  "Camlann's Torment": {
+    "name": "Camlann's Torment",
+    "type": "Polearm",
+    "class": "Physical",
+    "tpMod": "Defense ignored",
+    "ftp": [
+      12.5,
+      37.5,
+      62.5
+    ],
+    "wsc": {
+      "str": 0.6,
+      "vit": 0.6
+    },
+    "sc": [
+      "Light",
+      "Fragmentation"
+    ],
+    "quest": "Kupofried's Weapon Skill Moogle Magic",
+    "jobs": {
+      "DRGviaRhongomiant": 85,
+      "Cerastes": 85,
+      "Cerastes+1": 85
+    },
+    "hits": 1,
+    "description": "Delivers a triple damage attack that ignores target's defense. Amount ignored varies with [[TP]]."
+  },
+  "Celidon's Torment": {
+    "name": "Celidon's Torment",
+    "type": "Polearm",
+    "class": "Physical",
+    "tpMod": "Defense ignored",
+    "ftp": [],
+    "wsc": {
+      "str": 0.6,
+      "vit": 0.6
+    },
+    "sc": [
+      "Light",
+      "Fragmentation"
+    ],
+    "jobs": {
+      "Flaviria(UC)": 50
+    },
+    "hits": 1,
+    "description": "Delivers a triple damage attack that ignores target's defense. Amount ignored varies with [[TP]]."
+  },
+  "Diarmuid": {
+    "name": "Diarmuid",
+    "type": "Polearm",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      2.17,
+      5.36,
+      8.55
+    ],
+    "wsc": {
+      "str": 0.55,
+      "vit": 0.55
+    },
+    "sc": [
+      "Transfixion",
+      "Scission",
+      "Gravitation"
+    ],
+    "jobs": {
+      "DRGviaGaeBuide(Level119)orhigher": 99
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack. Damage varies with TP."
+  },
+  "Double Thrust": {
+    "name": "Double Thrust",
+    "type": "Polearm",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      2.5,
+      4
+    ],
+    "wsc": {
+      "str": 0.3,
+      "dex": 0.3
+    },
+    "sc": [
+      "Transfixion"
+    ],
+    "reqSkill": 5,
+    "jobs": {
+      "DRG": 1,
+      "WAR": 3,
+      "SAM": 3,
+      "PLD": 4
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack. Damage varies with [[TP]]."
+  },
+  "Geirskogul": {
+    "name": "Geirskogul",
+    "type": "Polearm",
+    "class": "Physical",
+    "tpMod": "Aftermath<br />(Shock Spikes)",
+    "ftp": [
+      20,
+      40,
+      60
+    ],
+    "wsc": {
+      "dex": 0.8
+    },
+    "sc": [
+      "Light",
+      "Distortion"
+    ],
+    "jobs": {
+      "DRGviaGaeAssailorGungnir": 75,
+      "DRGviaSkogulLance": 85
+    },
+    "hits": 1,
+    "description": "[[Gae Assail]]/[[Gungnir]]: Additional Effect: Shock Spikes"
+  },
+  "Impulse Drive": {
+    "name": "Impulse Drive",
+    "type": "Polearm",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      3,
+      5.5
+    ],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Gravitation",
+      "Induration"
+    ],
+    "reqSkill": 240,
+    "quest": "Methods Create Madness",
+    "jobs": {
+      "DRG": 99,
+      "WAR": 99,
+      "SAM": 99,
+      "PLDviaKajaLance/ShiningOne": 99
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack. Damage varies with [[TP]]."
+  },
+  "Leg Sweep": {
+    "name": "Leg Sweep",
+    "type": "Polearm",
+    "class": "Physical",
+    "tpMod": "Effect accuracy",
+    "ftp": [],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Impaction"
+    ],
+    "reqSkill": 100,
+    "jobs": {
+      "DRG": 33,
+      "WAR": 34,
+      "SAM": 34,
+      "PLD": 40
+    },
+    "hits": 1,
+    "description": "[[Stun"
+  },
+  "Penta Thrust": {
+    "name": "Penta Thrust",
+    "type": "Polearm",
+    "class": "Physical",
+    "tpMod": "Accuracy",
+    "ftp": [],
+    "wsc": {
+      "str": 0.2,
+      "dex": 0.2
+    },
+    "sc": [
+      "Compression"
+    ],
+    "reqSkill": 150,
+    "jobs": {
+      "DRG": 49,
+      "WAR": 51,
+      "SAM": 51,
+      "PLD": 56
+    },
+    "hits": 1,
+    "description": "Delivers a fivefold attack. Accuracy varies with TP."
+  },
+  "Raiden Thrust": {
+    "name": "Raiden Thrust",
+    "type": "Polearm",
+    "class": "Magical",
+    "element": "{{thunder}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      3.91,
+      7.96
+    ],
+    "wsc": {
+      "str": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Transfixion",
+      "Impaction"
+    ],
+    "reqSkill": 70,
+    "jobs": {
+      "DRG": 23,
+      "WAR": 24,
+      "SAM": 24,
+      "PLD": 28
+    },
+    "hits": 1,
+    "description": "Deals lightning elemental damage. Damage varies with [[TP]]."
+  },
+  "Skewer": {
+    "name": "Skewer",
+    "type": "Polearm",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [],
+    "wsc": {
+      "str": 0.5
+    },
+    "sc": [
+      "Transfixion",
+      "Impaction"
+    ],
+    "reqSkill": 200,
+    "jobs": {
+      "DRG": 60
+    },
+    "hits": 1,
+    "description": "Delivers a threefold attack. Chance of critical hit varies with TP."
+  },
+  "Sonic Thrust": {
+    "name": "Sonic Thrust",
+    "type": "Polearm",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      3,
+      3.7,
+      4.5
+    ],
+    "wsc": {
+      "str": 0.4,
+      "dex": 0.4
+    },
+    "sc": [
+      "Transfixion",
+      "Scission"
+    ],
+    "reqSkill": 300,
+    "jobs": {
+      "DRG": 80,
+      "WAR": 86,
+      "SAM": 86,
+      "PLD": 99
+    },
+    "hits": 1,
+    "description": "Delivers an area attack. Damage varies with TP."
+  },
+  "Stardiver": {
+    "name": "Stardiver",
+    "type": "Polearm",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      0.75,
+      1.25,
+      1.75
+    ],
+    "wsc": {
+      "str": 0.85
+    },
+    "sc": [
+      "Darkness",
+      "Gravitation",
+      "Transfixion"
+    ],
+    "reqSkill": 357,
+    "quest": "Martial Mastery",
+    "jobs": {
+      "DRG": 90,
+      "WAR": 95,
+      "SAM": 95
+    },
+    "hits": 1,
+    "description": "Delivers a fourfold attack. Decreases enemy critical hit evasion. Damage varies with [[TP]]."
+  },
+  "Thunder Thrust": {
+    "name": "Thunder Thrust",
+    "type": "Polearm",
+    "class": "Magical",
+    "element": "{{thunder}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1.5,
+      3.28,
+      5.43
+    ],
+    "wsc": {
+      "str": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Transfixion",
+      "Impaction"
+    ],
+    "reqSkill": 30,
+    "jobs": {
+      "DRG": 9,
+      "WAR": 10,
+      "SAM": 10,
+      "PLD": 12
+    },
+    "hits": 1,
+    "description": "Deals lightning elemental damage. Damage varies with [[TP]]."
+  },
+  "Vorpal Thrust": {
+    "name": "Vorpal Thrust",
+    "type": "Polearm",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [],
+    "wsc": {
+      "str": 0.5,
+      "agi": 0.5
+    },
+    "sc": [
+      "Reverberation",
+      "Transfixion"
+    ],
+    "reqSkill": 175,
+    "jobs": {
+      "DRG": 55,
+      "WAR": 56,
+      "SAM": 56,
+      "PLD": 63
+    },
+    "hits": 1,
+    "description": "Deals critical damage. Chance of critical hit varies with TP."
+  },
+  "Wheeling Thrust": {
+    "name": "Wheeling Thrust",
+    "type": "Polearm",
+    "class": "Physical",
+    "tpMod": "Defense ignored",
+    "ftp": [
+      50,
+      62.5,
+      75
+    ],
+    "wsc": {
+      "str": 0.8
+    },
+    "sc": [
+      "Fusion"
+    ],
+    "reqSkill": 225,
+    "jobs": {
+      "DRG": 99,
+      "WAR": 99,
+      "PLD": 99,
+      "SAMviaExaltedSpear/ExaltedSpear+1": 99
+    },
+    "hits": 1,
+    "description": "Delivers an attack that ignores target defense. Amount ignored varies with [[TP]]."
+  },
+  "Prominence": {
+    "name": "Prominence",
+    "type": "Sword",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "{{question}}",
+      "{{question}}",
+      "{{question}}"
+    ],
+    "jobs": {
+      "AshmeaBGreinner": 73
+    },
+    "hits": 1,
+    "description": "{{question}}"
+  },
+  "Rejuvenation": {
+    "name": "Rejuvenation",
+    "type": "Hand-to-Hand",
+    "class": "Magical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Restores TP, HP, and MP to all nearby allies."
+  },
+  "Revelation": {
+    "name": "Revelation",
+    "type": "Hand-to-Hand",
+    "class": "Magical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Fusion"
+    ],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Deals light damage to a single target."
+  },
+  "Rising Dragon": {
+    "name": "Rising Dragon",
+    "type": "Hand-to-Hand",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "{{question}}",
+      "{{question}}",
+      "{{question}}"
+    ],
+    "jobs": {
+      "Degenhard(S)": 73
+    },
+    "hits": 1,
+    "description": "{{question}}"
+  },
+  "Ruthlessness": {
+    "name": "Ruthlessness",
+    "type": "Club",
+    "class": "Magical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Drains target's HP."
+  },
+  "Salaheem Spirit": {
+    "name": "Salaheem Spirit",
+    "type": "Hand-to-Hand",
+    "class": "None",
+    "element": "{{question}}",
+    "tpMod": "Duration",
+    "ftp": [
+      50,
+      90,
+      120
+    ],
+    "wsc": {},
+    "sc": [],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Provides a bonus to base attributes for party members in area of effect. Duration varies by TP."
+  },
+  "Catastrophe": {
+    "name": "Catastrophe",
+    "type": "Scythe",
+    "class": "Physical",
+    "tpMod": "Aftermath<br />(10% Haste)",
+    "ftp": [
+      20,
+      40,
+      60
+    ],
+    "wsc": {
+      "str": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Darkness",
+      "Gravitation"
+    ],
+    "jobs": {
+      "DRKviaBecdeFauconorApocalypse": 75,
+      "DRKviaCrisisScythe": 85
+    },
+    "hits": 1,
+    "description": "Drains target's HP. [[Bec de Faucon]]/[[Apocalypse]]: Additional Effect: Haste"
+  },
+  "Cross Reaper": {
+    "name": "Cross Reaper",
+    "type": "Scythe",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      2,
+      4,
+      7
+    ],
+    "wsc": {
+      "str": 0.6,
+      "mnd": 0.6
+    },
+    "sc": [
+      "Distortion"
+    ],
+    "reqSkill": 225,
+    "jobs": {
+      "DRK": 99,
+      "WAR": 99,
+      "BLM": 99,
+      "BSTviaMaliyaSickle/MaliyaSickle+1": 99
+    },
+    "hits": 1,
+    "description": "Delivers a two-hit attack. Damage varies with [[TP]]."
+  },
+  "Dark Harvest": {
+    "name": "Dark Harvest",
+    "type": "Scythe",
+    "class": "Magical",
+    "element": "{{dark}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      3.54,
+      6.07
+    ],
+    "wsc": {
+      "str": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Reverberation"
+    ],
+    "reqSkill": 30,
+    "jobs": {
+      "DRK": 9,
+      "WAR": 10,
+      "BST": 10,
+      "BLM": 12
+    },
+    "hits": 1,
+    "description": "Delivers a dark elemental attack. Damage varies with [[TP]]."
+  },
+  "Entropy": {
+    "name": "Entropy",
+    "type": "Scythe",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      0.75,
+      1.25,
+      2
+    ],
+    "wsc": {
+      "int": 0.85
+    },
+    "sc": [
+      "Darkness",
+      "Gravitation",
+      "Reverberation"
+    ],
+    "reqSkill": 357,
+    "quest": "Martial Mastery",
+    "jobs": {
+      "DRK": 90,
+      "WAR": 93,
+      "BST": 95
+    },
+    "hits": 1,
+    "description": "Delivers a fourfold attack. Converts some of the damage into [[MP]]. Damage varies with [[TP]]."
+  },
+  "Guillotine": {
+    "name": "Guillotine",
+    "type": "Scythe",
+    "class": "Physical",
+    "tpMod": "Effect duration",
+    "ftp": [
+      60,
+      120,
+      180
+    ],
+    "wsc": {
+      "mnd": 0.5,
+      "str": 0.3
+    },
+    "sc": [
+      "Induration"
+    ],
+    "reqSkill": 200,
+    "jobs": {
+      "DRK": 60
+    },
+    "hits": 1,
+    "description": "Delivers a four-hit attack.[[Silence]]s enemy. Duration of effect varies with [[TP]]."
+  },
+  "Infernal Scythe": {
+    "name": "Infernal Scythe",
+    "type": "Scythe",
+    "class": "Magical",
+    "element": "{{dark}}",
+    "tpMod": "Effect Duration",
+    "ftp": [
+      180,
+      360,
+      540
+    ],
+    "wsc": {
+      "int": 0.7,
+      "str": 0.3
+    },
+    "sc": [
+      "Compression",
+      "Reverberation"
+    ],
+    "reqSkill": 300,
+    "jobs": {
+      "DRK": 80,
+      "WAR": 84,
+      "BST": 86,
+      "BLM": 99
+    },
+    "hits": 1,
+    "description": "Deals darkness elemental damage. Additional effect: Lowers target's attack. Duration of effect varies with TP."
+  },
+  "Insurgency": {
+    "name": "Insurgency",
+    "type": "Scythe",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      0.5,
+      3.25,
+      6
+    ],
+    "wsc": {
+      "str": 0.2,
+      "int": 0.2
+    },
+    "sc": [
+      "Fusion",
+      "Compression"
+    ],
+    "quest": "Unlocking a Myth (Dark Knight)",
+    "jobs": {
+      "DRK": 75
+    },
+    "hits": 1,
+    "description": "Delivers a fourfold attack. Damage varies with [[TP]]."
+  },
+  "Nightmare Scythe": {
+    "name": "Nightmare Scythe",
+    "type": "Scythe",
+    "class": "Physical",
+    "tpMod": "Effect duration",
+    "ftp": [
+      60,
+      120,
+      180
+    ],
+    "wsc": {
+      "str": 0.6,
+      "mnd": 0.6
+    },
+    "sc": [
+      "Compression",
+      "Scission"
+    ],
+    "reqSkill": 100,
+    "jobs": {
+      "DRK": 33,
+      "WAR": 34,
+      "BST": 34,
+      "BLM": 40
+    },
+    "hits": 1,
+    "description": "[[Blind (Status)"
+  },
+  "Origin": {
+    "name": "Origin",
+    "type": "Scythe",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      3,
+      6,
+      9
+    ],
+    "wsc": {
+      "str": 0.6,
+      "int": 0.6
+    },
+    "sc": [
+      "Induration",
+      "Reverberation",
+      "Fusion"
+    ],
+    "jobs": {
+      "DRKviaFoenaria(Level119)orhigher": 99
+    },
+    "hits": 1,
+    "description": "Absorbs HP and MP. Damage varies with TP."
+  },
+  "Quietus": {
+    "name": "Quietus",
+    "type": "Scythe",
+    "class": "Physical",
+    "tpMod": "Defense ignored",
+    "ftp": [
+      12.5,
+      37.5,
+      62.5
+    ],
+    "wsc": {
+      "str": 0.6,
+      "mnd": 0.6
+    },
+    "sc": [
+      "Darkness",
+      "Distortion"
+    ],
+    "quest": "Kupofried's Weapon Skill Moogle Magic",
+    "jobs": {
+      "DRKviaRedemption": 85,
+      "Penitence": 85,
+      "Penitence+1": 85
+    },
+    "hits": 1,
+    "description": "Delivers a triple damage attack that ignores target's defense. Amount ignored varies with [[TP]]."
+  },
+  "Salamander Flame": {
+    "name": "Salamander Flame",
+    "type": "Scythe",
+    "class": "Magical",
+    "element": "Fire",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light",
+      "Fusion"
+    ],
+    "jobs": {
+      ":Category:Trust": 50
+    },
+    "hits": 1,
+    "description": "Deals fire damage in an area around the user. Additional effect: [[Dia]]."
+  },
+  "Shadow of Death": {
+    "name": "Shadow of Death",
+    "type": "Scythe",
+    "class": "Magical",
+    "element": "{{dark}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      4.17,
+      8.6
+    ],
+    "wsc": {
+      "str": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Induration",
+      "Reverberation"
+    ],
+    "reqSkill": 70,
+    "jobs": {
+      "DRK": 23,
+      "WAR": 24,
+      "BST": 24,
+      "BLM": 28
+    },
+    "hits": 1,
+    "description": "Delivers a dark elemental attack. Damage varies with [[TP]]."
+  },
+  "Slice": {
+    "name": "Slice",
+    "type": "Scythe",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      2.5,
+      4.125
+    ],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Scission"
+    ],
+    "reqSkill": 5,
+    "jobs": {
+      "DRK": 1,
+      "WAR": 3,
+      "BST": 3,
+      "BLM": 4
+    },
+    "hits": 1,
+    "description": "Delivers a single-hit attack. Damage varies with [[TP]]."
+  },
+  "Spinning Scythe": {
+    "name": "Spinning Scythe",
+    "type": "Scythe",
+    "class": "Physical",
+    "tpMod": "Attack radius",
+    "ftp": [
+      3.5,
+      4.5,
+      5.5
+    ],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Reverberation",
+      "Scission"
+    ],
+    "reqSkill": 125,
+    "jobs": {
+      "DRK": 41,
+      "WAR": 43,
+      "BST": 43,
+      "BLM": 50
+    },
+    "hits": 1,
+    "description": "Delivers an [[area of effect]] attack. Attack radius varies with [[TP]]."
+  },
+  "Spiral Hell": {
+    "name": "Spiral Hell",
+    "type": "Scythe",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1.375,
+      2.75,
+      4.75
+    ],
+    "wsc": {
+      "str": 0.5,
+      "int": 0.5
+    },
+    "sc": [
+      "Distortion",
+      "Scission"
+    ],
+    "reqSkill": 240,
+    "quest": "Souls in Shadow",
+    "jobs": {
+      "DRK": 99,
+      "WAR": 99,
+      "BST": 99,
+      "BLMviaKajaScythe/Drepanum": 99
+    },
+    "hits": 1,
+    "description": "Delivers a single attack. Damage varies with [[TP]]."
+  },
+  "Vorpal Scythe": {
+    "name": "Vorpal Scythe",
+    "type": "Scythe",
+    "class": "Physical",
+    "tpMod": "Critical hit rate",
+    "ftp": [],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Transfixion",
+      "Scission"
+    ],
+    "reqSkill": 150,
+    "jobs": {
+      "DRK": 49,
+      "WAR": 51,
+      "BST": 51,
+      "BLM": 56
+    },
+    "hits": 1,
+    "description": "Delivers a single-hit attack. Chance of critical varies with [[TP]]."
+  },
+  "Spine Chiller": {
+    "name": "Spine Chiller",
+    "type": "Great Sword",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "{{question}}",
+      "{{question}}",
+      "{{question}}"
+    ],
+    "jobs": {
+      "Leonoyne": 73
+    },
+    "hits": 1,
+    "description": "{{question}}"
+  },
+  "Cataclysm": {
+    "name": "Cataclysm",
+    "type": "Staff",
+    "class": "Magical",
+    "element": "{{dark}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1.75,
+      3.75,
+      6.5
+    ],
+    "wsc": {
+      "str": 0.3,
+      "int": 0.3
+    },
+    "sc": [
+      "Compression",
+      "Reverberation"
+    ],
+    "reqSkill": 290,
+    "jobs": {
+      "PLD": 80,
+      "WAR": 83,
+      "MNK": 83,
+      "SMN": 83,
+      "BLM": 85,
+      "DRG": 85,
+      "WHM": 86,
+      "BRD": 86,
+      "SCH": 86,
+      "GEO": 86
+    },
+    "hits": 1,
+    "description": "Delivers an area attack that deals darkness elemental damage. Damage varies with TP."
+  },
+  "Earth Crusher": {
+    "name": "Earth Crusher",
+    "type": "Staff",
+    "class": "Magical",
+    "element": "{{earth}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      3.58,
+      6.16
+    ],
+    "wsc": {
+      "str": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Detonation",
+      "Impaction"
+    ],
+    "reqSkill": 70,
+    "jobs": {
+      "PLD": 23,
+      "WAR": 24,
+      "MNK": 24,
+      "BLM": 24,
+      "DRG": 24,
+      "SMN": 24,
+      "WHM": 25,
+      "BRD": 25,
+      "SCH": 25,
+      "GEO": 25
+    },
+    "hits": 1,
+    "description": "Delivers an area of effect [[earth]] attack. Damage varies with [[TP]]."
+  },
+  "Full Swing": {
+    "name": "Full Swing",
+    "type": "Staff",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      3,
+      9
+    ],
+    "wsc": {
+      "str": 0.5
+    },
+    "sc": [
+      "Liquefaction",
+      "Impaction"
+    ],
+    "reqSkill": 200,
+    "jobs": {
+      "PLD": 60,
+      "WAR": 62,
+      "MNK": 62,
+      "BLM": 62,
+      "DRG": 62,
+      "SMN": 62,
+      "WHM": 64,
+      "BRD": 64,
+      "SCH": 64,
+      "GEO": 64
+    },
+    "hits": 1,
+    "description": "Delivers a single-hit attack. Damage varies with [[TP]]."
+  },
+  "Garland of Bliss": {
+    "name": "Garland of Bliss",
+    "type": "Staff",
+    "class": "Magical",
+    "element": "{{light}}",
+    "tpMod": "Effect duration",
+    "ftp": [
+      60,
+      120,
+      180
+    ],
+    "wsc": {
+      "mnd": 0.7,
+      "str": 0.3
+    },
+    "sc": [
+      "Fusion",
+      "Reverberation"
+    ],
+    "quest": "Unlocking a Myth (Summoner)",
+    "jobs": {
+      "SMN": 75
+    },
+    "hits": 1,
+    "description": "Lowers target's defense.  Duration of effect varies with [[TP]]."
+  },
+  "Gate of Tartarus": {
+    "name": "Gate of Tartarus",
+    "type": "Staff",
+    "class": "Physical",
+    "tpMod": "Aftermath<br />(+8MP/tick Refresh)",
+    "ftp": [],
+    "wsc": {
+      "int": 0.8
+    },
+    "sc": [
+      "Darkness",
+      "Distortion"
+    ],
+    "jobs": {
+      "BLMorSMNviaThyrusorClaustrum": 75,
+      "BLMorSMNviaChthonicStaff": 85
+    },
+    "hits": 1,
+    "description": "Lowers target's [[attack]] [[Thyrus]]/[[Claustrum]]: Additional Effect: [[Refresh]]."
+  },
+  "Heavy Swing": {
+    "name": "Heavy Swing",
+    "type": "Staff",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      2,
+      3
+    ],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Impaction"
+    ],
+    "reqSkill": 5,
+    "jobs": {
+      "WAR": 1,
+      "MNK": 1,
+      "WHM": 1,
+      "BLM": 1,
+      "PLD": 1,
+      "BRD": 1,
+      "DRG": 1,
+      "SMN": 1,
+      "SCH": 1,
+      "GEO": 1
+    },
+    "hits": 1,
+    "description": "Delivers a single-hit attack. Damage varies with [[TP]]."
+  },
+  "Myrkr": {
+    "name": "Myrkr",
+    "type": "Staff",
+    "class": "None",
+    "tpMod": "MP Restored",
+    "ftp": [
+      20,
+      40,
+      60
+    ],
+    "wsc": {},
+    "sc": [],
+    "quest": "Kupofried's Weapon Skill Moogle Magic",
+    "jobs": {
+      "BLM": 85,
+      "SMN": 85,
+      "orSCHviaHvergelmir": 85,
+      "Taiaha": 85,
+      "Taiaha+1": 85
+    },
+    "hits": 1,
+    "description": "Restores [[MP]] and removes status ailments. Amount of MP restored varies with [[TP]]."
+  },
+  "Omniscience": {
+    "name": "Omniscience",
+    "type": "Staff",
+    "class": "Magical",
+    "element": "{{dark}}",
+    "tpMod": "Effect duration",
+    "ftp": [
+      60,
+      120,
+      180
+    ],
+    "wsc": {
+      "mnd": 0.8
+    },
+    "sc": [
+      "Gravitation",
+      "Transfixion"
+    ],
+    "quest": "Unlocking a Myth (Scholar)",
+    "jobs": {
+      "SCH": 75
+    },
+    "hits": 1,
+    "description": "Lowers target's magic attack.  Duration of effect varies with [[TP]]."
+  },
+  "Oshala": {
+    "name": "Oshala",
+    "type": "Staff",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      3.95,
+      7.89,
+      11.84
+    ],
+    "wsc": {
+      "mnd": 0.45,
+      "int": 0.45
+    },
+    "sc": [
+      "Induration",
+      "Reverberation",
+      "Fusion"
+    ],
+    "jobs": {
+      "BLM": 99,
+      "SMNandSCHviaOpashoro(Level119)orhigher": 99
+    },
+    "hits": 1,
+    "description": "Damage varies with TP."
+  },
+  "Retribution": {
+    "name": "Retribution",
+    "type": "Staff",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      2,
+      3,
+      5
+    ],
+    "wsc": {
+      "mnd": 0.5,
+      "str": 0.3
+    },
+    "sc": [
+      "Gravitation",
+      "Reverberation"
+    ],
+    "reqSkill": 230,
+    "quest": "Blood and Glory",
+    "jobs": {
+      "PLD": 67,
+      "WAR": 99,
+      "MNK": 99,
+      "SMN": 99,
+      "BLM": 99,
+      "DRG": 73,
+      "WHM": 99,
+      "BRD": 99,
+      "GEO": 99,
+      "RDM": 99,
+      "BST": 99,
+      "SCHviaKajaStaff/Xoanon": 99
+    },
+    "hits": 1,
+    "description": "Delivers a single attack. Damage varies with [[TP]]."
+  },
+  "Rock Crusher": {
+    "name": "Rock Crusher",
+    "type": "Staff",
+    "class": "Magical",
+    "element": "{{earth}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      3.27,
+      5.54
+    ],
+    "wsc": {
+      "str": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Impaction"
+    ],
+    "reqSkill": 40,
+    "jobs": {
+      "PLD": 13,
+      "WAR": 14,
+      "MNK": 14,
+      "WHM": 14,
+      "BLM": 14,
+      "BRD": 14,
+      "DRG": 14,
+      "SMN": 14,
+      "SCH": 14,
+      "GEO": 14
+    },
+    "hits": 1,
+    "description": "Delivers an [[earth]] elemental attack.  Damage varies with [[TP]]."
+  },
+  "Shattersoul": {
+    "name": "Shattersoul",
+    "type": "Staff",
+    "class": "Physical",
+    "tpMod": "Duration of effect",
+    "ftp": [
+      120,
+      120,
+      120
+    ],
+    "wsc": {
+      "int": 0.85
+    },
+    "sc": [
+      "Darkness",
+      "Gravitation",
+      "Induration"
+    ],
+    "reqSkill": 357,
+    "quest": "Martial Mastery",
+    "jobs": {
+      "PLD": 91,
+      "MNK": 94,
+      "SMN": 94,
+      "WAR": 94,
+      "BLM": 95,
+      "DRG": 95,
+      "WHM": 96,
+      "BRD": 96,
+      "SCH": 96,
+      "GEO": 96
+    },
+    "hits": 1,
+    "description": "Delivers a threefold attack. Decreases target's magic defense. Duration of effect varies with [[TP]]."
+  },
+  "Shell Crusher": {
+    "name": "Shell Crusher",
+    "type": "Staff",
+    "class": "Physical",
+    "tpMod": "Effect duration",
+    "ftp": [
+      180,
+      360,
+      540
+    ],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Detonation"
+    ],
+    "reqSkill": 175,
+    "jobs": {
+      "PLD": 55,
+      "WAR": 56,
+      "MNK": 56,
+      "BLM": 56,
+      "DRG": 56,
+      "SMN": 56,
+      "WHM": 57,
+      "BRD": 57,
+      "SCH": 57,
+      "GEO": 57
+    },
+    "hits": 1,
+    "description": "Lowers target's [[defense]]. Duration of effect varies with [[TP]]."
+  },
+  "Spirit Taker": {
+    "name": "Spirit Taker",
+    "type": "Staff",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      2,
+      3
+    ],
+    "wsc": {
+      "int": 0.5,
+      "mnd": 0.5
+    },
+    "sc": [],
+    "reqSkill": 215,
+    "jobs": {
+      "PLD": 63,
+      "WAR": 66,
+      "MNK": 66,
+      "SMN": 66,
+      "BLM": 68,
+      "DRG": 68,
+      "WHM": 70,
+      "BRD": 70,
+      "SCH": 70,
+      "GEO": 70
+    },
+    "hits": 1,
+    "description": "Converts damage dealt to own [[MP]]. Damage varies with [[TP]]."
+  },
+  "Starburst": {
+    "name": "Starburst",
+    "type": "Staff",
+    "class": "Magical",
+    "element": "{{light}}/{{dark}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      3.27,
+      5.54
+    ],
+    "wsc": {
+      "str": 0.4,
+      "mnd": 0.4
+    },
+    "sc": [
+      "Compression",
+      "Reverberation"
+    ],
+    "reqSkill": 100,
+    "jobs": {
+      "PLD": 33,
+      "WAR": 34,
+      "MNK": 34,
+      "BLM": 34,
+      "DRG": 34,
+      "SMN": 34,
+      "WHM": 35,
+      "BRD": 35,
+      "SCH": 35,
+      "GEO": 35
+    },
+    "hits": 1,
+    "description": "Delivers a [[light]]/[[dark]] attack.  Damage varies with [[TP]]."
+  },
+  "Sunburst": {
+    "name": "Sunburst",
+    "type": "Staff",
+    "class": "Magical",
+    "element": "{{light}}/{{dark}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      3.58,
+      6.16
+    ],
+    "wsc": {
+      "str": 0.4,
+      "mnd": 0.4
+    },
+    "sc": [
+      "Compression",
+      "Reverberation"
+    ],
+    "reqSkill": 150,
+    "jobs": {
+      "PLD": 49,
+      "WAR": 51,
+      "MNK": 51,
+      "BLM": 51,
+      "DRG": 51,
+      "SMN": 51,
+      "WHM": 52,
+      "BRD": 52,
+      "SCH": 52,
+      "GEO": 52
+    },
+    "hits": 1,
+    "description": "Delivers a [[light]]/[[dark]] attack.  Damage varies with [[TP]]."
+  },
+  "Vidohunir": {
+    "name": "Vidohunir",
+    "type": "Staff",
+    "class": "Magical",
+    "element": "{{dark}}",
+    "tpMod": "Effect duration",
+    "ftp": [
+      60,
+      120,
+      180
+    ],
+    "wsc": {
+      "int": 0.8
+    },
+    "sc": [
+      "Fragmentation",
+      "Distortion"
+    ],
+    "quest": "Unlocking a Myth (Black Mage)",
+    "jobs": {
+      "BLM": 75
+    },
+    "hits": 1,
+    "description": "Lowers target's magic defense.  Duration of effect varies with [[TP]]."
+  },
+  "Arrogance Incarnate": {
+    "name": "Arrogance Incarnate",
+    "type": "Sword",
+    "class": "Breath",
+    "element": "{{Light}}",
+    "tpMod": "Damage",
+    "ftp": [
+      9.375,
+      37.5,
+      75
+    ],
+    "wsc": {},
+    "sc": [],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Delivers an unavoidable area attack. Damage varies with [[HP]] and [[TP]]."
+  },
+  "Atonement": {
+    "name": "Atonement",
+    "type": "Sword",
+    "class": "Breath",
+    "tpMod": "Enmity multiplier",
+    "ftp": [
+      1,
+      1.5,
+      2
+    ],
+    "wsc": {},
+    "sc": [
+      "Fusion",
+      "Reverberation"
+    ],
+    "quest": "Unlocking a Myth (Paladin)",
+    "jobs": {
+      "PLD": 75
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack.  Enmity varies with [[TP]]."
+  },
+  "Berserk-Ruf": {
+    "name": "Berserk-Ruf",
+    "type": "Sword",
+    "class": "None",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Enhances attacks. TP increases {{question}}"
+  },
+  "Burning Blade": {
+    "name": "Burning Blade",
+    "type": "Sword",
+    "class": "Magical",
+    "element": "{{fire}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      2,
+      3
+    ],
+    "wsc": {
+      "str": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Liquefaction"
+    ],
+    "reqSkill": 30,
+    "jobs": {
+      "PLD": 9,
+      "BLU": 9,
+      "RUN": 9,
+      "WAR": 10,
+      "RDM": 10,
+      "DRK": 10,
+      "BRD": 10,
+      "SAM": 10,
+      "NIN": 10,
+      "DRG": 10,
+      "COR": 10,
+      "THF": 11,
+      "RNG": 11,
+      "DNC": 11,
+      "BST": 12
+    },
+    "hits": 1,
+    "description": "Deals fire elemental damage to enemy. Damage varies with [[TP]]."
+  },
+  "Chant du Cygne": {
+    "name": "Chant du Cygne",
+    "type": "Sword",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [
+      15,
+      25,
+      40
+    ],
+    "wsc": {
+      "dex": 0.8
+    },
+    "sc": [
+      "Light",
+      "Distortion"
+    ],
+    "quest": "Kupofried's Weapon Skill Moogle Magic",
+    "jobs": {
+      "RDM": 85,
+      "PLD": 85,
+      "BLUviaAlmace": 85,
+      "Badelaire": 85,
+      "Badelaire+1": 85
+    },
+    "hits": 1,
+    "description": "Delivers a threefold attack. Chance of critical hit varies with [[TP]]."
+  },
+  "Circle Blade": {
+    "name": "Circle Blade",
+    "type": "Sword",
+    "class": "Physical",
+    "tpMod": "Attack Radius",
+    "ftp": [],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Reverberation",
+      "Impaction"
+    ],
+    "reqSkill": 150,
+    "jobs": {
+      "PLD": 49,
+      "BLU": 49,
+      "RUN": 49,
+      "WAR": 51,
+      "RDM": 51,
+      "DRK": 51,
+      "COR": 51,
+      "BRD": 52,
+      "SAM": 52,
+      "NIN": 52,
+      "DRG": 52,
+      "THF": 53,
+      "RNG": 53,
+      "DNC": 53,
+      "BST": 56
+    },
+    "hits": 1,
+    "description": "Delivers an area of effect attack. Attack radius varies with [[TP]]."
+  },
+  "Coming Up Roses": {
+    "name": "Coming Up Roses",
+    "type": "Sword",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light",
+      "Fusion"
+    ],
+    "jobs": {
+      ":BGWiki:Trusts#Mayakov": 60
+    },
+    "hits": 1,
+    "description": "Deliverth a beautiful blow to the target."
+  },
+  "Death Blossom": {
+    "name": "Death Blossom",
+    "type": "Sword",
+    "class": "Physical",
+    "tpMod": "Effect accuracy",
+    "ftp": [],
+    "wsc": {
+      "mnd": 0.5,
+      "str": 0.3
+    },
+    "sc": [
+      "Fragmentation",
+      "Distortion"
+    ],
+    "quest": "Unlocking a Myth (Red Mage)",
+    "jobs": {
+      "RDM": 75
+    },
+    "hits": 1,
+    "description": "Delivers a threefold attack that lowers target's [[magic evasion]].  Chance of lowering target's magic evasion varies with [[TP]]."
+  },
+  "Dominion Slash": {
+    "name": "Dominion Slash",
+    "type": "Sword",
+    "class": "Physical",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [],
+    "jobs": {
+      ":Category:Trust": null
+    },
+    "hits": 1,
+    "description": "Deals area damage."
+  },
+  "Expiacion": {
+    "name": "Expiacion",
+    "type": "Sword",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      3.796875,
+      9.390625,
+      12.1875
+    ],
+    "wsc": {
+      "str": 0.3,
+      "dex": 0.2,
+      "int": 0.3
+    },
+    "sc": [
+      "Distortion",
+      "Scission"
+    ],
+    "quest": "Unlocking a Myth (Blue Mage)",
+    "jobs": {
+      "BLU": 75
+    },
+    "hits": 1,
+    "description": "Delivers a twofold attack.  Damage varies with [[TP]]."
+  },
+  "Fast Blade": {
+    "name": "Fast Blade",
+    "type": "Sword",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      3,
+      5
+    ],
+    "wsc": {
+      "str": 0.4,
+      "dex": 0.4
+    },
+    "sc": [
+      "Scission"
+    ],
+    "reqSkill": 5,
+    "jobs": {
+      "PLD": 1,
+      "BLU": 1,
+      "WAR": 3,
+      "RDM": 3,
+      "DRK": 3,
+      "BRD": 3,
+      "SAM": 3,
+      "NIN": 3,
+      "DRG": 3,
+      "COR": 3,
+      "RUN": 3,
+      "THF": 4,
+      "BST": 4,
+      "RNG": 4,
+      "DNC": 4
+    },
+    "hits": 1,
+    "description": "Two-hit attack. Damage varies with [[TP]]."
+  },
+  "Fast Blade II": {
+    "name": "Fast Blade II",
+    "type": "Sword",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      1.8,
+      3.5,
+      5
+    ],
+    "wsc": {
+      "dex": 0.8
+    },
+    "sc": [
+      "Fusion"
+    ],
+    "jobs": {
+      "AllJobs": 99
+    },
+    "hits": 1,
+    "description": "Two-hit attack. Damage varies with [[TP]]."
+  },
+  "Flat Blade": {
+    "name": "Flat Blade",
+    "type": "Sword",
+    "class": "Physical",
+    "tpMod": "Effect accuracy",
+    "ftp": [],
+    "wsc": {
+      "str": 1
+    },
+    "sc": [
+      "Impaction"
+    ],
+    "reqSkill": 75,
+    "jobs": {
+      "PLD": 24,
+      "BLU": 24,
+      "RUN": 24,
+      "WAR": 26,
+      "RDM": 26,
+      "DRK": 26,
+      "BRD": 26,
+      "SAM": 26,
+      "NIN": 26,
+      "DRG": 26,
+      "COR": 26,
+      "THF": 28,
+      "RNG": 28,
+      "DNC": 28,
+      "BST": 30
+    },
+    "hits": 1,
+    "description": "[[Stun]]s enemy. Chance of stunning varies with [[TP]]."
+  },
+  "Imperator": {
+    "name": "Imperator",
+    "type": "Sword",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      3.75,
+      7.5,
+      11.75
+    ],
+    "wsc": {
+      "dex": 0.7,
+      "mnd": 0.7
+    },
+    "sc": [
+      "Detonation",
+      "Compression",
+      "Distortion"
+    ],
+    "jobs": {
+      "RDM": 99,
+      "PLDandBLUviaCaliburnus(Level119)orhigher": 99
+    },
+    "hits": 1,
+    "description": "Damage varies with TP."
+  },
+  "Knights of Rotund": {
+    "name": "Knights of Rotund",
+    "type": "Sword",
+    "class": "Physical",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "Light"
+    ],
+    "jobs": {
+      "jobs": 1
+    },
+    "hits": 1,
+    "description": "BMI varies with TP"
+  },
+  "Knights of Round": {
+    "name": "Knights of Round",
+    "type": "Sword",
+    "class": "Physical",
+    "tpMod": "Aftermath<br />(+10HP/tick Regen)",
+    "ftp": [
+      20,
+      40,
+      60
+    ],
+    "wsc": {
+      "str": 0.4,
+      "mnd": 0.4
+    },
+    "sc": [
+      "Light",
+      "Fusion"
+    ],
+    "jobs": {
+      "RDM": 85,
+      "PLDviaCaliburnorExcalibur": 75,
+      "PLD": 85,
+      "BLUviaCorbenicSword": 85
+    },
+    "hits": 1,
+    "description": "[[Caliburn]]/[[Excalibur]]: Additional Effect: Regen"
+  },
+  "Red Lotus Blade": {
+    "name": "Red Lotus Blade",
+    "type": "Sword",
+    "class": "Magical",
+    "element": "{{fire}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1,
+      2,
+      3.75
+    ],
+    "wsc": {
+      "str": 0.4,
+      "int": 0.4
+    },
+    "sc": [
+      "Liquefaction",
+      "Detonation"
+    ],
+    "reqSkill": 50,
+    "jobs": {
+      "PLD": 16,
+      "BLU": 16,
+      "RUN": 16,
+      "WAR": 17,
+      "RDM": 17,
+      "DRK": 17,
+      "COR": 17,
+      "SAM": 18,
+      "NIN": 18,
+      "DRG": 18,
+      "BRD": 18,
+      "THF": 19,
+      "RNG": 19,
+      "DNC": 19,
+      "BST": 20
+    },
+    "hits": 1,
+    "description": "Deals fire elemental damage to enemy. Damage varies with [[TP]]."
+  },
+  "Requiescat": {
+    "name": "Requiescat",
+    "type": "Sword",
+    "class": "Physical",
+    "tpMod": "Attack Power",
+    "ftp": [
+      -20,
+      -10,
+      0
+    ],
+    "wsc": {
+      "mnd": 0.85
+    },
+    "sc": [
+      "Darkness",
+      "Gravitation",
+      "Scission"
+    ],
+    "reqSkill": 357,
+    "quest": "Martial Mastery",
+    "jobs": {
+      "PLD": 90,
+      "BLU": 90,
+      "RUN": 91,
+      "WAR": 94,
+      "RDM": 94,
+      "DRK": 95,
+      "COR": 95,
+      "SAM": 96
+    },
+    "hits": 1,
+    "description": "Delivers a fivefold attack, non-elemental damage. Attack power varies with [[TP]]."
+  },
+  "Sanguine Blade": {
+    "name": "Sanguine Blade",
+    "type": "Sword",
+    "class": "Magical",
+    "element": "{{dark}}",
+    "tpMod": "HP Drained",
+    "ftp": [
+      50,
+      100,
+      160
+    ],
+    "wsc": {
+      "mnd": 0.5,
+      "str": 0.3
+    },
+    "sc": [],
+    "reqSkill": 300,
+    "jobs": {
+      "PLD": 80,
+      "BLU": 80,
+      "RUN": 81,
+      "WAR": 85,
+      "RDM": 85,
+      "DRK": 86,
+      "COR": 86,
+      "SAM": 88,
+      "NIN": 89,
+      "BRD": 90,
+      "DRG": 90,
+      "THF": 94,
+      "RNG": 94,
+      "DNC": 94,
+      "BST": 99
+    },
+    "hits": 1,
+    "description": "Drains target's [[HP]]. Amount drained varies with [[TP]]."
+  },
+  "Savage Blade": {
+    "name": "Savage Blade",
+    "type": "Sword",
+    "class": "Physical",
+    "tpMod": "fTP",
+    "ftp": [
+      4,
+      10.25,
+      13.75
+    ],
+    "wsc": {
+      "str": 0.5,
+      "mnd": 0.5
+    },
+    "sc": [
+      "Fragmentation",
+      "Scission"
+    ],
+    "reqSkill": 240,
+    "quest": "Old Wounds",
+    "jobs": {
+      "PLD": 99,
+      "BLU": 99,
+      "RUN": 99,
+      "WAR": 99,
+      "RDM": 99,
+      "DRK": 99,
+      "COR": 99,
+      "THF": 99,
+      "BST": 99,
+      "BRD": 99,
+      "RNG": 99,
+      "NIN": 99,
+      "DRGviaKajaSword/Naeglinginthemainhandonly": 99
+    },
+    "hits": 2,
+    "description": "Delivers an aerial attack comprised of two hits. Damage varies with [[TP]]."
+  },
+  "Seraph Blade": {
+    "name": "Seraph Blade",
+    "type": "Sword",
+    "class": "Magical",
+    "element": "{{light}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1.125,
+      2.625,
+      4.125
+    ],
+    "wsc": {
+      "str": 0.4,
+      "mnd": 0.4
+    },
+    "sc": [
+      "Scission"
+    ],
+    "reqSkill": 125,
+    "jobs": {
+      "PLD": 41,
+      "BLU": 41,
+      "RUN": 41,
+      "WAR": 43,
+      "RDM": 43,
+      "DRK": 43,
+      "COR": 43,
+      "BRD": 44,
+      "SAM": 44,
+      "NIN": 44,
+      "DRG": 44,
+      "THF": 46,
+      "RNG": 46,
+      "DNC": 46,
+      "BST": 50
+    },
+    "hits": 1,
+    "description": "Deals light elemental damage to enemy. Damage varies with [[TP]]."
+  },
+  "Shining Blade": {
+    "name": "Shining Blade",
+    "type": "Sword",
+    "class": "Magical",
+    "element": "{{light}}",
+    "tpMod": "fTP",
+    "ftp": [
+      1.125,
+      2,
+      3
+    ],
+    "wsc": {
+      "str": 0.4,
+      "mnd": 0.4
+    },
+    "sc": [
+      "Scission"
+    ],
+    "reqSkill": 100,
+    "jobs": {
+      "PLD": 33,
+      "BLU": 33,
+      "RUN": 33,
+      "WAR": 34,
+      "RDM": 34,
+      "DRK": 34,
+      "COR": 34,
+      "BRD": 35,
+      "SAM": 35,
+      "NIN": 35,
+      "DRG": 35,
+      "THF": 37,
+      "RNG": 37,
+      "DNC": 37,
+      "BST": 40
+    },
+    "hits": 1,
+    "description": "Deals light elemental damage to enemy. Damage varies with [[TP]]."
+  },
+  "Spirits Within": {
+    "name": "Spirits Within",
+    "type": "Sword",
+    "class": "Breath",
+    "element": "{{Light}}",
+    "tpMod": "Damage",
+    "ftp": [
+      12.5,
+      50,
+      100
+    ],
+    "wsc": {},
+    "sc": [],
+    "reqSkill": 175,
+    "jobs": {
+      "PLD": 55,
+      "BLU": 55,
+      "RUN": 55,
+      "WAR": 56,
+      "RDM": 56,
+      "DRK": 56,
+      "COR": 56,
+      "BRD": 57,
+      "SAM": 57,
+      "NIN": 57,
+      "DRG": 57,
+      "THF": 59,
+      "RNG": 59,
+      "DNC": 59,
+      "BST": 63
+    },
+    "hits": 1,
+    "description": "Delivers an unavoidable attack. Damage varies with [[HP]] and [[TP]]."
+  },
+  "Swift Blade": {
+    "name": "Swift Blade",
+    "type": "Sword",
+    "class": "Physical",
+    "tpMod": "Accuracy",
+    "ftp": [],
+    "wsc": {
+      "str": 0.5,
+      "mnd": 0.5
+    },
+    "sc": [
+      "Gravitation"
+    ],
+    "reqSkill": 225,
+    "jobs": {
+      "PLD": 99,
+      "RUN": 66,
+      "WAR": 99,
+      "THF": 99,
+      "DRK": 99,
+      "SAM": 99,
+      "BLU": 99,
+      "CORviaHepatizonSapara/HepatizonSapara+1": 99,
+      "RDM": 99,
+      "BRD": 99,
+      "DRG": 99,
+      "COR": 99,
+      "DNCviaHepatizonRapier/HepatizonRapier+1": 99
+    },
+    "hits": 1,
+    "description": "Delivers a three-hit attack. Accuracy varies with [[TP]]."
+  },
+  "Vorpal Blade": {
+    "name": "Vorpal Blade",
+    "type": "Sword",
+    "class": "Physical",
+    "tpMod": "Critical Hit Rate",
+    "ftp": [],
+    "wsc": {
+      "str": 0.6
+    },
+    "sc": [
+      "Scission",
+      "Impaction"
+    ],
+    "reqSkill": 200,
+    "jobs": {
+      "PLD": 60,
+      "BLU": 60,
+      "RUN": 60,
+      "WAR": 62,
+      "RDM": 62,
+      "DRK": 62,
+      "COR": 62,
+      "SAM": 64,
+      "BRD": 65,
+      "NIN": 65,
+      "DRG": 65,
+      "THF": 70,
+      "RNG": 70,
+      "DNC": 70,
+      "BST": 75
+    },
+    "hits": 1,
+    "description": "Delivers a fourfold attack. Chance of critical hit varies with [[TP]]."
+  },
+  "Tartarus Torpor": {
+    "name": "Tartarus Torpor",
+    "type": "Staff",
+    "class": "Magical",
+    "element": "{{Dark}}",
+    "tpMod": "Duration",
+    "ftp": [],
+    "wsc": {
+      "str": 0.3,
+      "int": 0.3
+    },
+    "sc": [],
+    "jobs": {
+      "MNK": 73,
+      "WHM": 73,
+      "BLM": 73,
+      "RDM": 73,
+      "PLD": 73,
+      "BRD": 73,
+      "RNG": 73,
+      "SMN": 73,
+      "BLU": 73,
+      "PUP": 73,
+      "SCH": 73,
+      "GEO": 73,
+      "RUN": 73
+    },
+    "hits": 1,
+    "description": "Puts to sleep enemies within the area of effect and lowers their magical defense and magical evasion. Duration of effect varies with TP."
+  },
+  "Tongue Lash": {
+    "name": "Tongue Lash",
+    "type": "Sword",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "{{question}}",
+      "{{question}}",
+      "{{question}}"
+    ],
+    "jobs": {
+      "RongeloutsNDistaud": 73
+    },
+    "hits": 1,
+    "description": "{{question}}"
+  },
+  "Uriel Blade": {
+    "name": "Uriel Blade",
+    "type": "Sword",
+    "class": "Magical",
+    "element": "{{Light}}",
+    "tpMod": "fTP",
+    "ftp": [],
+    "wsc": {
+      "str": 0.32,
+      "mnd": 0.32
+    },
+    "sc": [
+      "Light",
+      "Fragmentation",
+      "Scission"
+    ],
+    "jobs": {
+      "WAR": 73,
+      "RDM": 73,
+      "PLD": 73,
+      "DRK": 73,
+      "BLU": 73,
+      "COR": 73,
+      "RUN": 73
+    },
+    "hits": 1,
+    "description": "Delivers an area attack that deals light elemental damage. Additional effect: Flash. Damage varies with TP."
+  },
+  "Volant Angon": {
+    "name": "Volant Angon",
+    "type": "Polearm",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "{{question}}",
+      "{{question}}",
+      "{{question}}"
+    ],
+    "jobs": {
+      "YrvaulairSCousseraux": 73
+    },
+    "hits": 1,
+    "description": "{{question}}"
+  },
+  "Warden of Terror": {
+    "name": "Warden of Terror",
+    "type": "Great Sword",
+    "class": "{{question}}",
+    "element": "{{question}}",
+    "tpMod": "{{question}}",
+    "ftp": [],
+    "wsc": {},
+    "sc": [
+      "{{question}}",
+      "{{question}}",
+      "{{question}}"
+    ],
+    "jobs": {
+      "Duskraven": 73
+    },
+    "hits": 1,
+    "description": "{{question}}"
   }
-};
+}

--- a/scripts/generateWeaponSkills.js
+++ b/scripts/generateWeaponSkills.js
@@ -1,0 +1,119 @@
+import fs from 'fs';
+import { execSync } from 'child_process';
+
+function fetchJSON(url) {
+  const output = execSync(`curl -L --silent ${JSON.stringify(url)}`);
+  return JSON.parse(output.toString());
+}
+
+function getAllWeaponSkillPages() {
+  let members = [];
+  let cont = '';
+  do {
+    const url = `https://www.bg-wiki.com/api.php?action=query&list=categorymembers&cmtitle=Category:Weapon_Skills&cmlimit=500&format=json${cont ? `&cmcontinue=${encodeURIComponent(cont)}` : ''}`;
+    const data = fetchJSON(url);
+    const items = data.query?.categorymembers || [];
+    members = members.concat(items.filter(m => m.ns === 0 && !m.title.includes('Weapon Skills')));
+    cont = data.continue?.cmcontinue;
+  } while (cont);
+  return members;
+}
+
+function parseWSC(statmod) {
+  const wsc = {};
+  if (!statmod) return wsc;
+  const regex = /(\d+)%\s*\[\[(\w+)\]\]/g;
+  let m;
+  while ((m = regex.exec(statmod)) !== null) {
+    wsc[m[2].toLowerCase()] = Number(m[1]) / 100;
+  }
+  return wsc;
+}
+
+function parseJobLevels(text) {
+  const jobs = {};
+  const regex = /\{\{WS Job Level\n?\|([^}]*)\}\}/g;
+  let m;
+  while ((m = regex.exec(text)) !== null) {
+    const body = m[1];
+    const level = Number(/level=(\d+)/.exec(body)?.[1]);
+    const jobsPart = /jobs=([^|]+)/.exec(body)?.[1] || '';
+    const jobList = jobsPart.replace(/\[\[|\]\]|\s|'/g, '').split(',').filter(Boolean);
+    for (const j of jobList) {
+      jobs[j] = level;
+    }
+  }
+  return jobs;
+}
+
+function parseTPMods(text) {
+  const tp = [];
+  const m100 = /\|100TP=([^\n|]+)/.exec(text);
+  const m200 = /\|200TP=([^\n|]+)/.exec(text);
+  const m300 = /\|300TP=([^\n|]+)/.exec(text);
+  if (m100 && m200 && m300) {
+    const n100 = parseFloat(m100[1]);
+    const n200 = parseFloat(m200[1]);
+    const n300 = parseFloat(m300[1]);
+    if (!Number.isNaN(n100) && !Number.isNaN(n200) && !Number.isNaN(n300)) {
+      tp.push(n100, n200, n300);
+    }
+  }
+  return tp;
+}
+
+function getField(text, field) {
+  const m = new RegExp(`\\|${field}=([^\\n|]*)`).exec(text);
+  if (!m) return undefined;
+  return m[1].replace(/<\!--.*?-->/g, '').trim() || undefined;
+}
+
+function parseHits(description) {
+  const m = /(\d+)[- ]?hit/.exec(description.toLowerCase());
+  if (m) return Number(m[1]);
+  const words = { one:1, two:2, three:3, four:4, five:5, six:6, seven:7, eight:8, nine:9 };
+  const m2 = /comprised of (\w+) hits/.exec(description.toLowerCase());
+  if (m2 && words[m2[1]]) return words[m2[1]];
+  return 1;
+}
+
+function fetchWeaponSkill(title) {
+  const page = title.replace(/ /g, '_');
+  const url = `https://www.bg-wiki.com/api.php?action=parse&page=${encodeURIComponent(page)}&prop=wikitext&format=json`;
+  const data = fetchJSON(url);
+  const text = data.parse?.wikitext?.['*'] || '';
+  const description = getField(text, 'description') || '';
+  return {
+    name: data.parse.title,
+    type: getField(text, 'type'),
+    class: getField(text, 'class'),
+    element: getField(text, 'element'),
+    tpMod: getField(text, 'tpmod'),
+    ftp: parseTPMods(text),
+    wsc: parseWSC(getField(text, 'statmod')),
+    sc: [getField(text, 'sc1'), getField(text, 'sc2'), getField(text, 'sc3')].filter(Boolean),
+    reqSkill: Number(getField(text, 'reqskill')) || undefined,
+    quest: getField(text, 'quest'),
+    jobs: parseJobLevels(text),
+    hits: parseHits(description),
+    description
+  };
+}
+
+function main() {
+  const pages = getAllWeaponSkillPages();
+  const result = {};
+  for (const p of pages) {
+    try {
+      const ws = fetchWeaponSkill(p.title);
+      result[ws.name] = ws;
+    } catch (e) {
+      console.error('Failed', p.title, e.message);
+    }
+  }
+  const out = 'export const weaponSkillDetails = ' + JSON.stringify(result, null, 2) + '\n';
+  fs.writeFileSync('data/weaponskills.js', out);
+}
+
+main();
+


### PR DESCRIPTION
## Summary
- add script to scrape BG-wiki for weapon skill metadata
- regenerate weapon skill database with type, element, TP mods, stat weights, skill/job requirements and quests

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_6891459fd3508325888460ac790b602f