### PR TITLE
Refine equipment and inventory UI interactions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -917,9 +917,16 @@ body.portrait .main-layout {
     gap: 4px;
 }
 
+.equipment-actions button {
+    padding: 0 4px;
+    margin: 0;
+    min-height: 0;
+    width: auto;
+}
+
 .inventory-section {
     width: fit-content;
-    margin: 0 auto 10px;
+    margin: 0 0 10px 0;
 }
 
 .inventory-header {

--- a/js/ui.js
+++ b/js/ui.js
@@ -4204,13 +4204,6 @@ export function renderEquipmentScreen(root) {
     const title = document.createElement('h2');
     title.textContent = 'Equipment';
     root.appendChild(title);
-    const wardBtn = document.createElement('button');
-    wardBtn.textContent = 'Wardrobe';
-    wardBtn.addEventListener('click', () => {
-        showWardrobePopup();
-    });
-    root.appendChild(wardBtn);
-    root.appendChild(characterSummary());
     if (!activeCharacter) {
         const p = document.createElement('p');
         p.textContent = 'No active character';
@@ -4485,7 +4478,11 @@ function renderKeyItemsScreen(root) {
         categories[cat].forEach(ent => {
             const nameLi = document.createElement('li');
             nameLi.className = 'inventory-name';
-            nameLi.textContent = ent.item.name;
+            const nameBtn = document.createElement('button');
+            nameBtn.className = 'item-name-btn';
+            nameBtn.textContent = ent.item.name;
+            setupItemHoldDetails(nameBtn, ent.item);
+            nameLi.appendChild(nameBtn);
             ul.appendChild(nameLi);
             const filler = document.createElement('li');
             filler.className = 'item-actions';


### PR DESCRIPTION
## Summary
- Streamline equipment screen by removing profile details and wardrobe access
- Convert all inventory and equipment item names to hold-for-details buttons
- Align inventory entries and slim down equipment unequip buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689246b8d6788325bd8939ef07abf25e