### PR TITLE
feat: add popup menu and adjust UI elements

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -104,6 +104,26 @@ body.portrait #app {
     height: 28px;
 }
 
+#menu-popup {
+    position: fixed;
+    right: 5px;
+    bottom: 40px;
+    background: rgba(0, 0, 0, 0.8);
+    padding: 8px;
+    border-radius: 4px;
+    z-index: 1400;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+#menu-popup button {
+    padding: 2px 6px;
+    font-size: 14px;
+    height: 28px;
+    margin: 2px 0;
+}
+
 .element-icon {
     width: 16px;
     height: 16px;
@@ -128,7 +148,7 @@ body.portrait #app {
     height: auto;
 }
 
-#character-select {
+#menu-button {
     padding: 2px 6px;
     font-size: 14px;
     margin: 0 2px;
@@ -372,10 +392,10 @@ body.portrait .nav-row {
 }
 
 .monster-btn {
-    width: 160px;
+    width: 168px;
     margin: 1px 0;
     position: relative;
-    padding-bottom: 5px;
+    padding: 3px 0 8px;
     overflow: hidden;
 }
 
@@ -401,11 +421,11 @@ body.portrait .nav-row {
 }
 
 .party-btn {
-    width: 160px;
+    width: 168px;
     margin: 1px 0;
     display: flex;
     align-items: stretch;
-    padding: 0;
+    padding: 3px 0;
     position: relative;
 }
 

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
         <button id="time-display"></button>
         <button id="back-button">Back</button>
         <button id="log-button">Log</button>
-        <button id="character-select">Character</button>
+        <button id="menu-button">Menu</button>
         <button class="scale-btn" id="scale-dec">-</button>
         <button class="scale-btn" id="scale-inc">+</button>
     </div>
@@ -20,6 +20,7 @@
         <!-- UI will be rendered here -->
     </div>
     <div id="time-popup" class="hidden"></div>
+    <div id="menu-popup" class="hidden"></div>
     <div id="game-log" class="log-overlay hidden"></div>
     <div id="map-overlay" class="hidden">
         <button id="map-close" class="map-close">X</button>

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls, setupLogControls, setupTimeDisplay, setupMapOverlay, setupItemPopup, setupStoragePopup, setupProfilePopup, updateTimeDisplay, isLogFullscreen, adjustLogFontSize, setupPressFeedback } from './ui.js';
+import { renderMainMenu, renderCharacterMenu, setupBackButton, renderUserControls, setupLogControls, setupTimeDisplay, setupMapOverlay, setupItemPopup, setupStoragePopup, setupProfilePopup, setupMenuButton, updateTimeDisplay, isLogFullscreen, adjustLogFontSize, setupPressFeedback } from './ui.js';
 import { loadCharacters, initCurrentUser, initNotorious, activeCharacter, persistCharacter } from '../data/index.js';
 import { startTicks, onTick } from './tick.js';
 
@@ -107,14 +107,10 @@ function init() {
         setupProfilePopup(profilePopup, profilePopupContent, profilePopupClose);
     }
 
-    const charBtn = document.getElementById('character-select');
-    if (charBtn) {
-        charBtn.addEventListener('click', () => {
-            const root = document.getElementById('app').firstElementChild;
-            if (root) {
-                renderCharacterMenu(root);
-            }
-        });
+    const menuBtn = document.getElementById('menu-button');
+    const menuPopup = document.getElementById('menu-popup');
+    if (menuBtn && menuPopup) {
+        setupMenuButton(menuBtn, menuPopup);
     }
 
     startTicks();


### PR DESCRIPTION
## Summary
- add persistent popup menu with character, inventory, equipment, crafting, wardrobe and macro options
- resize party and monster list buttons and update TP bar text contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68920af013408325bc79fb1d249dd78e