### PR TITLE
Ensure craft belts appear in vendor inventories

### DIFF
--- a/data/vendors.js
+++ b/data/vendors.js
@@ -7209,8 +7209,7 @@ export const vendorInventories = {
   Sororo: ['scrollDiaga', 'scrollStoneskin', 'scrollSlow', 'scrollCureII', 'scrollBanish', 'scrollBanishga', 'scrollBlink', 'scrollCure', 'scrollCuraga', 'scrollPoisona', 'scrollParalyna', 'scrollBlindna', 'scrollDia', 'scrollProtect', 'scrollShell', 'scrollRepose'],
   Zaira: ['scrollBlind', 'scrollBio', 'scrollPoison', 'scrollSleep', 'scrollAero', 'scrollBlizzard', 'scrollBurn', 'scrollChoke', 'scrollDrown', 'scrollFire', 'scrollFrost', 'scrollRasp', 'scrollShock', 'scrollStone', 'scrollThunder', 'scrollWater'],
   Teerth: ['workshopAnvil', 'mandrel', 'zincOre', 'copperOre', 'brassNugget', 'brassSheet', 'silverOre', 'silverNugget', 'tourmaline', 'sardonyx', 'clearTopaz', 'amethyst', 'lapisLazuli', 'amber', 'onyx'],
-  Visala: ['silverOre', 'mythrilOre', 'brassScales', 'mythrilChain', 'redRock', 'blueRock', 'yellowRock', 'greenRock', 'translucentRock', 'purpleRock', 'blackRock', 'whiteRock', 'lapisLazuli', 'lightOpal', 'onyx', 'amethyst', 'tourmaline', 'sardonyx', 'clearTopaz']
-  ,
+  Visala: ['silverOre', 'mythrilOre', 'brassScales', 'mythrilChain', 'redRock', 'blueRock', 'yellowRock', 'greenRock', 'translucentRock', 'purpleRock', 'blackRock', 'whiteRock', 'lapisLazuli', 'lightOpal', 'onyx', 'amethyst', 'tourmaline', 'sardonyx', 'clearTopaz'],
   Hemewmew: ['alchemistsBelt'],
   Macuillie: ['blacksmithsBelt'],
   Lorena: ['blacksmithsBelt'],


### PR DESCRIPTION
## Summary
- Fix vendor inventory data to properly list crafting belts

## Testing
- `node scripts/testBalance.js` (fails: ReferenceError: craftNames is not defined)
- `node scripts/testTaruBlm.js` (fails: ReferenceError: craftNames is not defined)
- `node scripts/validateZones.js`


------
https://chatgpt.com/codex/tasks/task_e_68937ee12ffc8325a89e413b69c9473b