### PR TITLE
Sync docs after 0.5 foundation merges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable reset-branch changes are tracked here.
 - Account/save tests for encoding, slot listing, character loading, active character restore, save clearing, and inventory reference relinking.
 - Slash-router tests for bare-command rejection, menu/help output, gameplay forwarding, account commands, and character creation prompts.
 - Argument-aware command parser with aliases, quoted arguments, positional args, and `--named=value` args.
-- Version manifest for app, save, data, benchmark, and system versions.
+- Explicit version manifest fields for app, account save, game state, data, benchmark, and system versions.
 - Baseline benchmark harness for stat profile calculation, enemy profiles, battle attacks, tick dispatch, and direct travel route lookup.
 - Database registry covering players, NPCs, enemies, places, zone connections, travel, quests, achievements, items, key items, magic, abilities, loot, leveling, trusts, crafting, mounts, status effects, and ticks.
 - Live tick engine scaffold with subscriptions, manual ticks, start/stop, enabled state, and standard tick channels.
@@ -42,7 +42,10 @@ All notable reset-branch changes are tracked here.
 - Inventory container framework for Inventory, Mog Safe, Mog Safe 2, Storage, Mog Locker, Mog Satchel, Mog Sack, Mog Case, and Mog Wardrobes 1-8.
 - Mog House-only access rules for Mog Safe and Storage.
 - Furniture-derived Storage capacity for Mog House furniture.
-- Atomic item transfer command between containers with access, capacity, and item-kind checks.
+- Common item schema helpers for item kinds, normalization, stackability, max stack, source, flags, modifiers, and item display.
+- Stack-aware inventory insertion and transfer stacking for stackable consumables, materials, and misc items.
+- Split-stack overflow protection so failed partial stacks do not mutate existing quantities.
+- Atomic item transfer command between containers with access, capacity, item-kind, and stack-rule checks.
 - Equip/unequip commands using Inventory and accessible Wardrobes.
 - Starter equipment catalog with conservative stat modifiers.
 - Equipped gear modifiers feeding into the stat/combat profile.
@@ -51,29 +54,32 @@ All notable reset-branch changes are tracked here.
 - Job seed definitions for all standard FFXI player jobs through Rune Fencer.
 - Player, NPC, and enemy entity factories.
 - Conservative stat engine for attributes, resources, skills, derived stats, equipment modifiers, and resistances.
-- Simple battle-state engine with combatants, HP/MP/TP, hit chance, basic physical damage, victory/defeat state, and battle log.
+- Simple battle-state engine with combatants, HP/MP/TP, deterministic RNG injection, hit chance, basic physical damage, victory/defeat state, and battle log.
 - Combat action command layer for attack, placeholder weapon skills, and placeholder casting.
+- Starter loot table data and seed enemy loot table references.
+- Battle reward resolution for victory EXP, gil, deterministic loot rolls, Inventory insertion, failed loot storage reporting, and duplicate payout prevention.
 - Status effect engine with apply/remove/advance behavior and basic tick support.
 - Game-state and entity validation helpers.
 - Seed NPCs and enemies for early command-shell verification.
 - `inspect <target>` command for player, stats, inventory, NPC, enemy, state, log, version, systems, database, maps, zone, atlas, grid, travel, controls, and storage inspection.
 - `validate` command for current state validation.
 - `version`, `systems`, `databases`, `tick`, `maps`, `map`, `zones`, `zone`, `atlas`, `grid`, `move`, `controls`, `travel`, `wait`, `containers`, `container`, `transfer`, `equip`, `unequip`, `equipSources`, `here`, `talk`, `shop`, `buy`, `guild`, `quest`, `discovered`, `fastpoi`, and `zonefast` commands.
-- Node test coverage for command parsing, validation, entity factories, stat calculations, baseline pipeline, versioning, database registry, tick dispatch, zone graph, starter maps, world-data validation, travel flow, atlas discovery, controls, aggro checks, POI discovery, shop transactions, inventory transfers, equipment commands, save accounts, slash commands, UI panel helpers, and basic battle flow.
+- Node test coverage for command parsing, validation, entity factories, stat calculations, baseline pipeline, versioning, database registry, tick dispatch, zone graph, starter maps, world-data validation, travel flow, atlas discovery, controls, aggro checks, POI discovery, shop transactions, inventory transfers, equipment commands, save accounts, slash commands, UI panel helpers, deterministic RNG, battle rewards, item schema/stacking, and basic battle flow.
 - Architecture, roadmap, baseline pipeline, system catalog, research reference, and thread handoff documents for the rebuild.
 
 ### Changed
 - Moved the browser shell into an app frame with a slim top bar above the sidebar/terminal grid.
 - Preserved FFXI macro-style slash commands through the browser slash router so the FFXI command adapter can handle them.
 - Aligned character-creation docs and slash-router tests with the current name-first, confirmation-based creator flow.
+- Clarified version naming with `VERSION.accountSave` and `VERSION.gameState`; `VERSION.save` remains a temporary alias for account save version.
 - Replaced the old graphical/menu-heavy entry path with a minimal text-first foundation.
 - Replaced the UI-facing bare-command model with slash commands.
 - Updated sidebar buttons to emit slash commands and include main menu, new character, characters, save, containers, and commands actions.
 - Updated shell intro text to guide users toward `/menu`, `/newcharacter`, `/commands`, and `/help`.
-- Rebuilt initial game state around structured player, NPC, enemy, place, coordinate, atlas, map, travel, inventory, POI, and account-save state.
+- Rebuilt initial game state around structured player, NPC, enemy, place, coordinate, atlas, map, travel, inventory, item, POI, and account-save state.
 - Refactored command routing to operate on parsed command objects instead of whole-command strings.
-- Updated app/package version to `0.4.1`, save version to `3`, data version to `7`, and codename to `Slash UI Account Saves`.
-- Refreshed README, architecture, roadmap, and handoff documentation for the current repo state.
+- Updated app/package version to `0.4.1`, account save version to `3`, game state version to `2`, data version to `9`, and codename to `Slash UI Account Saves`.
+- Refreshed README, roadmap, and handoff documentation for the current post-0.5 foundation state.
 
 ### Removed
 - Active panzoom dependency from the text-only branch.
@@ -85,4 +91,4 @@ All notable reset-branch changes are tracked here.
 - Backwards compatibility with the old browser UI and old save shape is intentionally not preserved beyond the current raw-save migration path.
 - `base64-json-v1` save storage is encoded, not strong encryption.
 - Current formulas are conservative approximations until exact researched formulas are migrated deliberately.
-- Current recommended next pass is version naming cleanup, then deterministic combat RNG before battle rewards.
+- Current recommended next pass is progression: EXP tables, level-up rules, job-level state preparation, and resource refresh on level-up.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A text-only RPG foundation inspired by Final Fantasy XI systems.
 
-This branch intentionally resets the project around a stable slash-command shell, structured entities, account/character save slots, conservative stat engines, parser-backed commands, validation helpers, version tracking, benchmarks, a database registry, seeded world graph, starter city maps, coordinate atlas, travel scaffold, text HUD/control metadata, inventory/storage containers, POI discovery, starter shops/guild hooks, equipment commands, and implementation-first documentation.
+This branch intentionally resets the project around a stable slash-command shell, structured entities, account/character save slots, conservative stat engines, parser-backed commands, validation helpers, version tracking, benchmarks, a database registry, seeded world graph, starter city maps, coordinate atlas, travel scaffold, text HUD/control metadata, inventory/storage containers, item schema and stacking, POI discovery, starter shops/guild hooks, equipment commands, deterministic combat, battle rewards, and implementation-first documentation.
 
 Backwards compatibility with the previous UI/save shape is not considered until explicitly reintroduced.
 
@@ -10,10 +10,13 @@ Backwards compatibility with the previous UI/save shape is not considered until 
 
 ```text
 App/package: 0.4.1
-Save: 3
-Data: 7
+Account Save: 3
+Game State: 2
+Data: 9
 Codename: Slash UI Account Saves
 ```
+
+`VERSION.save` remains as a backward-compatible alias for `VERSION.accountSave` while callers migrate to the clearer name.
 
 See `js/text/version.js` for the authoritative runtime/system version map.
 
@@ -50,7 +53,7 @@ Read these first in a new thread or fresh development session:
 
 ## UI command policy
 
-The browser UI now expects slash commands.
+The browser UI expects slash commands.
 
 ```text
 /menu
@@ -108,29 +111,11 @@ Bare commands are rejected by the UI except while answering active character-cre
 
 ## Browser UI panels
 
-The browser shell remains text-first, but the page now has a slim app frame with a persistent top bar and populated sidebar.
+The browser shell remains text-first, but the page has a slim app frame with a persistent top bar and populated sidebar.
 
-The top bar includes:
+The top bar includes compact branding, active character name, main job and level, current location and grid, last command feedback, and quick actions for Menu, Look, Inventory, Equipment, and Save.
 
-- compact FFXI/Text RPG branding
-- active character name
-- main job and level
-- current location and grid
-- last command feedback
-- quick actions for Menu, Look, Inventory, Equipment, and Save
-
-The sidebar includes:
-
-- active character hero panel
-- last-action feedback
-- main menu actions
-- character summary
-- HP, MP, TP, and EXP bars
-- location/status panel
-- wallet/title panel
-- character-slot load cards
-- command chips for common movement, inventory, map, atlas, travel, and save commands
-- full menu buttons
+The sidebar includes active character hero, last-action feedback, main menu actions, character summary, HP/MP/TP/EXP bars, location/status, wallet/title, character-slot load cards, command chips, and full menu buttons.
 
 ## Character creation
 
@@ -192,7 +177,7 @@ js/text/
   topBar.js                DOM top bar/status strip renderer
   textShell.js             DOM shell only
   uiPanels.js              reusable text-first UI panel render helpers
-  version.js               app/save/data/system version manifest
+  version.js               app/account-save/game-state/data/system version manifest
   commands/
     parser.js
   data/
@@ -201,7 +186,9 @@ js/text/
     equipmentCatalog.js
     guildServices.js
     inventoryContainers.js
+    itemSchema.js
     jobs.js
+    lootTables.js
     maps.js
     mogHouseFurniture.js
     nations.js
@@ -225,6 +212,8 @@ js/text/
     inventoryEngine.js
     menuDescriptions.js
     poiEngine.js
+    rewardEngine.js
+    rng.js
     shopEngine.js
     statEngine.js
     statusEngine.js
@@ -252,9 +241,7 @@ docs/
 - Text-first sidebar panels for main menu actions, character-slot load buttons, command chips, resources, location, wallet, and last-action feedback.
 - Prompt-based character creation from `/newcharacter`.
 - Argument-aware command parser.
-- Structured player character entity.
-- Structured NPC entity.
-- Structured enemy entity.
+- Structured player, NPC, and enemy entities.
 - Race seed definitions.
 - Job seed definitions for standard FFXI player jobs through Rune Fencer.
 - Three starter city clusters: San d’Oria, Bastok, and Windurst.
@@ -269,13 +256,15 @@ docs/
 - Starter shop catalogs, guild service hooks, and quest/mission hooks.
 - Inventory container framework: Inventory, Mog Safe, Mog Safe 2, Storage, Mog Locker, Mog Satchel, Mog Sack, Mog Case, and Mog Wardrobes 1-8.
 - Mog House-only Storage/Mog Safe access and furniture-derived Storage capacity.
-- Container transfer rules with capacity/access/item-kind validation.
+- Common item schema, item normalization, stack metadata, and stack-aware container insertion.
+- Container transfer rules with access, capacity, item-kind, and stack-handling validation.
 - Shop buying into Inventory.
 - Equip/unequip commands using Inventory and accessible Wardrobes.
 - Starter equipment catalog with conservative stat modifiers.
 - Attribute/resource/derived-stat/skill/equipment/currency constants.
 - Conservative stat calculation engine.
-- Simple battle-state engine.
+- Simple battle-state engine with deterministic RNG injection.
+- Battle reward resolution for EXP, gil, loot rolls, Inventory insertion, and duplicate payout prevention.
 - Status effect lifecycle engine.
 - Live tick engine scaffold.
 - Version manifest and system version tracking.
@@ -300,4 +289,9 @@ Current formulas are conservative placeholders. They exist to make the architect
 
 ## Current next best pass
 
-The current recommended next pass is version naming cleanup, then deterministic combat RNG before battle rewards.
+The current recommended next pass is progression:
+
+1. Add EXP table data and level-up rules.
+2. Update player/job progression containers when rewards grant EXP.
+3. Refresh HP/MP/resources and EXP-to-next after level-up.
+4. Add tests for no level-up, single level-up, multi-level-up, and level-cap behavior.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,7 +9,7 @@ This roadmap turns the text-only reset into a stable expandable RPG foundation. 
 | 0.2.x | Foundation pipeline, version tracking, benchmarks, registries | Tests, benchmark harness, docs |
 | 0.3.x | Places, zone connections, travel restrictions, tick-based travel, POIs, starter services | Zone graph tests, POI tests, travel benchmark |
 | 0.4.x | Slash UI, account saves, character creation, inventory, equipment, starter item modifiers | Save/schema tests, UI command tests, equipment stat tests |
-| 0.5.x | Combat rewards, enemies, loot, magic basics, enemy AI | Battle benchmarks and deterministic combat tests |
+| 0.5.x | Combat rewards, enemies, loot, item schema, magic basics, enemy AI | Battle benchmarks and deterministic combat tests |
 | 0.6.x | Quests, trusts, enmity, party AI, progression flags | Quest and trust AI tests |
 | 0.7.x | Achievements, missions, skillchains, magic bursts, reputation | Formula confidence documentation |
 | 0.8.x | Crafting, mounts, advanced travel/economy | Crafting and travel benchmark coverage |
@@ -49,15 +49,15 @@ Status: mostly complete.
 
 Status: mostly complete for a starter shell.
 
-- [x] Character creation flow: name, race, sex, nation, main job.
+- [x] Character creation flow: name, nation, race, sex, starting job, confirmation.
 - [x] New Character entry from main menu via `/newcharacter`.
 - [x] Job list and race list commands.
 - [x] Full character sheet output.
 - [x] Equipment sheet output.
 - [x] Account character listing and load commands.
+- [x] UI character-slot cards/buttons.
 - [ ] Support job unlock placeholder.
-- [ ] Level and EXP progression containers need real reward integration.
-- [ ] UI character-slot cards/buttons beyond text output.
+- [ ] Level and EXP progression containers need real level-up rules.
 
 ## Phase 3: World graph, zones, and travel
 
@@ -92,9 +92,9 @@ Status: starter framework implemented.
 - [x] Stat aggregation from equipped gear.
 - [x] Equip/unequip commands.
 - [x] Shop buying into Inventory.
-- [ ] New full item schema.
+- [x] New full item schema foundation.
+- [x] Inventory stack handling.
 - [ ] Key item schema for unlocks and permissions.
-- [ ] Inventory stack handling.
 - [ ] Equipment validation by job/race/level.
 - [ ] Item flags: rare, exclusive, key item, no sell, latent, enchantment, charges.
 - [ ] Item command inspection.
@@ -102,7 +102,7 @@ Status: starter framework implemented.
 
 ## Phase 5: Leveling, skills, and progression
 
-Target: 0.4.x to 0.5.x.
+Target: 0.5.x.
 
 - [ ] EXP tables and level-up rules.
 - [ ] Job-level state for all jobs.
@@ -118,13 +118,16 @@ Target: 0.5.x.
 - [x] Encounter command.
 - [x] Basic target attack flow.
 - [x] Placeholder weapon skill and cast commands.
+- [x] Deterministic combat RNG injection.
+- [x] EXP rewards.
+- [x] Gil rewards.
+- [x] Loot table schema.
+- [x] Drop roll engine.
+- [x] Inventory insertion through existing container rules.
+- [x] Duplicate reward payout guard.
 - [ ] Target selection improvements.
 - [ ] Enemy AI turn.
 - [ ] Battle tick integration.
-- [ ] EXP rewards.
-- [ ] Gil rewards.
-- [ ] Loot table schema.
-- [ ] Drop roll engine.
 - [ ] Death/KO flow.
 - [ ] Simple rest/recovery flow.
 
@@ -204,10 +207,10 @@ Target: ongoing.
 
 ## Current recommended next pass
 
-Pause on deeper combat rewards until the UI is more usable:
+The next best implementation pass is progression, not more UI or loot plumbing:
 
-1. Add visible character-slot cards/buttons in the browser UI.
-2. Add a clearer main menu panel rather than relying only on terminal output.
-3. Add command chips/buttons for common slash commands.
-4. Add save/load failure messages in the UI.
-5. Then resume 0.5.x battle reward handling: EXP, gil, loot rolls, and Inventory insertion.
+1. Add EXP table data and level-up rules.
+2. Update player/job progression containers when rewards grant EXP.
+3. Refresh HP/MP/resources and EXP-to-next after level-up.
+4. Add tests for no level-up, single level-up, multi-level-up, and level-cap behavior.
+5. Update README, THREAD_HANDOFF, CHANGELOG, version map, and benchmark coverage if progression logic becomes runtime-heavy.

--- a/docs/THREAD_HANDOFF.md
+++ b/docs/THREAD_HANDOFF.md
@@ -36,8 +36,9 @@ Current state at handoff:
 
 ```text
 App/package: 0.4.1
-Save: 3
-Data: 7
+Account Save: 3
+Game State: 2
+Data: 9
 Codename: Slash UI Account Saves
 ```
 
@@ -50,8 +51,14 @@ saveEncoding: 0.4.1
 statEngine: 0.4.0
 equipmentCommands: 0.4.0
 equipmentCatalog: 0.4.0
-inventoryContainers: 0.3.8
-inventoryTransfers: 0.3.8
+inventoryContainers: 0.5.1
+inventoryTransfers: 0.5.1
+itemSchema: 0.5.1
+itemStacking: 0.5.1
+battleEngine: 0.5.0
+combatActions: 0.5.0
+battleRewards: 0.5.0
+loot: 0.5.0
 shops/shopTransactions: 0.3.7
 pois/poiDiscovery/poiFastTravel: 0.3.4
 travel/gridMovement/aggro: 0.3.3
@@ -176,6 +183,7 @@ index.html
       -> loadActiveCharacter() or createInitialState()
       -> createSlashCommandRouter(state)
           -> createCommandRouter(state)
+      -> createTopBar(...)
       -> createSidebar(...)
       -> createTextShell(...)
 ```
@@ -185,8 +193,10 @@ Relevant UI files:
 ```text
 js/main.js
 js/text/slashCommandRouter.js
+js/text/topBar.js
 js/text/textShell.js
 js/text/sidebar.js
+js/text/uiPanels.js
 css/style.css
 ```
 
@@ -242,11 +252,12 @@ Implemented:
 
 Selling is intentionally not implemented yet.
 
-### Inventory, storage, wardrobes
+### Inventory, items, storage, wardrobes
 
 Files:
 
 ```text
+js/text/data/itemSchema.js
 js/text/data/inventoryContainers.js
 js/text/data/mogHouseFurniture.js
 js/text/systems/inventoryEngine.js
@@ -274,7 +285,9 @@ Rules:
 - Satchel/Sack/Case exist but are locked by default.
 - Wardrobe 1 is unlocked by default, equipment-only, accessible anywhere.
 - Wardrobes 2-8 exist but are locked by default.
-- Container transfers are atomic and enforce source access, destination access, capacity, and item-kind rules.
+- Item normalization adds kind, quantity, stackable, maxStack, tags, source, flags, modifiers, and equipmentSlot fields.
+- Stackable consumables/materials/misc items merge into existing stacks when possible.
+- Container transfers are atomic and enforce source access, destination access, capacity, item-kind, and stack rules.
 
 Temporary limitation: Mog House is currently a boolean access context, not a real zone/interior yet.
 
@@ -296,15 +309,18 @@ Implemented:
 - slot inference from `equipmentSlot` or tags
 - starter equipment modifiers affect combat profile
 
-Starter gear bonuses are conservative placeholders, not exact FFXI formulas.
+Starter gear bonuses are conservative placeholders, not exact FFXI formulas. Equipment validation by job/race/level is still pending.
 
-### Combat and actions
+### Combat, rewards, and actions
 
 Files:
 
 ```text
+js/text/data/lootTables.js
 js/text/systems/battleEngine.js
 js/text/systems/combatActionEngine.js
+js/text/systems/rewardEngine.js
+js/text/systems/rng.js
 js/text/systems/statusEngine.js
 js/text/systems/tickEngine.js
 ```
@@ -312,33 +328,37 @@ js/text/systems/tickEngine.js
 Implemented:
 
 - basic encounter/battle state
+- deterministic RNG injection for battle attacks and tests
 - basic attack flow
 - placeholder weapon skill/cast commands
+- starter loot tables
+- victory reward resolution for EXP, gil, loot rolls, Inventory insertion, and duplicate payout prevention
 - status lifecycle scaffold
 - tick engine scaffold
 
 Not implemented yet:
 
-- battle rewards
+- EXP tables and level-up rules
 - enemy AI turn depth
-- EXP/gil/loot roll handling
 - death/KO flow
 - real magic/recast/cast-time integration
 
-## Tests added during recent passes
-
-Important test files:
+## Important tests
 
 ```text
 tests/saveAccount.test.js
 tests/slashCommandRouter.test.js
 tests/equipmentEngine.test.js
 tests/inventoryEngine.test.js
+tests/itemSchema.test.js
+tests/rewardEngine.test.js
+tests/rngEngine.test.js
 tests/shopEngine.test.js
 tests/poiEngine.test.js
 tests/travelEngine.test.js
 tests/atlasAndControls.test.js
 tests/characterCreation.test.js
+tests/uiPanels.test.js
 ```
 
 New work should add tests in the same style using Node's built-in `node:test`.
@@ -352,6 +372,7 @@ README.md
 docs/ARCHITECTURE.md
 docs/ROADMAP.md
 docs/THREAD_HANDOFF.md
+CHANGELOG.md
 ```
 
 Still useful but may need future refresh as systems deepen:
@@ -360,27 +381,17 @@ Still useful but may need future refresh as systems deepen:
 docs/BASELINE_PIPELINE.md
 docs/SYSTEM_CATALOG.md
 docs/RESEARCH_REFERENCES.md
-CHANGELOG.md
 ```
 
 ## Current recommended next pass
 
-The user paused battle rewards and asked to make the UI usable. Continue UI hardening before returning to deeper combat systems.
+The next best implementation pass is progression:
 
-Recommended next pass:
-
-1. Add visible character-slot cards/buttons in the browser UI.
-2. Add a clearer main menu panel instead of relying only on terminal text.
-3. Add command chips/buttons for common slash commands.
-4. Improve save/load UI feedback.
-5. Add tests for any new UI command wrappers or save-slot helpers.
-
-After UI hardening, resume game-system work with:
-
-1. Battle rewards: EXP, gil, loot.
-2. Loot table schema and drop roll engine.
-3. Inventory insertion through existing container rules.
-4. Level-up rules and EXP-to-next handling.
+1. Add EXP table data and level-up rules.
+2. Update player/job progression containers when rewards grant EXP.
+3. Refresh HP/MP/resources and EXP-to-next after level-up.
+4. Add tests for no level-up, single level-up, multi-level-up, and level-cap behavior.
+5. Update README, THREAD_HANDOFF, CHANGELOG, version map, and benchmark coverage if progression logic becomes runtime-heavy.
 
 ## Rules for future agents
 


### PR DESCRIPTION
## Summary

- Update ROADMAP to mark UI hardening, item schema, item stacking, battle rewards, deterministic RNG, loot tables, drop rolls, and inventory reward insertion as implemented.
- Update README current version/state from stale Save/Data wording to explicit Account Save, Game State, and Data values.
- Update README architecture and implemented-foundation sections for item schema, loot tables, reward engine, deterministic RNG, and battle rewards.
- Refresh THREAD_HANDOFF with current system versions, browser entry path, item/stacking rules, reward systems, and the next recommended progression pass.
- Refresh CHANGELOG with post-0.5 foundation additions and the new recommended next pass.

## Testing

Docs-only change. Still recommended locally before the next implementation branch:

```bash
npm test
npm run benchmark
npm run check
```
