### PR TITLE
feat: add fishing and gathering systems

### DIFF
--- a/data/bestiary.js
+++ b/data/bestiary.js
@@ -547,6 +547,7 @@ export const bestiaryByZone = {
       spawns: 1,
       spawnChance: 0,
       fishingOnly: true,
+      fishingSkill: 0,
       notes: 'Fishing only'
     },
     {
@@ -631,6 +632,7 @@ export const bestiaryByZone = {
       spawns: 1,
       spawnChance: 0,
       fishingOnly: true,
+      fishingSkill: 10,
       notes: 'Fishing only'
     },
     {
@@ -796,6 +798,7 @@ export const bestiaryByZone = {
       spawns: 1,
       spawnChance: 0,
       fishingOnly: true,
+      fishingSkill: 20,
       notes: 'Fishing only'
     },
     {
@@ -841,6 +844,7 @@ export const bestiaryByZone = {
       spawnChance: 0,
       coords: ['E-8', 'E-9'],
       fishingOnly: true,
+      fishingSkill: 30,
       notes: 'Fishing only',
       areas: [null]
     }

--- a/data/characters.js
+++ b/data/characters.js
@@ -6,6 +6,7 @@ import { bestiaryByZone } from './bestiary.js';
 import { getScale, proficiencyScale } from './scales.js';
 import { weaponSkills, magicSkills } from './proficiencies.js';
 import { craftNames } from './crafting.js';
+import { gatheringNames } from './gathering.js';
 
 const aldoScale = buildScaleFields('Hume', 'Thief');
 const shantottoScale = buildScaleFields('Tarutaru', 'Black Mage');
@@ -13,6 +14,7 @@ const shantottoScale = buildScaleFields('Tarutaru', 'Black Mage');
 const baseCombatSkills = Object.fromEntries(weaponSkills.map(s => [s, 0]));
 const baseMagicSkills = Object.fromEntries(magicSkills.map(s => [s.name, 0]));
 const baseCraftSkills = Object.fromEntries(craftNames.map(c => [c, 0]));
+const baseGatheringSkills = Object.fromEntries(gatheringNames.map(g => [g, 0]));
 
 const startingGearByJob = {
   'Warrior': { weapon: 'bronzeSword', armor: 'leatherVest' },
@@ -165,6 +167,9 @@ export const characters = [
     combatSkills: { ...baseCombatSkills },
     magicSkills: { ...baseMagicSkills },
     crafting: { ...baseCraftSkills },
+    gathering: { ...baseGatheringSkills },
+    fishCount: 0,
+    fishDay: null,
     spells: [],
     ...aldoScale,
     mLvX: 0,
@@ -251,6 +256,9 @@ export const characters = [
     combatSkills: { ...baseCombatSkills },
     magicSkills: { ...baseMagicSkills },
     crafting: { ...baseCraftSkills },
+    gathering: { ...baseGatheringSkills },
+    fishCount: 0,
+    fishDay: null,
     spells: [],
     ...shantottoScale,
     mLvX: 0,
@@ -363,6 +371,9 @@ export function createCharacterObject(name, job, race, sex = 'Male') {
     combatSkills: { ...baseCombatSkills },
     magicSkills: { ...baseMagicSkills },
     crafting: { ...baseCraftSkills },
+    gathering: { ...baseGatheringSkills },
+    fishCount: 0,
+    fishDay: null,
     spells: [],
     ...buildScaleFields(selectedRace, selectedJob),
     mLvX: 0,

--- a/data/gathering.js
+++ b/data/gathering.js
@@ -1,0 +1,10 @@
+export const gathering = [
+  { name: 'Logging', description: 'Harvest lumber from logging points.' },
+  { name: 'Mining', description: 'Extract ore from mining points.' },
+  { name: 'Harvesting', description: 'Gather plants from harvesting points.' },
+  { name: 'Excavation', description: 'Dig for fossils and artifacts.' },
+  { name: 'Clamming', description: 'Collect shellfish from tidal pools.' },
+  { name: 'Chocobo Digging', description: 'Unearth items while riding a chocobo.' }
+];
+
+export const gatheringNames = gathering.map(g => g.name);

--- a/data/index.js
+++ b/data/index.js
@@ -2,6 +2,7 @@ export { jobs, jobNames, baseJobNames } from './jobs.js';
 export { races, raceNames, startingCities } from './races.js';
 export { weaponSkills, magicSkills } from './proficiencies.js';
 export { crafts, craftNames } from './crafting.js';
+export { gathering, gatheringNames } from './gathering.js';
 export {
   characters,
   activeCharacter,
@@ -69,9 +70,11 @@ export {
   randomMonster,
   huntEncounter,
   spawnNearbyMonsters,
+  monstersByDistance,
   parseCoordinate,
   coordinateDistance,
   stepToward
 } from '../js/encounter.js';
 export { calculateBattleRewards, findItemIdByName } from '../js/rewards.js';
 export { initNotorious, handleMonsterKill, checkForNM } from '../js/notorious.js';
+export { attemptFishing, attemptGather } from '../js/gathering.js';

--- a/js/gathering.js
+++ b/js/gathering.js
@@ -1,0 +1,41 @@
+import { monstersByDistance } from '../data/index.js';
+
+const DAILY_FISH_LIMIT = 200;
+
+function pickRandom(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+export function attemptFishing(character, zone, subArea = null) {
+  const today = new Date().toDateString();
+  if (character.fishDay !== today) {
+    character.fishDay = today;
+    character.fishCount = 0;
+  }
+  if (character.fishCount >= DAILY_FISH_LIMIT) {
+    return { success: false, message: 'You are too tired to fish today.' };
+  }
+  const pool = (monstersByDistance(zone, subArea) || []).filter(m => m.fishingOnly);
+  if (!pool.length) {
+    return { success: false, message: 'There is nothing to fish here.' };
+  }
+  const target = { ...pickRandom(pool) };
+  const required = target.fishingSkill || 0;
+  const skill = character.crafting?.Fishing || 0;
+  let chance = 0.5 + (skill - required) * 0.02;
+  if (chance < 0.05) chance = 0.05;
+  if (chance > 0.95) chance = 0.95;
+  character.fishCount++;
+  if (Math.random() < chance) {
+    return { success: true, fish: target.name };
+  }
+  return { success: false, message: 'The catch got away.' };
+}
+
+export function attemptGather(character, skillName, difficulty = 0) {
+  const level = character.gathering?.[skillName] || 0;
+  let chance = 0.5 + (level - difficulty) * 0.02;
+  if (chance < 0.05) chance = 0.05;
+  if (chance > 0.95) chance = 0.95;
+  return Math.random() < chance;
+}


### PR DESCRIPTION
## Summary
- add gathering skill definitions and export support
- track gathering skills and fishing fatigue on characters
- implement chance-based fishing with daily limits and generic gathering helper

## Testing
- `node --check js/gathering.js`
- `node --check data/characters.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891865984908325b8d126b6e4b279d4