### PR TITLE
Align inventory screen items and center headers

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -918,25 +918,25 @@ body.portrait .main-layout {
 }
 
 .inventory-section {
-    width: 100%;
-    margin: 0 0 10px 0;
+    width: fit-content;
+    margin: 0 auto 10px;
 }
 
 .inventory-header {
     display: block;
-    margin: 20px 0 5px 0;
+    margin: 20px auto 5px;
     font-size: 1.2em;
     font-weight: bold;
-    text-align: left;
+    text-align: center;
 }
 
 .inventory-list {
     list-style: none;
     padding: 0;
-    margin: 0 auto;
-    display: inline-grid;
+    margin: 0;
+    display: grid;
     grid-template-columns: max-content max-content;
-    justify-content: center;
+    justify-content: start;
     column-gap: 8px;
     row-gap: 4px;
 }
@@ -947,7 +947,7 @@ body.portrait .main-layout {
 
 .item-actions {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     gap: 4px;
 }
 


### PR DESCRIPTION
## Summary
- left-align inventory list items
- keep action buttons inline across rows
- center inventory category headers on the page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68923988cb1083258a0cd84d0e588d7a