### PR TITLE
Fix invalid vendor string causing UI load failure

### DIFF
--- a/data/vendors.js
+++ b/data/vendors.js
@@ -9936,7 +9936,7 @@ export const items = {
     jobs: jobNames,
     keyItem: false,
     sellable: true,
-    additionalEffects: ['EXP +5% in San d'Oria'],
+    additionalEffects: ["EXP +5% in San d'Oria"],
     latentEffects: [],
   },
   smithsRing: {


### PR DESCRIPTION
## Summary
- fix unescaped apostrophe in vendor item effects causing JS parse error

## Testing
- `node scripts/testBalance.js`
- `node scripts/testTaruBlm.js`
- `node scripts/validateZones.js`
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893de69ed448325a895875679422aa3