### PR TITLE
Add continent and zone lore data

### DIFF
--- a/data/index.js
+++ b/data/index.js
@@ -45,6 +45,7 @@ export {
 export { proficiencyScale, getScale } from './scales.js';
 export { names, randomName } from './names.js';
 export { raceInfo, jobInfo, cityImages, characterImages } from './descriptions.js';
+export { continentLore, zoneLore } from './lore.js';
 export { cityList, zonesByCity, locations, zoneNames } from './locations.js';
 export { bestiaryByZone, allMonsters } from './bestiary.js';
 export { zoneMaps, registerZoneMap, getSubArea, canMove } from './maps.js';

--- a/data/lore.js
+++ b/data/lore.js
@@ -1,0 +1,304 @@
+export const continentLore = {
+  'Middle Lands': {
+    history: 'The heart of civilized Vana\'diel, home to Bastok, San d\'Oria, Windurst and neutral Jeuno.',
+    geography: 'Comprised of the sister continents Quon and Mindartia separated by the Silver Sea.',
+    subareas: {
+      Quon: {
+        history: 'Western landmass dominated by Bastok and San d\'Oria with Jeuno at its crossroads.',
+        geography: 'Rolling plains, rugged highlands and mineral-rich mountains define the continent.',
+      },
+      Mindartia: {
+        history: 'Eastern home of the Tarutaru and Mithra forming the Federation of Windurst.',
+        geography: 'A lush island continent bordered by warm seas and verdant plains.',
+      },
+    },
+  },
+  'Near East': {
+    history: 'Region ruled by the Empire of Aht Urhgan which recently opened its borders.',
+    geography: 'Desert and coastal lands east of the Middle Lands across the Aradjiah Sea.',
+    subareas: {
+      Aradjiah: {
+        history: 'Seat of the Aht Urhgan Empire and center of Near Eastern commerce.',
+        geography: 'Arid deserts surrounding bustling port cities like Al Zahbi and Whitegate.',
+      },
+    },
+  },
+  'Far East': {
+    history: 'Mystic realms of distant oriental cultures mentioned in legends.',
+    geography: 'Scattered islands and far-flung territories largely unknown to adventurers.',
+    subareas: {},
+  },
+  'Far South': {
+    history: 'Uncharted southern territories known only through scattered tales.',
+    geography: 'Believed to hold tropical jungles and wide island chains.',
+    subareas: {
+      Garhada: {
+        history: 'Rumored southern nation famed for exotic spices.',
+        geography: 'Humid and fertile lowlands.',
+      },
+      Olzhirya: {
+        history: 'Cultural crossroads of the deep south.',
+        geography: 'Coastal region of sandy atolls.',
+      },
+      Tsahya: {
+        history: 'Little documented; said to host unique beastmen tribes.',
+        geography: 'Savannah and scrublands.',
+      },
+      Zhwa: {
+        history: 'Name appearing in ancient records with few details.',
+        geography: 'Geography remains a mystery.',
+      },
+    },
+  },
+  'Far West': {
+    history: 'Frontier land of Ulbuka reached during the Adoulin expedition.',
+    geography: 'Vast western continent covered in dense jungles and untamed wilderness.',
+    subareas: {
+      Ulbuka: {
+        history: 'Home to the Sacred City of Adoulin and its colonization efforts.',
+        geography: 'Lush jungle continent filled with powerful fauna and elemental strife.',
+      },
+    },
+  },
+  'Far North': {
+    history: 'Frozen northern reaches beyond the northern seas.',
+    geography: 'Perpetual winter dominated by glaciers and icy plains.',
+    subareas: {
+      Rhazowa: {
+        history: 'Land of the Sauretto people seldom visited by outsiders.',
+        geography: 'Harsh tundra and frigid coastline.',
+      },
+    },
+  },
+};
+
+export const zoneLore = {
+  'Bastok Mines': {
+    history: 'Founding site of Bastok where industrious Humes and Galka mine precious ore.',
+    geography: 'A network of excavated tunnels beneath the republic.',
+  },
+  'Bastok Markets': {
+    history: 'Commercial hub where merchants from across Quon trade goods.',
+    geography: 'Bustling bazaar streets built around the city\'s central canal.',
+  },
+  'Port Bastok': {
+    history: 'Gateway for Bastok\'s trade and travel overseas.',
+    geography: 'Seaside district with docks along the Bastore Sea.',
+  },
+  Metalworks: {
+    history: 'Industrial complex housing Cid\'s workshop and the presidency.',
+    geography: 'Fortified foundry district filled with forges and machinery.',
+  },
+  'Bastok Residential Area': {
+    history: 'Apartment quarter providing housing for Bastok\'s citizens.',
+    geography: 'Compact blocks of residences connected by narrow alleys.',
+  },
+  'Zeruhn Mines': {
+    history: 'Originally an abandoned shaft, now Bastok\'s training grounds for miners.',
+    geography: 'Damp subterranean tunnels rich in low-grade ore.',
+  },
+  'North Gustaberg (East)': {
+    history: 'Borderland once patrolled to defend Bastok from Quadav incursions.',
+    geography: 'Rocky cliffs and canyons overlooking the Bastore Sea.',
+  },
+  'North Gustaberg (West)': {
+    history: 'Wild territory supporting the republic\'s early expansion.',
+    geography: 'Arid valleys dotted with basalt formations.',
+  },
+  'South Gustaberg': {
+    history: 'Region shaped by Bastok\'s mining operations and volcanic activity.',
+    geography: 'Dry badlands separated by the deep chasm of the Dangruf Wadi.',
+  },
+  'Vomp Hill L1': {
+    history: 'Lower terrace of Vomp Hill used for early copper extraction.',
+    geography: 'Grassy rise at the base of the hill.',
+  },
+  'Vomp Hill L2': {
+    history: 'Middle tier where roamings beasts keep miners on guard.',
+    geography: 'Steeper slopes covered in sparse brush.',
+  },
+  'Vomp Hill L3': {
+    history: 'Upper plateau once claimed by aggressive goblins.',
+    geography: 'Wind-swept summit offering view over Gustaberg.',
+  },
+  'Goblin Camp': {
+    history: 'Encampment established by goblin tribes near Bastok.',
+    geography: 'Makeshift tents erected around the hilltop.',
+  },
+  'Konschtat Highlands': {
+    history: 'Historic pastureland linking Bastok to Selbina and the north.',
+    geography: 'Vast grasslands with rolling hills and stone outcroppings.',
+  },
+  'Gusgen Mines': {
+    history: 'Abandoned coal mine haunted by memories of a tragic cave-in.',
+    geography: 'Collapsed shafts filled with subterranean pools.',
+  },
+  'Palborough Mines': {
+    history: 'Ancient Quadav mine seized by Bastok for mythril extraction.',
+    geography: 'Labyrinth of mine tunnels carved into the mountainside.',
+  },
+  'Oldton Movalpolos': {
+    history: 'Underground goblin city built within the Movalpolos caverns.',
+    geography: 'Twisting passages and crude dwellings lit by furnace fires.',
+  },
+  'Dangruf Wadi': {
+    history: 'Eroded canyon created by volcanic runoff and flash floods.',
+    geography: 'Network of water-filled ravines and geothermal vents.',
+  },
+  "Northern San d'Oria": {
+    history: 'Noble quarter of the elvaan capital and center of chivalric tradition.',
+    geography: 'Stone-lined streets leading to the royal castle.',
+  },
+  "Southern San d'Oria": {
+    history: 'Craftsmen and merchant district of the kingdom.',
+    geography: 'Bustling avenues surrounding the grand cathedral.',
+  },
+  "Port San d'Oria": {
+    history: 'Seaport receiving goods and pilgrims from across Vana\'diel.',
+    geography: 'Harbor district along the Rosel Sea.',
+  },
+  "Château d'Oraguille": {
+    history: 'Seat of San d\'Oria\'s royal family and headquarters of the Temple Knights.',
+    geography: 'Fortified castle overlooking the city.',
+  },
+  "San d'Oria Residential Area": {
+    history: 'Housing for the elvaan populace outside the castle walls.',
+    geography: 'Quiet neighborhood of timber and stone homes.',
+  },
+  'West Ronfaure': {
+    history: 'Forest shielding San d\'Oria from orcish invasions.',
+    geography: 'Dense woodland of towering evergreens.',
+  },
+  'East Ronfaure': {
+    history: 'Former royal hunting grounds now patrolled by knights.',
+    geography: 'Expansive forest cut by crystal streams.',
+  },
+  'La Theine Plateau': {
+    history: 'Strategic highland connecting Ronfaure to the northern realms.',
+    geography: 'Windy plateau with steep cliffs and rolling fields.',
+  },
+  "King Ranperre's Tomb": {
+    history: 'Burial site of San d\'Oria\'s monarchs and war heroes.',
+    geography: 'Subterranean mausoleum carved into ancient rock.',
+  },
+  'Ghelsba Outpost': {
+    history: 'Orcish forward base launched against San d\'Oria.',
+    geography: 'Fortified encampment hidden in the Ronfaure woods.',
+  },
+  'Windurst Waters': {
+    history: 'Scholarly quarter and hub for the Fisheries Guild.',
+    geography: 'Canal-lined district built upon a network of bridges.',
+  },
+  'Windurst Woods': {
+    history: 'Commercial center where guilds and vendors gather.',
+    geography: 'Wooden platforms nestled among enormous trees.',
+  },
+  'Windurst Walls': {
+    history: 'Old defensive perimeter now home to residential areas and training grounds.',
+    geography: 'Stone ramparts surrounding inner Windurst.',
+  },
+  'Port Windurst': {
+    history: 'Port where airships and ferries connect Windurst to the world.',
+    geography: 'Harbor district on the southern coast of Mindartia.',
+  },
+  'Heavens Tower': {
+    history: 'Spiritual and administrative center of the Federation.',
+    geography: 'Sky-piercing spire rising from the middle of Windurst.',
+  },
+  'Windurst Residential Area': {
+    history: 'Neighborhood housing the federation\'s citizens.',
+    geography: 'Cluster of domed homes linked by cobbled paths.',
+  },
+  'East Sarutabaruta': {
+    history: 'Fertile plain serving as Windurst\'s breadbasket.',
+    geography: 'Open grassland dotted with palm groves.',
+  },
+  'West Sarutabaruta': {
+    history: 'Training ground for Windurst\'s fledgling mages.',
+    geography: 'Rolling savannah with scattered ruins.',
+  },
+  Giddeus: {
+    history: 'Stronghold of the avian Yagudo who oppose Windurst.',
+    geography: 'Maze of narrow caves hidden within a forested basin.',
+  },
+  'Tahrongi Canyon': {
+    history: 'Natural corridor linking Sarutabaruta to the outlands.',
+    geography: 'Deep ravines carved by ancient rivers.',
+  },
+  'Buburimu Peninsula': {
+    history: 'Strategic coastal region contested during the Great War.',
+    geography: 'Sandy beaches and palm-lined inlets.',
+  },
+  'Meriphataud Mountains': {
+    history: 'Mountain range dividing Windurst from the Yagudo territory.',
+    geography: 'Jagged peaks and narrow passes.',
+  },
+  'Lower Jeuno': {
+    history: 'Ground-level quarter bustling with adventurers and bazaars.',
+    geography: 'Labyrinthine streets built atop Qufim Island\'s cliffs.',
+  },
+  'Upper Jeuno': {
+    history: 'Administrative center overseeing trade and diplomacy.',
+    geography: 'Elevated terraces overlooking the lower city.',
+  },
+  'Port Jeuno': {
+    history: 'Aeronautics hub connecting Jeuno to distant cities.',
+    geography: 'Airship docks and warehouses perched on the island\'s edge.',
+  },
+  "Ru'Lude Gardens": {
+    history: 'High-class district housing the Archduke and his court.',
+    geography: 'Elegant plazas and manicured gardens.',
+  },
+  'Jeuno Residential Area': {
+    history: 'Housing for Jeuno\'s diverse populace.',
+    geography: 'Series of terraced apartments within the city walls.',
+  },
+  'Qufim Island': {
+    history: 'Frozen island once used for military outposts, now overrun with monsters.',
+    geography: 'Snowy coastline crowned by the colossal Delkfutt\'s Tower.',
+  },
+  'Rolanberry Fields': {
+    history: 'Once productive farmland now left fallow by war.',
+    geography: 'Rolling fields dotted with giant rolanberry bushes.',
+  },
+  'Sauromugue Champaign': {
+    history: 'Battle-scarred plain where nations clashed during the Crystal War.',
+    geography: 'Expansive grassland cut by ravines.',
+  },
+  'Battalia Downs': {
+    history: 'Harsh moor that served as a barrier during wartime.',
+    geography: 'Uneven terrain with scattered rock formations.',
+  },
+  'Pashhow Marshlands': {
+    history: 'Swamp crossed by merchants and soldiers en route to Jeuno.',
+    geography: 'Foggy wetlands teeming with leeches and will-o\'the-wisps.',
+  },
+  'Valkurm Dunes': {
+    history: 'Popular training ground for new adventurers.',
+    geography: 'White-sand desert along the Bastore Sea.',
+  },
+  Mhaura: {
+    history: 'Mindartian port town and former pirate haven now allied with Windurst.',
+    geography: 'Tropical village on the Bastore coast.',
+  },
+  Selbina: {
+    history: 'Quonian fishing settlement serving as a link between nations.',
+    geography: 'Coastal hamlet on the Dunes\' northern shore.',
+  },
+  'Castle Oztroja': {
+    history: 'Ancient Yagudo fortress guarding their sacred relics.',
+    geography: 'Towering castle filled with traps and prayer halls.',
+  },
+  Beadeaux: {
+    history: 'Fortified home of the Quadav who wage war against Bastok.',
+    geography: 'Flooded tunnels and bronze-plated chambers.',
+  },
+  Davoi: {
+    history: 'Stronghold of the orcs threatening San d\'Oria.',
+    geography: 'Forest valley fortified with palisades and tents.',
+  },
+  'Aht Urhgan Whitegate': {
+    history: 'Mercantile capital of the Aht Urhgan Empire welcoming foreign adventurers.',
+    geography: 'Sprawling port city surrounded by the Azure Sea.',
+  },
+};


### PR DESCRIPTION
## Summary
- Add `lore.js` dataset with history and geography for continents, regions, and all zones
- Export continent and zone lore through the data index

## Testing
- `node scripts/validateZones.js`
- `node scripts/testTaruBlm.js` *(fails: ReferenceError: craftNames is not defined)*
- `node scripts/testBalance.js` *(fails: ReferenceError: craftNames is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689181fed8dc8325b08abccaa3e9ca20