### PR TITLE
Add Sleep and Stun black magic spells

### DIFF
--- a/data/characters.js
+++ b/data/characters.js
@@ -748,6 +748,7 @@ export function clearTemporaryEffects(character) {
   character.stoneskinHP = 0;
   character.slowMultiplier = 0;
   character.asleep = false;
+  character.stunned = false;
 }
 
 export function pruneExpiredEffects(character) {
@@ -771,6 +772,7 @@ export function pruneExpiredEffects(character) {
     if (d.mdb) character.mdb = (character.mdb || 0) + d.mdb;
     if (d.slow) character.slowMultiplier = 0;
     if (d.sleep) character.asleep = false;
+    if (d.stun) character.stunned = false;
     if (character.debuffs) {
       const idx = character.debuffs.indexOf(d.name);
       if (idx !== -1) character.debuffs.splice(idx, 1);

--- a/data/spells.js
+++ b/data/spells.js
@@ -1244,6 +1244,86 @@ const whiteMagicSpells = [
 
 spells.push(...whiteMagicSpells);
 
+const blackEnfeeblingSpells = [
+  {
+    name: 'Sleep',
+    level: 20,
+    element: 'Dark',
+    target: 'ST',
+    mpCost: 19,
+    castTime: 2.5,
+    recastTime: 30,
+    magicType: 'Black Magic',
+    subType: 'Enfeebling',
+    proficiency: 'Enfeebling Magic',
+    tier: 1,
+    noInitialDamage: true,
+    debuff: { duration: 60, sleep: true }
+  },
+  {
+    name: 'Sleep II',
+    level: 41,
+    element: 'Dark',
+    target: 'ST',
+    mpCost: 29,
+    castTime: 3,
+    recastTime: 30,
+    magicType: 'Black Magic',
+    subType: 'Enfeebling',
+    proficiency: 'Enfeebling Magic',
+    tier: 2,
+    noInitialDamage: true,
+    debuff: { duration: 90, sleep: true }
+  },
+  {
+    name: 'Sleepga',
+    level: 31,
+    element: 'Dark',
+    target: 'AoE',
+    mpCost: 38,
+    castTime: 3,
+    recastTime: 30,
+    magicType: 'Black Magic',
+    subType: 'Enfeebling',
+    proficiency: 'Enfeebling Magic',
+    tier: 1,
+    noInitialDamage: true,
+    debuff: { duration: 60, sleep: true }
+  },
+  {
+    name: 'Sleepga II',
+    level: 56,
+    element: 'Dark',
+    target: 'AoE',
+    mpCost: 58,
+    castTime: 3.5,
+    recastTime: 45,
+    magicType: 'Black Magic',
+    subType: 'Enfeebling',
+    proficiency: 'Enfeebling Magic',
+    tier: 2,
+    noInitialDamage: true,
+    debuff: { duration: 90, sleep: true }
+  },
+  {
+    name: 'Stun',
+    level: 45,
+    element: 'Lightning',
+    target: 'ST',
+    mpCost: 25,
+    castTime: 0.5,
+    recastTime: 45,
+    magicType: 'Black Magic',
+    subType: 'Dark',
+    proficiency: 'Dark Magic',
+    tier: 1,
+    baseDamage: 10,
+    debuff: { duration: 5, stun: true }
+  }
+];
+
+spells.push(...blackEnfeeblingSpells);
+
 const dotSpells = [];
 
 // Poison line


### PR DESCRIPTION
## Summary
- add Sleep, Sleep II, Sleepga, Sleepga II, and Stun to black magic spell list
- support stun debuff and state handling in characters and battle flow

## Testing
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_68917917be84832588aa303443ee5b46