### PR TITLE
Refine profile access and party status bars

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -425,7 +425,7 @@ body.portrait .nav-row {
     margin: 1px 0;
     display: flex;
     align-items: stretch;
-    padding: 3px 0;
+    padding: 0;
     position: relative;
 }
 
@@ -451,20 +451,17 @@ body.portrait .nav-row {
     border-top-right-radius: 4px;
     border-bottom-right-radius: 4px;
     overflow: hidden;
+    gap: 1px;
+    background: #555;
 }
 
 .party-bars .bar {
     flex: 1;
     background: #333;
-    border-bottom: 1px solid #555;
     position: relative;
     color: white;
     text-align: center;
     font-size: 10px;
-}
-
-.party-bars .bar:last-child {
-    border-bottom: none;
 }
 
 .party-bars .bar-fill {

--- a/data/characters.js
+++ b/data/characters.js
@@ -410,7 +410,8 @@ export function createCharacterObject(name, job, race, sex = 'Male') {
     targetIndex: null,
     monsterCoord: '',
     citySections: {},
-    monsters: []
+    monsters: [],
+    recentLogs: []
   };
   updateDerivedStats(character);
   return character;


### PR DESCRIPTION
## Summary
- Move character profile access to the menu popup and drop the main screen button
- Equalize party list HP/MP/TP bars and show current HP and MP with dynamic contrast
- Track last 10 log messages per character

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68924b1f1f6c8325abdff14e8444e5fe