### PR TITLE
Add basic crafting professions and pages

### DIFF
--- a/data/characters.js
+++ b/data/characters.js
@@ -5,12 +5,14 @@ import { parseCoordinate } from '../js/encounter.js';
 import { bestiaryByZone } from './bestiary.js';
 import { getScale, proficiencyScale } from './scales.js';
 import { weaponSkills, magicSkills } from './proficiencies.js';
+import { craftNames } from './crafting.js';
 
 const aldoScale = buildScaleFields('Hume', 'Thief');
 const shantottoScale = buildScaleFields('Tarutaru', 'Black Mage');
 
 const baseCombatSkills = Object.fromEntries(weaponSkills.map(s => [s, 0]));
 const baseMagicSkills = Object.fromEntries(magicSkills.map(s => [s.name, 0]));
+const baseCraftSkills = Object.fromEntries(craftNames.map(c => [c, 0]));
 
 const startingGearByJob = {
   'Warrior': { weapon: 'bronzeSword', armor: 'leatherVest' },
@@ -162,7 +164,7 @@ export const characters = [
     gil: 100000,
     combatSkills: { ...baseCombatSkills },
     magicSkills: { ...baseMagicSkills },
-    crafting: {},
+    crafting: { ...baseCraftSkills },
     spells: [],
     ...aldoScale,
     mLvX: 0,
@@ -248,7 +250,7 @@ export const characters = [
     gil: 500000,
     combatSkills: { ...baseCombatSkills },
     magicSkills: { ...baseMagicSkills },
-    crafting: {},
+    crafting: { ...baseCraftSkills },
     spells: [],
     ...shantottoScale,
     mLvX: 0,
@@ -360,7 +362,7 @@ export function createCharacterObject(name, job, race, sex = 'Male') {
     gil: STARTING_GIL,
     combatSkills: { ...baseCombatSkills },
     magicSkills: { ...baseMagicSkills },
-    crafting: {},
+    crafting: { ...baseCraftSkills },
     spells: [],
     ...buildScaleFields(selectedRace, selectedJob),
     mLvX: 0,

--- a/data/crafting.js
+++ b/data/crafting.js
@@ -1,0 +1,49 @@
+export const crafts = [
+  {
+    name: 'Alchemy',
+    description: 'Creates potions and chemical concoctions.',
+    guild: 'Bastok Markets'
+  },
+  {
+    name: 'Bonecraft',
+    description: 'Shapes bone and shell into equipment.',
+    guild: 'Windurst Woods'
+  },
+  {
+    name: 'Clothcraft',
+    description: 'Weaves fabrics and tailors clothing.',
+    guild: 'Windurst Woods'
+  },
+  {
+    name: 'Cooking',
+    description: 'Prepares meals and beverages.',
+    guild: 'Windurst Waters'
+  },
+  {
+    name: 'Fishing',
+    description: 'Catches fish with rods and bait.',
+    guild: 'Port Windurst'
+  },
+  {
+    name: 'Goldsmithing',
+    description: 'Works precious metals and gems.',
+    guild: 'Bastok Mines'
+  },
+  {
+    name: 'Leathercraft',
+    description: 'Tans hides and crafts leather gear.',
+    guild: 'Southern San d\'Oria'
+  },
+  {
+    name: 'Smithing',
+    description: 'Forges metal weapons and armor.',
+    guild: 'Bastok Markets'
+  },
+  {
+    name: 'Woodworking',
+    description: 'Shapes lumber into tools and weapons.',
+    guild: 'Northern San d\'Oria'
+  }
+];
+
+export const craftNames = crafts.map(c => c.name);

--- a/data/index.js
+++ b/data/index.js
@@ -1,6 +1,7 @@
 export { jobs, jobNames, baseJobNames } from './jobs.js';
 export { races, raceNames, startingCities } from './races.js';
 export { weaponSkills, magicSkills } from './proficiencies.js';
+export { crafts, craftNames } from './crafting.js';
 export {
   characters,
   activeCharacter,

--- a/js/ui.js
+++ b/js/ui.js
@@ -54,7 +54,8 @@ import {
     getAvailableSpells,
     weaponSkillDetails,
     resolveSkillchain,
-    skillchainBonus
+    skillchainBonus,
+    crafts
 } from '../data/index.js';
 import { randomName, raceInfo, jobInfo, cityImages, characterImages, getZoneTravelTurns, exploreEncounter, parseLevel, expNeeded, expToLevel} from '../data/index.js';
 import { onTick } from './tick.js';
@@ -1305,6 +1306,13 @@ export function renderMainMenu() {
             renderEquipmentScreen(container);
         });
 
+        const craftBtn = document.createElement('button');
+        craftBtn.className = 'profile-btn';
+        craftBtn.textContent = 'Crafting';
+        craftBtn.addEventListener('click', () => {
+            renderCraftingScreen(container);
+        });
+
         const jobBtn = document.createElement('button');
         jobBtn.className = 'profile-btn';
         jobBtn.textContent = 'Change Job';
@@ -1328,6 +1336,7 @@ export function renderMainMenu() {
 
         details.appendChild(invBtn);
         details.appendChild(equipBtn);
+        details.appendChild(craftBtn);
         if (modeBtn) details.appendChild(modeBtn);
         if (/Residential Area/i.test(activeCharacter.currentLocation)) {
             group.appendChild(jobBtn);
@@ -4145,6 +4154,56 @@ export function renderConquestShop(root, backFn = null) {
     });
     root.appendChild(list);
     showBackButton(backFn || (() => refreshMainMenu(root.parentElement)));
+}
+
+export function renderCraftingScreen(root) {
+    root.innerHTML = '';
+    resetDetails();
+    showBackButton(() => refreshMainMenu(root.parentElement));
+    const title = document.createElement('h2');
+    title.textContent = 'Crafting';
+    root.appendChild(title);
+    root.appendChild(characterSummary());
+    if (!activeCharacter) {
+        const p = document.createElement('p');
+        p.textContent = 'No active character';
+        root.appendChild(p);
+    } else {
+        const list = document.createElement('ul');
+        list.className = 'craft-list';
+        crafts.forEach(c => {
+            const li = document.createElement('li');
+            const btn = document.createElement('button');
+            const lvl = activeCharacter.crafting?.[c.name] || 0;
+            btn.textContent = `${c.name} (Lv.${lvl})`;
+            btn.addEventListener('click', () => {
+                renderCraftDetailScreen(root, c);
+            });
+            li.appendChild(btn);
+            list.appendChild(li);
+        });
+        root.appendChild(list);
+    }
+}
+
+function renderCraftDetailScreen(root, craft) {
+    root.innerHTML = '';
+    resetDetails();
+    showBackButton(() => renderCraftingScreen(root));
+    const title = document.createElement('h2');
+    title.textContent = craft.name;
+    root.appendChild(title);
+    const lvl = document.createElement('div');
+    lvl.textContent = `Skill Level: ${activeCharacter?.crafting?.[craft.name] || 0}`;
+    root.appendChild(lvl);
+    const desc = document.createElement('p');
+    desc.textContent = craft.description;
+    root.appendChild(desc);
+    if (craft.guild) {
+        const guild = document.createElement('div');
+        guild.textContent = `Guild: ${craft.guild}`;
+        root.appendChild(guild);
+    }
 }
 
 export function renderEquipmentScreen(root) {


### PR DESCRIPTION
## Summary
- add crafting data for nine professions with descriptions and guild locations
- expose craft info to characters and UI with new crafting menu

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68917f23a390832598a816042234bce3