### PR TITLE
Clarify version manifest names

### DIFF
--- a/js/text/version.js
+++ b/js/text/version.js
@@ -1,11 +1,15 @@
 export const VERSION = Object.freeze({
     app: '0.4.1',
-    save: 3,
+    accountSave: 3,
+    gameState: 2,
     data: 7,
     benchmark: 1,
     codename: 'Slash UI Account Saves',
     compatibility: 'no-backwards-compatibility',
     released: false,
+
+    // Backward-compatible alias for older callers while they migrate.
+    save: 3,
 });
 
 export const SYSTEM_VERSIONS = Object.freeze({
@@ -60,7 +64,8 @@ export const SYSTEM_VERSIONS = Object.freeze({
 export function describeVersion() {
     return [
         `App: ${VERSION.app}`,
-        `Save: ${VERSION.save}`,
+        `Account Save: ${VERSION.accountSave}`,
+        `Game State: ${VERSION.gameState}`,
         `Data: ${VERSION.data}`,
         `Benchmark: ${VERSION.benchmark}`,
         `Codename: ${VERSION.codename}`,

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -7,12 +7,16 @@ import { createTickEngine } from '../js/text/systems/tickEngine.js';
 import { describeSystemVersions, describeVersion, VERSION } from '../js/text/version.js';
 
 
-test('version manifest exposes app save data and benchmark versions', () => {
-    assert.equal(VERSION.app, '0.3.1');
-    assert.equal(VERSION.save, 2);
-    assert.equal(VERSION.data, 3);
+test('version manifest exposes explicit app account save game state data and benchmark versions', () => {
+    assert.equal(VERSION.app, '0.4.1');
+    assert.equal(VERSION.accountSave, 3);
+    assert.equal(VERSION.gameState, 2);
+    assert.equal(VERSION.data, 7);
     assert.equal(VERSION.benchmark, 1);
-    assert.match(describeVersion(), /App: 0.3.1/);
+    assert.equal(VERSION.save, VERSION.accountSave);
+    assert.match(describeVersion(), /App: 0.4.1/);
+    assert.match(describeVersion(), /Account Save: 3/);
+    assert.match(describeVersion(), /Game State: 2/);
     assert.match(describeSystemVersions(), /characterCreation/);
 });
 


### PR DESCRIPTION
## Summary

- Add explicit `VERSION.accountSave` and `VERSION.gameState` fields so account-save versioning is not confused with game-state schema versioning.
- Keep `VERSION.save` as a backward-compatible alias for `VERSION.accountSave` while callers migrate.
- Update the stale pipeline version test from the old `0.3.1 / 2 / 3` expectations to the current `0.4.1 / 3 / 2 / 7` manifest.

## Notes

This PR was rebuilt cleanly on top of current `main` after #281 was merged. It should now only touch:

- `js/text/version.js`
- `tests/pipeline.test.js`

## Testing

Not run through GitHub connector. Please run locally:

```bash
npm test
npm run benchmark
npm run check
```