### PR TITLE
Harden text-first browser UI panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable reset-branch changes are tracked here.
 
 ### Added
 - Text-only browser shell with command input/output.
+- Slim top bar with compact branding, active character/job/location status, last-command feedback, and quick action buttons.
+- Populated sidebar panels for active character, resources, location/status, wallet/title, character slots, command chips, main menu actions, and full menu buttons.
 - Slash-command UI wrapper requiring `/` commands in the browser shell.
 - `/menu`, `/commands`, `/help`, `/newcharacter`, `/characters`, `/load`, `/save`, `/account`, and `/reset` commands.
 - Prompt-based character creation from `/newcharacter`, with natural non-slash answers while prompts are active.
@@ -57,15 +59,15 @@ All notable reset-branch changes are tracked here.
 - `inspect <target>` command for player, stats, inventory, NPC, enemy, state, log, version, systems, database, maps, zone, atlas, grid, travel, controls, and storage inspection.
 - `validate` command for current state validation.
 - `version`, `systems`, `databases`, `tick`, `maps`, `map`, `zones`, `zone`, `atlas`, `grid`, `move`, `controls`, `travel`, `wait`, `containers`, `container`, `transfer`, `equip`, `unequip`, `equipSources`, `here`, `talk`, `shop`, `buy`, `guild`, `quest`, `discovered`, `fastpoi`, and `zonefast` commands.
-- Node test coverage for command parsing, validation, entity factories, stat calculations, baseline pipeline, versioning, database registry, tick dispatch, zone graph, starter maps, world-data validation, travel flow, atlas discovery, controls, aggro checks, POI discovery, shop transactions, inventory transfers, equipment commands, save accounts, slash commands, and basic battle flow.
+- Node test coverage for command parsing, validation, entity factories, stat calculations, baseline pipeline, versioning, database registry, tick dispatch, zone graph, starter maps, world-data validation, travel flow, atlas discovery, controls, aggro checks, POI discovery, shop transactions, inventory transfers, equipment commands, save accounts, slash commands, UI panel helpers, and basic battle flow.
 - Architecture, roadmap, baseline pipeline, system catalog, research reference, and thread handoff documents for the rebuild.
 
 ### Changed
+- Moved the browser shell into an app frame with a slim top bar above the sidebar/terminal grid.
 - Preserved FFXI macro-style slash commands through the browser slash router so the FFXI command adapter can handle them.
 - Aligned character-creation docs and slash-router tests with the current name-first, confirmation-based creator flow.
 - Replaced the old graphical/menu-heavy entry path with a minimal text-first foundation.
 - Replaced the UI-facing bare-command model with slash commands.
-- Replaced single raw local save storage with encoded local account/character save slots.
 - Updated sidebar buttons to emit slash commands and include main menu, new character, characters, save, containers, and commands actions.
 - Updated shell intro text to guide users toward `/menu`, `/newcharacter`, `/commands`, and `/help`.
 - Rebuilt initial game state around structured player, NPC, enemy, place, coordinate, atlas, map, travel, inventory, POI, and account-save state.
@@ -83,4 +85,4 @@ All notable reset-branch changes are tracked here.
 - Backwards compatibility with the old browser UI and old save shape is intentionally not preserved beyond the current raw-save migration path.
 - `base64-json-v1` save storage is encoded, not strong encryption.
 - Current formulas are conservative approximations until exact researched formulas are migrated deliberately.
-- Current recommended next pass is UI hardening: character-slot cards/buttons, clearer main menu panel, command chips, and save/load feedback before returning to battle rewards.
+- Current recommended next pass is version naming cleanup, then deterministic combat RNG before battle rewards.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,15 @@ Gameplay commands are also slash-prefixed in the UI:
 
 Bare commands are rejected by the UI except while answering active character-creation prompts. The lower-level internal router still accepts bare commands for tests and engine reuse.
 
+## Browser UI panels
+
+The browser shell remains text-first, but the sidebar now includes:
+
+- A main menu panel for New Character, Characters, Save, and All Commands.
+- Character-slot cards with Load buttons for local saved characters.
+- Command chips for common commands such as `/look`, `/stats`, `/inventory`, `/equipment`, `/containers`, `/here`, `/maps`, `/atlas`, movement, travel, and save.
+- A last-action feedback panel that classifies command responses as success, error, or info.
+
 ## Character creation
 
 Use:
@@ -164,6 +173,7 @@ js/text/
   save.js                  encoded account/character localStorage adapter
   sidebar.js               DOM sidebar/HUD/menu buttons
   textShell.js             DOM shell only
+  uiPanels.js              reusable text-first UI panel render helpers
   version.js               app/save/data/system version manifest
   commands/
     parser.js
@@ -220,6 +230,7 @@ docs/
 
 - Text-only browser shell with slash-command UI.
 - Account profile and multiple encoded local character save slots.
+- Text-first sidebar panels for main menu actions, character-slot load buttons, command chips, and last-action feedback.
 - Prompt-based character creation from `/newcharacter`.
 - Argument-aware command parser.
 - Structured player character entity.
@@ -270,10 +281,4 @@ Current formulas are conservative placeholders. They exist to make the architect
 
 ## Current next best pass
 
-The current recommended next pass is UI hardening, not new combat systems:
-
-1. Make the main menu visually clearer and less terminal-only.
-2. Add character-slot cards/buttons for `/characters` and `/load`.
-3. Add visible command chips/buttons for common slash commands.
-4. Add save/load error display in the UI.
-5. Then resume game-system work with battle rewards: EXP, gil, and loot into Inventory.
+The current recommended next pass is version naming cleanup, then deterministic combat RNG before battle rewards.

--- a/README.md
+++ b/README.md
@@ -108,12 +108,29 @@ Bare commands are rejected by the UI except while answering active character-cre
 
 ## Browser UI panels
 
-The browser shell remains text-first, but the sidebar now includes:
+The browser shell remains text-first, but the page now has a slim app frame with a persistent top bar and populated sidebar.
 
-- A main menu panel for New Character, Characters, Save, and All Commands.
-- Character-slot cards with Load buttons for local saved characters.
-- Command chips for common commands such as `/look`, `/stats`, `/inventory`, `/equipment`, `/containers`, `/here`, `/maps`, `/atlas`, movement, travel, and save.
-- A last-action feedback panel that classifies command responses as success, error, or info.
+The top bar includes:
+
+- compact FFXI/Text RPG branding
+- active character name
+- main job and level
+- current location and grid
+- last command feedback
+- quick actions for Menu, Look, Inventory, Equipment, and Save
+
+The sidebar includes:
+
+- active character hero panel
+- last-action feedback
+- main menu actions
+- character summary
+- HP, MP, TP, and EXP bars
+- location/status panel
+- wallet/title panel
+- character-slot load cards
+- command chips for common movement, inventory, map, atlas, travel, and save commands
+- full menu buttons
 
 ## Character creation
 
@@ -172,6 +189,7 @@ js/text/
   gameState.js             initial state and text descriptions
   save.js                  encoded account/character localStorage adapter
   sidebar.js               DOM sidebar/HUD/menu buttons
+  topBar.js                DOM top bar/status strip renderer
   textShell.js             DOM shell only
   uiPanels.js              reusable text-first UI panel render helpers
   version.js               app/save/data/system version manifest
@@ -229,8 +247,9 @@ docs/
 ## Implemented foundation
 
 - Text-only browser shell with slash-command UI.
+- Slim top bar with character/location/status summary and quick actions.
 - Account profile and multiple encoded local character save slots.
-- Text-first sidebar panels for main menu actions, character-slot load buttons, command chips, and last-action feedback.
+- Text-first sidebar panels for main menu actions, character-slot load buttons, command chips, resources, location, wallet, and last-action feedback.
 - Prompt-based character creation from `/newcharacter`.
 - Argument-aware command parser.
 - Structured player character entity.

--- a/css/style.css
+++ b/css/style.css
@@ -50,7 +50,7 @@ button:focus-visible {
 .app-shell {
     min-height: 100vh;
     display: grid;
-    grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+    grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
     gap: 1rem;
     padding: 1rem;
 }
@@ -80,6 +80,82 @@ button:focus-visible {
 .sidebar-section h3 {
     margin: 0 0 0.5rem;
     color: var(--accent);
+}
+
+.sidebar-note {
+    margin: 0.25rem 0 0.75rem;
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+.main-menu-panel {
+    background: linear-gradient(180deg, #18202d, #10141d);
+}
+
+.primary-actions,
+.command-chip-grid,
+.sidebar-menu {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+}
+
+.primary-actions button,
+.command-chip,
+.sidebar-menu button {
+    padding: 0.45rem;
+    text-align: left;
+    font-size: 0.85rem;
+}
+
+.command-chip {
+    background: #1d2433;
+}
+
+.character-card-list {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.character-card {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: 0.5rem;
+    border: 1px solid var(--panel-border);
+    background: #0b0f17;
+    padding: 0.6rem;
+}
+
+.character-card div {
+    display: grid;
+    gap: 0.15rem;
+}
+
+.character-card span {
+    color: var(--muted);
+    font-size: 0.8rem;
+}
+
+.feedback {
+    border-color: var(--accent);
+}
+
+.feedback-success {
+    border-color: var(--good);
+}
+
+.feedback-error {
+    border-color: var(--danger);
+}
+
+.feedback p {
+    margin: 0.35rem 0 0;
+}
+
+.feedback-command {
+    color: var(--muted);
+    font-size: 0.85rem;
 }
 
 .character-name {
@@ -124,18 +200,6 @@ button:focus-visible {
     height: 100%;
     width: var(--value, 0%);
     background: linear-gradient(90deg, #6f7f5f, var(--accent));
-}
-
-.sidebar-menu {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 0.5rem;
-}
-
-.sidebar-menu button {
-    padding: 0.45rem;
-    text-align: left;
-    font-size: 0.85rem;
 }
 
 .terminal-panel {
@@ -233,11 +297,13 @@ h1 {
 }
 
 @media (max-width: 640px) {
-    .command-row {
+    .command-row,
+    .character-card {
         grid-template-columns: auto 1fr;
     }
 
-    .command-row button {
+    .command-row button,
+    .character-card button {
         grid-column: 1 / -1;
     }
 }

--- a/css/style.css
+++ b/css/style.css
@@ -47,8 +47,80 @@ button:focus-visible {
     border-color: var(--accent);
 }
 
-.app-shell {
+.app-frame {
     min-height: 100vh;
+    display: grid;
+    grid-template-rows: auto 1fr;
+}
+
+.topbar {
+    min-height: 2.6rem;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.45rem 1rem;
+    border-bottom: 1px solid var(--panel-border);
+    background: #10141d;
+}
+
+.topbar-brand {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    white-space: nowrap;
+}
+
+.topbar-mark {
+    color: var(--accent);
+    font-weight: 700;
+    letter-spacing: 0.08em;
+}
+
+.topbar-title,
+.topbar-status {
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+.topbar-status {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    overflow: hidden;
+    white-space: nowrap;
+}
+
+.topbar-status span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.topbar-feedback {
+    color: var(--text);
+}
+
+.topbar-feedback-success {
+    color: var(--good);
+}
+
+.topbar-feedback-error {
+    color: var(--danger);
+}
+
+.topbar-actions {
+    display: flex;
+    gap: 0.35rem;
+}
+
+.topbar-actions button {
+    padding: 0.25rem 0.55rem;
+    font-size: 0.78rem;
+}
+
+.app-shell {
+    min-height: 0;
     display: grid;
     grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
     gap: 1rem;
@@ -62,12 +134,47 @@ button:focus-visible {
 }
 
 .character-sidebar {
-    min-height: calc(100vh - 2rem);
+    min-height: 0;
+    max-height: calc(100vh - 4.6rem);
     padding: 1rem;
     display: flex;
     flex-direction: column;
     gap: 1rem;
     overflow: auto;
+}
+
+.sidebar-hero {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 0.75rem;
+    border: 1px solid var(--panel-border);
+    background: linear-gradient(180deg, #1a2231, #10141d);
+    padding: 0.85rem;
+}
+
+.sidebar-crest {
+    width: 3rem;
+    height: 3rem;
+    display: grid;
+    place-items: center;
+    border: 1px solid var(--accent);
+    color: var(--accent);
+    background: #0b0f17;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+}
+
+.sidebar-hero p,
+.sidebar-hero h2 {
+    margin: 0;
+}
+
+.sidebar-kicker {
+    color: var(--muted);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
 }
 
 .sidebar-section {
@@ -86,6 +193,11 @@ button:focus-visible {
     margin: 0.25rem 0 0.75rem;
     color: var(--muted);
     font-size: 0.85rem;
+}
+
+.compact-panel {
+    display: grid;
+    gap: 0.2rem;
 }
 
 .main-menu-panel {
@@ -172,6 +284,7 @@ button:focus-visible {
 .sidebar-line strong {
     color: var(--text);
     font-weight: 400;
+    text-align: right;
 }
 
 .bar-block {
@@ -203,7 +316,8 @@ button:focus-visible {
 }
 
 .terminal-panel {
-    min-height: calc(100vh - 2rem);
+    min-height: 0;
+    max-height: calc(100vh - 4.6rem);
     display: flex;
     flex-direction: column;
     gap: 1rem;
@@ -278,6 +392,19 @@ h1 {
     color: var(--text);
 }
 
+@media (max-width: 1000px) {
+    .topbar {
+        grid-template-columns: 1fr;
+        align-items: stretch;
+        gap: 0.4rem;
+    }
+
+    .topbar-status,
+    .topbar-actions {
+        flex-wrap: wrap;
+    }
+}
+
 @media (max-width: 900px) {
     .app-shell {
         grid-template-columns: 1fr;
@@ -286,6 +413,7 @@ h1 {
 
     .character-sidebar,
     .terminal-panel {
+        max-height: none;
         min-height: auto;
         border-left: 0;
         border-right: 0;

--- a/index.html
+++ b/index.html
@@ -7,27 +7,31 @@
     <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
-    <main id="app" class="app-shell" aria-label="FFXI Text RPG">
-        <aside id="sidebar" class="character-sidebar" aria-label="Character sidebar"></aside>
+    <main id="app" class="app-frame" aria-label="FFXI Text RPG">
+        <header id="topbar" class="topbar" aria-label="Top status bar"></header>
 
-        <section class="terminal-panel">
-            <header class="terminal-header">
-                <p class="eyebrow">Text foundation</p>
-                <h1>FFXI Text RPG</h1>
-                <p class="subtitle">Command-driven systems with persistent character HUD and quick menus.</p>
-            </header>
+        <div class="app-shell">
+            <aside id="sidebar" class="character-sidebar" aria-label="Character sidebar"></aside>
 
-            <pre id="output" class="terminal-output" aria-live="polite"></pre>
+            <section class="terminal-panel">
+                <header class="terminal-header">
+                    <p class="eyebrow">Text foundation</p>
+                    <h1>FFXI Text RPG</h1>
+                    <p class="subtitle">Command-driven systems with persistent character HUD and quick menus.</p>
+                </header>
 
-            <form id="command-form" class="command-form" autocomplete="off">
-                <label for="command-input">Command</label>
-                <div class="command-row">
-                    <span aria-hidden="true">&gt;</span>
-                    <input id="command-input" name="command" type="text" autofocus spellcheck="false" />
-                    <button type="submit">Enter</button>
-                </div>
-            </form>
-        </section>
+                <pre id="output" class="terminal-output" aria-live="polite"></pre>
+
+                <form id="command-form" class="command-form" autocomplete="off">
+                    <label for="command-input">Command</label>
+                    <div class="command-row">
+                        <span aria-hidden="true">&gt;</span>
+                        <input id="command-input" name="command" type="text" autofocus spellcheck="false" />
+                        <button type="submit">Enter</button>
+                    </div>
+                </form>
+            </section>
+        </div>
     </main>
 
     <script type="module" src="js/main.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -25,7 +25,7 @@ function init() {
         form: document.getElementById('command-form'),
         input: document.getElementById('command-input'),
         router,
-        afterCommand: () => sidebar.render(),
+        afterCommand: ({ feedback }) => sidebar.render(feedback),
     });
 
     shell.printIntro();

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,7 @@
 import { createInitialState } from './text/gameState.js';
 import { createSidebar } from './text/sidebar.js';
 import { createTextShell } from './text/textShell.js';
+import { createTopBar } from './text/topBar.js';
 import { loadActiveCharacter, saveGame, clearSave } from './text/save.js';
 import { createSlashCommandRouter } from './text/slashCommandRouter.js';
 
@@ -19,17 +20,26 @@ function init() {
         state,
         runCommand: (command) => shell?.submitCommand(command),
     });
+    const topBar = createTopBar({
+        root: document.getElementById('topbar'),
+        state,
+        runCommand: (command) => shell?.submitCommand(command),
+    });
 
     shell = createTextShell({
         output: document.getElementById('output'),
         form: document.getElementById('command-form'),
         input: document.getElementById('command-input'),
         router,
-        afterCommand: ({ feedback }) => sidebar.render(feedback),
+        afterCommand: ({ feedback }) => {
+            sidebar.render(feedback);
+            topBar.render(feedback);
+        },
     });
 
     shell.printIntro();
     sidebar.render();
+    topBar.render();
     shell.focus();
 }
 

--- a/js/text/sidebar.js
+++ b/js/text/sidebar.js
@@ -4,7 +4,10 @@ import {
     renderCharacterCards,
     renderCommandChips,
     renderFeedback,
+    renderLocationPanel,
     renderMainMenuPanel,
+    renderSidebarHeader,
+    renderWalletPanel,
 } from './uiPanels.js';
 
 const SIDEBAR_MENUS = Object.freeze([
@@ -46,10 +49,13 @@ export function createSidebar({ root, state, runCommand }) {
         const expToNext = player.progression?.expToNext ?? level * 500;
 
         root.innerHTML = [
+            renderSidebarHeader(player),
             renderFeedback(lastFeedback),
             renderMainMenuPanel(),
             renderCharacterSummary(player, state, level, exp, expToNext),
             renderBars(player, combat, exp, expToNext),
+            renderLocationPanel(state),
+            renderWalletPanel(player),
             renderCharacterCards(listCharacters()),
             renderCommandChips(),
             renderMenus(),
@@ -64,13 +70,12 @@ export function createSidebar({ root, state, runCommand }) {
 function renderCharacterSummary(player, state, level, exp, expToNext) {
     return `
         <section class="sidebar-section">
-            <h2 class="character-name">${escapeHtml(player.identity.name)}</h2>
+            <h3>Character</h3>
             <div class="sidebar-line"><span>Job</span><strong>${escapeHtml(player.jobs.mainJobName)} Lv.${level}</strong></div>
             <div class="sidebar-line"><span>Nation</span><strong>${escapeHtml(player.identity.nation)}</strong></div>
             <div class="sidebar-line"><span>Location</span><strong>${escapeHtml(state.location)}</strong></div>
             <div class="sidebar-line"><span>Grid</span><strong>${state.position?.x ?? '?'}:${state.position?.y ?? '?'}</strong></div>
             <div class="sidebar-line"><span>EXP</span><strong>${exp}/${expToNext}</strong></div>
-            <div class="sidebar-line"><span>Gil</span><strong>${player.wallet.gil}</strong></div>
         </section>
     `;
 }

--- a/js/text/sidebar.js
+++ b/js/text/sidebar.js
@@ -1,4 +1,11 @@
+import { listCharacters } from './save.js';
 import { calculateCombatProfile } from './systems/statEngine.js';
+import {
+    renderCharacterCards,
+    renderCommandChips,
+    renderFeedback,
+    renderMainMenuPanel,
+} from './uiPanels.js';
 
 const SIDEBAR_MENUS = Object.freeze([
     ['Main Menu', '/menu'],
@@ -22,13 +29,16 @@ export function createSidebar({ root, state, runCommand }) {
         throw new Error('Sidebar is missing root, state, or runCommand.');
     }
 
+    let lastFeedback = null;
+
     root.addEventListener('click', (event) => {
         const button = event.target.closest('[data-command]');
         if (!button) return;
         runCommand(button.dataset.command);
     });
 
-    function render() {
+    function render(feedback = lastFeedback) {
+        if (feedback !== undefined) lastFeedback = feedback;
         const player = state.player;
         const combat = calculateCombatProfile(player);
         const level = player.jobs.level;
@@ -36,8 +46,12 @@ export function createSidebar({ root, state, runCommand }) {
         const expToNext = player.progression?.expToNext ?? level * 500;
 
         root.innerHTML = [
+            renderFeedback(lastFeedback),
+            renderMainMenuPanel(),
             renderCharacterSummary(player, state, level, exp, expToNext),
             renderBars(player, combat, exp, expToNext),
+            renderCharacterCards(listCharacters()),
+            renderCommandChips(),
             renderMenus(),
         ].join('');
     }

--- a/js/text/textShell.js
+++ b/js/text/textShell.js
@@ -1,3 +1,5 @@
+import { classifyCommandFeedback } from './uiPanels.js';
+
 export function createTextShell({ output, form, input, router, afterCommand }) {
     if (!output || !form || !input || !router) {
         throw new Error('Text shell is missing required DOM elements or command router.');
@@ -20,7 +22,7 @@ export function createTextShell({ output, form, input, router, afterCommand }) {
 
         const response = router(command);
         append(`> ${command}\n${response}`);
-        afterCommand?.({ command, response });
+        afterCommand?.({ command, response, feedback: classifyCommandFeedback(command, response) });
         return response;
     }
 

--- a/js/text/topBar.js
+++ b/js/text/topBar.js
@@ -1,0 +1,24 @@
+import { renderTopBar } from './uiPanels.js';
+
+export function createTopBar({ root, state, runCommand }) {
+    if (!root || !state || !runCommand) {
+        throw new Error('Top bar is missing root, state, or runCommand.');
+    }
+
+    let lastFeedback = null;
+
+    root.addEventListener('click', (event) => {
+        const button = event.target.closest('[data-command]');
+        if (!button) return;
+        runCommand(button.dataset.command);
+    });
+
+    function render(feedback = lastFeedback) {
+        if (feedback !== undefined) lastFeedback = feedback;
+        root.innerHTML = renderTopBar(state, lastFeedback);
+    }
+
+    render();
+
+    return { render };
+}

--- a/js/text/uiPanels.js
+++ b/js/text/uiPanels.js
@@ -15,6 +15,49 @@ export const COMMON_COMMAND_CHIPS = Object.freeze([
     ['/save', 'Save'],
 ]);
 
+export const TOPBAR_ACTIONS = Object.freeze([
+    ['/menu', 'Menu'],
+    ['/look', 'Look'],
+    ['/inventory', 'Inventory'],
+    ['/equipment', 'Equipment'],
+    ['/save', 'Save'],
+]);
+
+export function renderTopBar(state, feedback = null) {
+    const player = state.player;
+    const location = state.location ?? 'Unknown';
+    const grid = state.position ? `${state.position.x}:${state.position.y}` : '?:?';
+    const status = feedback?.message ?? 'Ready';
+    return `
+        <div class="topbar-brand">
+            <span class="topbar-mark">FFXI</span>
+            <span class="topbar-title">Text RPG</span>
+        </div>
+        <div class="topbar-status">
+            <span>${escapeHtml(player.identity.name)}</span>
+            <span>${escapeHtml(player.jobs.mainJobName)} Lv.${escapeHtml(player.jobs.level)}</span>
+            <span>${escapeHtml(location)} · ${escapeHtml(grid)}</span>
+            <span class="topbar-feedback topbar-feedback-${escapeHtml(feedback?.kind ?? 'info')}">${escapeHtml(status)}</span>
+        </div>
+        <nav class="topbar-actions" aria-label="Quick actions">
+            ${TOPBAR_ACTIONS.map(([command, label]) => `<button type="button" data-command="${escapeHtml(command)}">${escapeHtml(label)}</button>`).join('')}
+        </nav>
+    `;
+}
+
+export function renderSidebarHeader(player) {
+    return `
+        <section class="sidebar-hero">
+            <div class="sidebar-crest" aria-hidden="true">XI</div>
+            <div>
+                <p class="sidebar-kicker">Active Character</p>
+                <h2 class="character-name">${escapeHtml(player.identity.name)}</h2>
+                <p>${escapeHtml(player.identity.raceName)} · ${escapeHtml(player.jobs.mainJobName)} Lv.${escapeHtml(player.jobs.level)}</p>
+            </div>
+        </section>
+    `;
+}
+
 export function renderMainMenuPanel() {
     return `
         <section class="sidebar-section main-menu-panel">
@@ -52,6 +95,29 @@ export function renderCharacterCards(characters = []) {
             <div class="character-card-list">
                 ${cards}
             </div>
+        </section>
+    `;
+}
+
+export function renderLocationPanel(state) {
+    const grid = state.position ? `${state.position.x}:${state.position.y}` : '?:?';
+    const battle = state.activeBattle?.phase === 'active' ? 'In battle' : 'Safe';
+    return `
+        <section class="sidebar-section compact-panel">
+            <h3>Location</h3>
+            <div class="sidebar-line"><span>Place</span><strong>${escapeHtml(state.location)}</strong></div>
+            <div class="sidebar-line"><span>Grid</span><strong>${escapeHtml(grid)}</strong></div>
+            <div class="sidebar-line"><span>Status</span><strong>${escapeHtml(battle)}</strong></div>
+        </section>
+    `;
+}
+
+export function renderWalletPanel(player) {
+    return `
+        <section class="sidebar-section compact-panel">
+            <h3>Wallet</h3>
+            <div class="sidebar-line"><span>Gil</span><strong>${escapeHtml(player.wallet?.gil ?? 0)}</strong></div>
+            <div class="sidebar-line"><span>Title</span><strong>${escapeHtml(player.identity.title ?? 'New Adventurer')}</strong></div>
         </section>
     `;
 }

--- a/js/text/uiPanels.js
+++ b/js/text/uiPanels.js
@@ -1,0 +1,106 @@
+export const COMMON_COMMAND_CHIPS = Object.freeze([
+    ['/look', 'Look'],
+    ['/stats', 'Stats'],
+    ['/inventory', 'Inventory'],
+    ['/equipment', 'Equipment'],
+    ['/containers', 'Containers'],
+    ['/here', 'Here'],
+    ['/maps', 'Maps'],
+    ['/atlas', 'Atlas'],
+    ['/move n', 'North'],
+    ['/move e', 'East'],
+    ['/move s', 'South'],
+    ['/move w', 'West'],
+    ['/travel', 'Travel'],
+    ['/save', 'Save'],
+]);
+
+export function renderMainMenuPanel() {
+    return `
+        <section class="sidebar-section main-menu-panel">
+            <h3>Main Menu</h3>
+            <p class="sidebar-note">Create, load, inspect, and save without memorizing every slash command.</p>
+            <div class="primary-actions">
+                <button type="button" data-command="/newcharacter">New Character</button>
+                <button type="button" data-command="/characters">Characters</button>
+                <button type="button" data-command="/save">Save</button>
+                <button type="button" data-command="/commands">All Commands</button>
+            </div>
+        </section>
+    `;
+}
+
+export function renderCommandChips(commands = COMMON_COMMAND_CHIPS) {
+    return `
+        <section class="sidebar-section">
+            <h3>Command Chips</h3>
+            <div class="command-chip-grid">
+                ${commands.map(([command, label]) => `<button type="button" class="command-chip" data-command="${escapeHtml(command)}">${escapeHtml(label)}</button>`).join('')}
+            </div>
+        </section>
+    `;
+}
+
+export function renderCharacterCards(characters = []) {
+    const cards = characters.length
+        ? characters.map(renderCharacterCard).join('')
+        : '<p class="sidebar-note">No saved characters yet. Use New Character to create one.</p>';
+
+    return `
+        <section class="sidebar-section">
+            <h3>Character Slots</h3>
+            <div class="character-card-list">
+                ${cards}
+            </div>
+        </section>
+    `;
+}
+
+export function renderFeedback(feedback = null) {
+    if (!feedback) return '';
+    return `
+        <section class="sidebar-section feedback feedback-${escapeHtml(feedback.kind)}" role="status" aria-live="polite">
+            <h3>Last Action</h3>
+            <div class="feedback-command">${escapeHtml(feedback.command)}</div>
+            <p>${escapeHtml(feedback.message)}</p>
+        </section>
+    `;
+}
+
+export function classifyCommandFeedback(command, response) {
+    const text = String(response ?? '').trim();
+    const normalized = text.toLowerCase();
+    const isFailure = /failed|invalid|unknown|not enough|no matching|no saved|cannot|blocked|missing|not implemented/.test(normalized);
+    const isSuccess = /saved|loaded|created|equipped|unequipped|transferred|bought|moved|arrived|fast traveled|advanced/.test(normalized);
+    return {
+        command: String(command ?? '').trim(),
+        message: firstMeaningfulLine(text) || 'Command completed.',
+        kind: isFailure ? 'error' : isSuccess ? 'success' : 'info',
+    };
+}
+
+function renderCharacterCard(record) {
+    return `
+        <article class="character-card">
+            <div>
+                <strong>${escapeHtml(record.name)}</strong>
+                <span>${escapeHtml(record.race)} ${escapeHtml(record.job)} Lv.${escapeHtml(record.level)}</span>
+                <span>${escapeHtml(record.nation)} · ${escapeHtml(record.location)}</span>
+            </div>
+            <button type="button" data-command="/load ${escapeHtml(record.index)}">Load</button>
+        </article>
+    `;
+}
+
+function firstMeaningfulLine(text) {
+    return String(text ?? '').split('\n').map((line) => line.trim()).find(Boolean) ?? '';
+}
+
+export function escapeHtml(value) {
+    return String(value ?? '')
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#039;');
+}

--- a/tests/uiPanels.test.js
+++ b/tests/uiPanels.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    classifyCommandFeedback,
+    renderCharacterCards,
+    renderCommandChips,
+    renderMainMenuPanel,
+} from '../js/text/uiPanels.js';
+
+test('renderMainMenuPanel exposes primary slash commands', () => {
+    const html = renderMainMenuPanel();
+
+    assert.match(html, /data-command="\/newcharacter"/);
+    assert.match(html, /data-command="\/characters"/);
+    assert.match(html, /data-command="\/save"/);
+});
+
+test('renderCommandChips exposes common command buttons', () => {
+    const html = renderCommandChips();
+
+    assert.match(html, /data-command="\/look"/);
+    assert.match(html, /data-command="\/inventory"/);
+    assert.match(html, /data-command="\/move n"/);
+});
+
+test('renderCharacterCards shows empty state and load buttons', () => {
+    assert.match(renderCharacterCards([]), /No saved characters/);
+
+    const html = renderCharacterCards([{ index: 2, name: 'Tester', race: 'Hume', job: 'Warrior', level: 1, nation: 'San d’Oria', location: 'Southern San d’Oria' }]);
+    assert.match(html, /Tester/);
+    assert.match(html, /data-command="\/load 2"/);
+});
+
+test('classifyCommandFeedback identifies success error and info responses', () => {
+    assert.equal(classifyCommandFeedback('/save', 'Character saved.').kind, 'success');
+    assert.equal(classifyCommandFeedback('/load 2', 'No saved character matched: 2').kind, 'error');
+    assert.equal(classifyCommandFeedback('/look', 'Southern San d’Oria').kind, 'info');
+});

--- a/tests/uiPanels.test.js
+++ b/tests/uiPanels.test.js
@@ -1,11 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
+import { createInitialState } from '../js/text/gameState.js';
 import {
     classifyCommandFeedback,
     renderCharacterCards,
     renderCommandChips,
     renderMainMenuPanel,
+    renderTopBar,
 } from '../js/text/uiPanels.js';
 
 test('renderMainMenuPanel exposes primary slash commands', () => {
@@ -30,6 +32,17 @@ test('renderCharacterCards shows empty state and load buttons', () => {
     const html = renderCharacterCards([{ index: 2, name: 'Tester', race: 'Hume', job: 'Warrior', level: 1, nation: 'San d’Oria', location: 'Southern San d’Oria' }]);
     assert.match(html, /Tester/);
     assert.match(html, /data-command="\/load 2"/);
+});
+
+test('renderTopBar exposes identity status and quick actions', () => {
+    const state = createInitialState();
+    const html = renderTopBar(state, { kind: 'success', message: 'Character saved.' });
+
+    assert.match(html, /FFXI/);
+    assert.match(html, /Adventurer/);
+    assert.match(html, /Character saved\./);
+    assert.match(html, /data-command="\/menu"/);
+    assert.match(html, /data-command="\/save"/);
 });
 
 test('classifyCommandFeedback identifies success error and info responses', () => {


### PR DESCRIPTION
## Summary

- Add a slim top bar above the sidebar/terminal grid with compact branding, active character/job/location status, last-command feedback, and quick actions.
- Populate the sidebar with an active character hero panel, main menu, character summary, HP/MP/TP/EXP resources, location/status, wallet/title, character slots, command chips, and full menu buttons.
- Add reusable text-first UI panel helpers for the main menu, command chips, character-slot cards, top bar, sidebar status panels, and last-action feedback.
- Render sidebar character-slot load cards from existing local save summaries.
- Classify command responses as success, error, or info for visible UI feedback.
- Add tests for pure UI panel helpers, including top bar rendering.
- Update README and CHANGELOG with the app frame/sidebar/topbar structure.

## Notes

This keeps the runtime text-first and does not add graphical map/image systems or battle reward logic.

## Testing

Not run through GitHub connector. Please run locally:

```bash
npm test
npm run benchmark
npm run check
```
