### PR TITLE
Add deterministic combat RNG helpers

### DIFF
--- a/js/text/systems/battleEngine.js
+++ b/js/text/systems/battleEngine.js
@@ -1,6 +1,7 @@
+import { rollPercent } from './rng.js';
 import { calculateCombatProfile } from './statEngine.js';
 
-export function createBattleState({ player, enemies = [], rngSeed = null } = {}) {
+export function createBattleState({ player, enemies = [], rngSeed = null, rng = null } = {}) {
     if (!player) throw new Error('createBattleState requires a player entity.');
     if (!enemies.length) throw new Error('createBattleState requires at least one enemy.');
 
@@ -9,6 +10,7 @@ export function createBattleState({ player, enemies = [], rngSeed = null } = {})
         round: 1,
         phase: 'active',
         rngSeed,
+        rng,
         combatants: [refreshCombatant(player), ...enemies.map(refreshCombatant)],
         enmity: {},
         skillchain: null,
@@ -37,19 +39,20 @@ export function refreshCombatant(entity) {
     };
 }
 
-export function performBasicAttack(battle, attackerId, defenderId) {
+export function performBasicAttack(battle, attackerId, defenderId, options = {}) {
     const attacker = getCombatant(battle, attackerId);
     const defender = getCombatant(battle, defenderId);
     if (!attacker || !defender) return appendBattleLog(battle, 'Invalid combatant.');
     if (attacker.battle.defeated || defender.battle.defeated) return battle;
 
+    const rng = options.rng ?? battle.rng ?? Math.random;
     const hitChance = calculateHitChance(attacker, defender);
-    const roll = Math.random() * 100;
+    const roll = rollPercent(rng);
     if (roll > hitChance) {
         return appendBattleLog(battle, `${attacker.identity.name} misses ${defender.identity.name}.`);
     }
 
-    const damage = calculatePhysicalDamage(attacker, defender);
+    const damage = calculatePhysicalDamage(attacker, defender, { rng });
     defender.resources.hp = Math.max(0, defender.resources.hp - damage);
     attacker.resources.tp = Math.min(attacker.combat.resources.maxTp, attacker.resources.tp + 100);
     defender.resources.tp = Math.min(defender.combat.resources.maxTp, defender.resources.tp + 30);
@@ -71,12 +74,13 @@ export function calculateHitChance(attacker, defender) {
     return clamp(75 + (accuracy - evasion) / 2, 20, 95);
 }
 
-export function calculatePhysicalDamage(attacker, defender) {
+export function calculatePhysicalDamage(attacker, defender, options = {}) {
+    const rng = options.rng ?? Math.random;
     const attack = attacker.combat.derived.attack;
     const defense = Math.max(1, defender.combat.derived.defense);
     const ratio = attack / defense;
     const base = Math.max(1, Math.floor(attacker.combat.level + attacker.combat.attributes.str / 2));
-    const variance = 0.9 + Math.random() * 0.2;
+    const variance = 0.9 + rng() * 0.2;
     return Math.max(1, Math.floor(base * ratio * variance));
 }
 

--- a/js/text/systems/combatActionEngine.js
+++ b/js/text/systems/combatActionEngine.js
@@ -18,6 +18,8 @@ export function startEncounter(state, enemyId, options = {}) {
     state.activeBattle = createBattleState({
         player: state.player,
         enemies: [{ ...enemy, id: `${enemy.id}-encounter-${Date.now()}` }],
+        rng: options.rng,
+        rngSeed: options.rngSeed ?? null,
     });
     state.activeBattle.source = options.source ?? 'manual';
     state.activeBattle.sourceEnemyId = enemy.id;

--- a/js/text/systems/rng.js
+++ b/js/text/systems/rng.js
@@ -1,0 +1,23 @@
+export function createSequenceRng(values = []) {
+    const sequence = values.length ? values : [0.5];
+    let index = 0;
+    return function sequenceRng() {
+        const value = sequence[index % sequence.length];
+        index += 1;
+        return clampRngValue(value);
+    };
+}
+
+export function resolveRng(options = {}) {
+    return typeof options.rng === 'function' ? options.rng : Math.random;
+}
+
+export function rollPercent(rng = Math.random) {
+    return clampRngValue(rng()) * 100;
+}
+
+function clampRngValue(value) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return 0;
+    return Math.max(0, Math.min(0.999999, number));
+}

--- a/tests/rngEngine.test.js
+++ b/tests/rngEngine.test.js
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createEnemy, createPlayerCharacter } from '../js/text/entities/entityFactory.js';
+import { createBattleState, performBasicAttack } from '../js/text/systems/battleEngine.js';
+import { createSequenceRng } from '../js/text/systems/rng.js';
+
+function createBattle(rngValues) {
+    const player = createPlayerCharacter({ id: 'player-rng', name: 'Tester', level: 5 });
+    const enemy = createEnemy({ id: 'enemy-rng', name: 'Target Dummy', level: 1 });
+    const battle = createBattleState({ player, enemies: [enemy], rng: createSequenceRng(rngValues) });
+    return { battle, playerId: 'player-rng', enemyId: 'enemy-rng' };
+}
+
+test('createSequenceRng loops through deterministic values', () => {
+    const rng = createSequenceRng([0.1, 0.2]);
+
+    assert.equal(rng(), 0.1);
+    assert.equal(rng(), 0.2);
+    assert.equal(rng(), 0.1);
+});
+
+test('performBasicAttack can deterministically hit', () => {
+    const { battle, playerId, enemyId } = createBattle([0.01, 0.5]);
+
+    performBasicAttack(battle, playerId, enemyId);
+
+    assert.match(battle.log.join('\n'), /hits Target Dummy/);
+});
+
+test('performBasicAttack can deterministically miss', () => {
+    const { battle, playerId, enemyId } = createBattle([0.99]);
+
+    performBasicAttack(battle, playerId, enemyId);
+
+    assert.match(battle.log.join('\n'), /misses Target Dummy/);
+});
+
+test('performBasicAttack uses deterministic damage variance', () => {
+    const low = createBattle([0.01, 0]);
+    const high = createBattle([0.01, 0.999999]);
+
+    performBasicAttack(low.battle, low.playerId, low.enemyId);
+    performBasicAttack(high.battle, high.playerId, high.enemyId);
+
+    const lowHp = low.battle.combatants.find((combatant) => combatant.id === low.enemyId).resources.hp;
+    const highHp = high.battle.combatants.find((combatant) => combatant.id === high.enemyId).resources.hp;
+    assert.ok(highHp <= lowHp);
+});


### PR DESCRIPTION
## Summary

- Add reusable deterministic RNG helpers for tests and future loot/reward rolls.
- Allow battle states and basic attacks to use injected RNG while preserving Math.random defaults.
- Pass encounter RNG options through the combat action layer.
- Add deterministic tests for sequence RNG, hit, miss, and damage variance behavior.

## Notes

This PR was rebuilt cleanly on top of current `main` after #282 was merged.

## Testing

Not run through GitHub connector. Please run locally:

```bash
npm test
npm run benchmark
npm run check
```