### PR TITLE
Stabilize slash routing and character creation docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable reset-branch changes are tracked here.
 - Slash-command UI wrapper requiring `/` commands in the browser shell.
 - `/menu`, `/commands`, `/help`, `/newcharacter`, `/characters`, `/load`, `/save`, `/account`, and `/reset` commands.
 - Prompt-based character creation from `/newcharacter`, with natural non-slash answers while prompts are active.
+- Slash-router tests for FFXI macro-style browser commands such as `/macrohelp`, `/ma`, `/ws`, and `/item`.
 - Encoded local account/character save model under `ffxiTextRpgAccount`.
 - Multiple local character save slots with character summaries and last-active-character tracking.
 - Legacy raw `ffxiTextRpgSave` migration into the encoded account save model.
@@ -29,7 +30,7 @@ All notable reset-branch changes are tracked here.
 - Zone atlas discovery where unvisited grids are unknown until visited and visited grids become visible through the atlas.
 - Text HUD/control metadata for HP/MP/TP resource bars, visual tick timer bar, 8-button navigation keypad, and action control groups.
 - Grid movement commands using 8-way navigation.
-- Foot-travel aggro scaffold based on grid spawn rules, spawn count, and aggro type such as sight or sound.
+- Foot-travel aggro scaffold based on grid spawn rules, count, and aggro type such as sight or sound.
 - Seed aggressive enemies for grid-spawn testing.
 - Direct travel engine with connection lookup, restrictions, active travel state, manual time advancement, arrival coordinates, atlas recording, and zone descriptions.
 - Starter-city points of interest with current-grid contextual actions.
@@ -60,6 +61,8 @@ All notable reset-branch changes are tracked here.
 - Architecture, roadmap, baseline pipeline, system catalog, research reference, and thread handoff documents for the rebuild.
 
 ### Changed
+- Preserved FFXI macro-style slash commands through the browser slash router so the FFXI command adapter can handle them.
+- Aligned character-creation docs and slash-router tests with the current name-first, confirmation-based creator flow.
 - Replaced the old graphical/menu-heavy entry path with a minimal text-first foundation.
 - Replaced the UI-facing bare-command model with slash commands.
 - Replaced single raw local save storage with encoded local account/character save slots.

--- a/README.md
+++ b/README.md
@@ -114,17 +114,18 @@ Use:
 /newcharacter
 ```
 
-The command starts prompt-based character creation. While prompts are active, answers are natural text and do not require `/`:
+The command starts prompt-based character creation. While prompts are active, answers are natural text and do not require `/`. The current prompt order is name, nation, race, sex, starting job, then confirmation:
 
 ```text
+CharacterName
 sandoria
 hume
 male
 warrior
-CharacterName
+yes
 ```
 
-A completed character is saved automatically into the local account save.
+A completed and confirmed character is saved automatically into the local account save.
 
 ## Save model
 

--- a/docs/THREAD_HANDOFF.md
+++ b/docs/THREAD_HANDOFF.md
@@ -110,6 +110,8 @@ Gameplay examples:
 
 Bare commands are rejected by the browser slash router except while character-creation prompts are active. Internal engine tests may still call the bare command router directly.
 
+FFXI macro-style commands such as `/macrohelp`, `/ma`, `/ja`, `/ws`, `/item`, `/equipset`, `/recast`, and `/echo` are preserved with their leading slash and routed through the FFXI command adapter.
+
 ## Character creation flow
 
 Start with:
@@ -118,17 +120,18 @@ Start with:
 /newcharacter
 ```
 
-While prompts are active, answers do not use `/`:
+While prompts are active, answers do not use `/`. Current prompt order is name, nation, race, sex, starting job, then confirmation:
 
 ```text
+CharacterName
 sandoria
 hume
 male
 warrior
-CharacterName
+yes
 ```
 
-When completed, the character is saved automatically.
+When confirmed, the character is saved automatically.
 
 ## Save/account model
 

--- a/js/text/slashCommandRouter.js
+++ b/js/text/slashCommandRouter.js
@@ -53,7 +53,6 @@ const FFXI_MACRO_COMMANDS = new Set([
     '/ja',
     '/ws',
     '/weaponskill',
-    '/weaponskill',
     '/ra',
     '/rangedattack',
     '/item',

--- a/js/text/slashCommandRouter.js
+++ b/js/text/slashCommandRouter.js
@@ -46,6 +46,35 @@ const SLASH_ALIASES = Object.freeze({
     '/chars': '/characters',
 });
 
+const FFXI_MACRO_COMMANDS = new Set([
+    '/macrohelp',
+    '/ma',
+    '/magic',
+    '/ja',
+    '/ws',
+    '/weaponskill',
+    '/weaponskill',
+    '/ra',
+    '/rangedattack',
+    '/item',
+    '/equipset',
+    '/recast',
+    '/target',
+    '/targetnpc',
+    '/targetbnpc',
+    '/assist',
+    '/lockon',
+    '/check',
+    '/echo',
+    '/p',
+    '/l',
+    '/linkshell',
+    '/say',
+    '/s',
+    '/tell',
+    '/t',
+]);
+
 export function createSlashCommandRouter(state, services = {}) {
     const engineRouter = createCommandRouter(state, services);
     const save = services.saveGame ?? saveGame;
@@ -103,7 +132,10 @@ export function createSlashCommandRouter(state, services = {}) {
 function routeGameplaySlash(engineRouter, input) {
     const stripped = input.slice(1);
     if (!stripped.trim()) return SLASH_HELP;
-    return engineRouter(stripped);
+    const commandName = input.split(/\s+/)[0].toLowerCase();
+    return FFXI_MACRO_COMMANDS.has(commandName)
+        ? engineRouter(input)
+        : engineRouter(stripped);
 }
 
 function describeCharacters() {

--- a/tests/slashCommandRouter.test.js
+++ b/tests/slashCommandRouter.test.js
@@ -55,6 +55,15 @@ test('slash router forwards slash gameplay commands to engine router', () => {
     assert.match(router('/stats'), /Attributes/);
 });
 
+test('slash router preserves FFXI macro-style slash commands for the adapter', () => {
+    const { router } = createRouterWithState();
+
+    assert.match(router('/macrohelp'), /FFXI Macro\/Text Command Reference/);
+    assert.match(router('/ma Cure'), /You are not in battle/);
+    assert.match(router('/ws "Fast Blade"'), /You are not in battle/);
+    assert.match(router('/item Potion'), /Item command accepted/);
+});
+
 test('slash router supports account character save and listing commands', () => {
     const { state, router } = createRouterWithState();
     state.player.identity.name = 'Slashsave';
@@ -65,14 +74,15 @@ test('slash router supports account character save and listing commands', () => 
     assert.match(router('/load 1'), /Loaded Slashsave/);
 });
 
-test('slash router allows natural answers during creator prompts', () => {
+test('slash router allows natural answers during creator prompts and saves after confirmation', () => {
     const { router } = createRouterWithState();
 
-    assert.match(router('/newcharacter'), /Choose a starting nation/);
-    assert.match(router('sandoria'), /Choose a race/);
-    assert.match(router('hume'), /Choose a sex/);
-    assert.match(router('male'), /Choose a starting job/);
-    assert.match(router('warrior'), /Choose a character name/);
-    assert.match(router('Prompted'), /Character saved/);
+    assert.match(router('/newcharacter'), /What is your character name/);
+    assert.match(router('Prompted'), /Choose starting nation/);
+    assert.match(router('sandoria'), /Choose race/);
+    assert.match(router('hume'), /Choose sex/);
+    assert.match(router('male'), /Choose starting job/);
+    assert.match(router('warrior'), /Confirm character/);
+    assert.match(router('yes'), /Character saved/);
     assert.match(router('/characters'), /Prompted/);
 });


### PR DESCRIPTION
## Summary

- Preserve FFXI macro-style slash commands through the browser slash router so the FFXI command adapter can handle `/macrohelp`, `/ma`, `/ws`, `/item`, and related commands.
- Align slash-router tests with the current name-first, confirmation-based character creation flow.
- Add slash-router coverage for FFXI macro-style browser commands.
- Update README, thread handoff, and changelog to document the confirmed character creation flow and FFXI slash routing behavior.

## Notes

This is a stabilization pass only. It does not add UI cards/chips or battle rewards.

## Testing

Not run through GitHub connector. Please run locally:

```bash
npm test
npm run benchmark
npm run check
```
