### PR TITLE
Overhaul character creation with guided canvas flow

### DIFF
--- a/js/text/data/characterCreationContent.js
+++ b/js/text/data/characterCreationContent.js
@@ -1,0 +1,85 @@
+import { getJob } from './jobs.js';
+import { getNation } from './nations.js';
+import { getPlace } from './places.js';
+import { RACES } from './races.js';
+
+const RACE_PRESENTATION = Object.freeze({
+    hume: presentation('Adaptable citizens found across the nations. Humes have no sharp weakness and are easy to build into any starting role.', ['Balanced', 'Flexible']),
+    elvaan: presentation('Tall, proud, and physically imposing. Elvaan favor direct martial roles and disciplined divine practice.', ['Strong', 'Stalwart']),
+    tarutaru: presentation('Small-bodied spellcasters with remarkable magical reserves. Tarutaru reward careful positioning and strong spell use.', ['Magical', 'Fragile']),
+    mithra: presentation('Quick, perceptive hunters with excellent agility and accuracy. Mithra naturally suit evasive and precise physical jobs.', ['Agile', 'Accurate']),
+    galka: presentation('Powerful, enduring laborers and warriors with exceptional toughness. Galka excel where durability matters most.', ['Durable', 'Physical']),
+});
+
+const NATION_PRESENTATION = Object.freeze({
+    sandoria: presentation('A fortified northern kingdom of knights, banners, and old vows. New adventurers begin inside Southern San d’Oria with Ronfaure beyond the gates.', ['Kingdom', 'Ronfaure']),
+    bastok: presentation('An industrial republic of markets, mines, engineers, and hard-earned ambition. New adventurers begin in Bastok Markets with Gustaberg outside the city.', ['Republic', 'Gustaberg']),
+    windurst: presentation('A magical federation of canals, towers, academies, and living tradition. New adventurers begin in Windurst Waters with Sarutabaruta nearby.', ['Federation', 'Sarutabaruta']),
+});
+
+const JOB_PRESENTATION = Object.freeze({
+    warrior: presentation('A weapon generalist trained to survive the front line and turn steady pressure into victory.', ['Frontline', 'Weaponry']),
+    monk: presentation('A hand-to-hand fighter with high endurance, counter pressure, and simple early momentum.', ['Brawler', 'High HP']),
+    whiteMage: presentation('A defensive support caster who keeps allies alive with healing and protection.', ['Healer', 'Support']),
+    blackMage: presentation('An elemental damage caster who trades fragility for direct magical force.', ['Caster', 'Damage']),
+    redMage: presentation('A hybrid spellblade using swordplay, support magic, and enfeebling tools.', ['Hybrid', 'Control']),
+    thief: presentation('An agile attacker built around evasion, accuracy, and opportunistic combat utility.', ['Agile', 'Utility']),
+});
+
+const SEX_LABELS = Object.freeze({
+    male: 'Male',
+    female: 'Female',
+});
+
+export function getRaceCreationPresentation(raceId) {
+    const race = RACES[raceId] ?? RACES.hume;
+    return { id: race.id, name: race.name, ...(RACE_PRESENTATION[race.id] ?? presentation(race.description, [])) };
+}
+
+export function getNationCreationPresentation(nationId) {
+    const nation = getNation(nationId);
+    const place = getPlace(nation.startingPlaceId);
+    return {
+        id: nation.id,
+        name: nation.name,
+        startingPlaceId: nation.startingPlaceId,
+        startingPlaceName: place?.name ?? nation.startingPlaceId,
+        starterRegion: place?.region ?? 'Unknown',
+        startingMapIds: [...nation.startingMapIds],
+        startingKeyItems: [...nation.startingKeyItems],
+        ...(NATION_PRESENTATION[nation.id] ?? presentation(nation.description, [])),
+    };
+}
+
+export function getJobCreationPresentation(jobId) {
+    const job = getJob(jobId);
+    return { id: job.id, name: job.name, abbreviation: job.abbreviation, role: job.role, ...(JOB_PRESENTATION[job.id] ?? presentation(job.role, [])) };
+}
+
+export function describeCreatorSex(sex) {
+    return SEX_LABELS[sex] ?? capitalize(sex);
+}
+
+export function composeStartingNarrative({ name = 'Adventurer', nationId = 'sandoria', mainJobId = 'warrior' } = {}) {
+    const nation = getNationCreationPresentation(nationId);
+    const job = getJobCreationPresentation(mainJobId);
+    const adventurerName = normalizeName(name) || 'Adventurer';
+    return [
+        `${adventurerName} steps into ${nation.startingPlaceName}, where the first work of an adventurer begins close to home.`,
+        `${nation.blurb}`,
+        `As a ${job.name}, your role is clear: ${job.role}. The gates to ${nation.starterRegion} are not far, and reputation starts with the first task you finish.`,
+    ];
+}
+
+function presentation(blurb, tags = []) {
+    return Object.freeze({ blurb, tags: Object.freeze([...tags]) });
+}
+
+function normalizeName(value) {
+    return String(value ?? '').trim().replace(/\s+/g, ' ');
+}
+
+function capitalize(value) {
+    const text = String(value ?? '');
+    return text ? `${text.slice(0, 1).toUpperCase()}${text.slice(1)}` : '';
+}

--- a/js/text/systems/characterCreationModel.js
+++ b/js/text/systems/characterCreationModel.js
@@ -1,0 +1,151 @@
+import { listJobs } from '../data/jobs.js';
+import { listNations } from '../data/nations.js';
+import { RACES } from '../data/races.js';
+import {
+    composeStartingNarrative,
+    describeCreatorSex,
+    getJobCreationPresentation,
+    getNationCreationPresentation,
+    getRaceCreationPresentation,
+} from '../data/characterCreationContent.js';
+
+const STARTING_JOB_IDS = Object.freeze(['warrior', 'monk', 'whiteMage', 'blackMage', 'redMage', 'thief']);
+export const CREATOR_STEPS = Object.freeze(['identity', 'nation', 'job', 'summary']);
+
+export function createGuidedCreatorState(options = {}) {
+    const raceId = RACES[options.raceId] ? options.raceId : 'hume';
+    const race = RACES[raceId];
+    const sex = race.allowedSexes.includes(options.sex) ? options.sex : race.allowedSexes[0];
+    return normalizeCreatorState({
+        stepIndex: clampStep(options.stepIndex ?? 0),
+        name: options.name ?? '',
+        raceId,
+        sex,
+        nationId: options.nationId ?? 'sandoria',
+        mainJobId: STARTING_JOB_IDS.includes(options.mainJobId) ? options.mainJobId : 'warrior',
+    });
+}
+
+export function normalizeCreatorState(creator = {}) {
+    const raceId = RACES[creator.raceId] ? creator.raceId : 'hume';
+    const race = RACES[raceId];
+    const sex = race.allowedSexes.includes(creator.sex) ? creator.sex : race.allowedSexes[0];
+    const nationId = getNationOptions().some((item) => item.id === creator.nationId) ? creator.nationId : 'sandoria';
+    const mainJobId = STARTING_JOB_IDS.includes(creator.mainJobId) ? creator.mainJobId : 'warrior';
+    return {
+        stepIndex: clampStep(creator.stepIndex ?? 0),
+        name: normalizeName(creator.name ?? ''),
+        raceId,
+        sex,
+        nationId,
+        mainJobId,
+    };
+}
+
+export function getCreatorStep(creator) {
+    return CREATOR_STEPS[normalizeCreatorState(creator).stepIndex] ?? 'identity';
+}
+
+export function getRaceOptions() {
+    return Object.values(RACES).map((race) => ({
+        ...getRaceCreationPresentation(race.id),
+        allowedSexes: [...race.allowedSexes],
+        sexLabel: race.allowedSexes.map(describeCreatorSex).join(' / '),
+    }));
+}
+
+export function getSexOptions(creator) {
+    const normalized = normalizeCreatorState(creator);
+    return RACES[normalized.raceId].allowedSexes.map((sex) => ({ id: sex, name: describeCreatorSex(sex) }));
+}
+
+export function getNationOptions() {
+    return listNations().map((nation) => getNationCreationPresentation(nation.id));
+}
+
+export function getStartingJobOptions() {
+    return listJobs().filter((job) => STARTING_JOB_IDS.includes(job.id)).map((job) => getJobCreationPresentation(job.id));
+}
+
+export function selectCreatorRace(creator, raceId) {
+    const nextRaceId = RACES[raceId] ? raceId : 'hume';
+    const race = RACES[nextRaceId];
+    return normalizeCreatorState({ ...creator, raceId: nextRaceId, sex: race.allowedSexes.includes(creator.sex) ? creator.sex : race.allowedSexes[0] });
+}
+
+export function selectCreatorSex(creator, sex) {
+    const normalized = normalizeCreatorState(creator);
+    const race = RACES[normalized.raceId];
+    return normalizeCreatorState({ ...normalized, sex: race.allowedSexes.includes(sex) ? sex : race.allowedSexes[0] });
+}
+
+export function selectCreatorNation(creator, nationId) {
+    return normalizeCreatorState({ ...creator, nationId });
+}
+
+export function selectCreatorJob(creator, mainJobId) {
+    return normalizeCreatorState({ ...creator, mainJobId });
+}
+
+export function setCreatorName(creator, name) {
+    return normalizeCreatorState({ ...creator, name: normalizeName(name).slice(0, 24) });
+}
+
+export function advanceCreatorStep(creator, delta) {
+    const normalized = normalizeCreatorState(creator);
+    return normalizeCreatorState({ ...normalized, stepIndex: clampStep(normalized.stepIndex + delta) });
+}
+
+export function getCreatorSummary(creator) {
+    const normalized = normalizeCreatorState(creator);
+    const race = getRaceCreationPresentation(normalized.raceId);
+    const nation = getNationCreationPresentation(normalized.nationId);
+    const job = getJobCreationPresentation(normalized.mainJobId);
+    return {
+        name: normalized.name || 'Adventurer',
+        race: race.name,
+        sex: describeCreatorSex(normalized.sex),
+        nation: nation.name,
+        startingCity: nation.startingPlaceName,
+        starterRegion: nation.starterRegion,
+        job: job.name,
+        jobAbbreviation: job.abbreviation,
+        startingMaps: nation.startingMapIds,
+        startingKeyItems: nation.startingKeyItems,
+    };
+}
+
+export function validateCreator(creator) {
+    const normalized = normalizeCreatorState(creator);
+    const issues = [];
+    if (!normalizeName(normalized.name)) issues.push('Name is required.');
+    if (normalizeName(normalized.name).length > 24) issues.push('Name must be 24 characters or fewer.');
+    if (!RACES[normalized.raceId].allowedSexes.includes(normalized.sex)) issues.push('Selected sex is not valid for the selected race.');
+    if (!STARTING_JOB_IDS.includes(normalized.mainJobId)) issues.push('Selected job is not a starting job.');
+    return issues;
+}
+
+export function createCreatorGameOptions(creator) {
+    const normalized = normalizeCreatorState(creator);
+    return {
+        name: normalizeName(normalized.name) || 'Adventurer',
+        raceId: normalized.raceId,
+        sex: normalized.sex,
+        nationId: normalized.nationId,
+        mainJobId: normalized.mainJobId,
+    };
+}
+
+export function describeCreatorOpening(creator) {
+    return composeStartingNarrative(createCreatorGameOptions(creator));
+}
+
+function normalizeName(value) {
+    return String(value ?? '').trim().replace(/\s+/g, ' ');
+}
+
+function clampStep(value) {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed)) return 0;
+    return Math.max(0, Math.min(CREATOR_STEPS.length - 1, parsed));
+}

--- a/js/text/ui/canvasApp.js
+++ b/js/text/ui/canvasApp.js
@@ -26,7 +26,7 @@ import {
 } from './canvasInput.js';
 import { renderCanvasApp } from './canvasRenderer.js';
 import { createCommandIntent, createCommandIntentAdapter } from './commandIntentAdapter.js';
-import { createActionList, createMenuActionList, TOP_ACTIONS } from './uiActions.js';
+import { createActionList, createCreatorActionList, createCreatorIntroActionList, createMenuActionList, TOP_ACTIONS } from './uiActions.js';
 import { dispatchUiIntent } from './uiIntentDispatcher.js';
 
 export function createCanvasApp({ canvas }) {
@@ -62,7 +62,7 @@ export function createCanvasApp({ canvas }) {
     }
 
     const commandAdapter = createCommandIntentAdapter(routeCommand);
-    const intentServices = { loadAccountSession: refreshSession, createAccountWithPassword, loginAccount, logoutAccount, updateAccountSettings, loadCharacter, replaceState, commandAdapter };
+    const intentServices = { loadAccountSession: refreshSession, createAccountWithPassword, loginAccount, logoutAccount, updateAccountSettings, loadCharacter, replaceState, saveGame, commandAdapter };
 
     function runCommand(command) {
         const { intent, payload } = createCommandIntent(command);
@@ -87,10 +87,12 @@ export function createCanvasApp({ canvas }) {
     }
 
     function dispatchCanvasAction(actionId) {
+        const creatorActions = uiState.screen === 'creator' ? createCreatorActionList(uiState) : uiState.screen === 'creatorIntro' ? createCreatorIntroActionList() : [];
         const allActions = [
             ...TOP_ACTIONS,
             ...(layout?.modalCloseButton ? [layout.modalCloseButton.action] : []),
             ...createMenuActionList(session, uiState.modal, uiState.modalPage),
+            ...creatorActions,
             ...createActionList(state),
         ];
         const action = allActions.find((item) => item.id === actionId);
@@ -129,9 +131,10 @@ export function createCanvasApp({ canvas }) {
 
     function render() {
         refreshSession();
-        const actions = createActionList(state);
+        const actions = uiState.screen === 'game' ? createActionList(state) : [];
         const menuActions = createMenuActionList(session, uiState.modal, uiState.modalPage);
-        layout = createCanvasLayout({ width: canvas.clientWidth || window.innerWidth, height: canvas.clientHeight || window.innerHeight, actions, menuActions, topActions: TOP_ACTIONS, modal: uiState.modal });
+        const creatorActions = uiState.screen === 'creator' ? createCreatorActionList(uiState) : uiState.screen === 'creatorIntro' ? createCreatorIntroActionList() : [];
+        layout = createCanvasLayout({ width: canvas.clientWidth || window.innerWidth, height: canvas.clientHeight || window.innerHeight, actions, menuActions, creatorActions, topActions: TOP_ACTIONS, modal: uiState.modal });
         renderCanvasApp(ctx, { layout, state, uiState, session });
     }
 
@@ -189,6 +192,7 @@ export function createCanvasApp({ canvas }) {
         if (result.type !== 'ignored') event.preventDefault();
         if (result.type === 'menu') dispatchAndRender('ui.menu.open');
         else if (result.type === 'modal') render();
+        else if (result.type === 'creator') dispatchAndRender(result.intent);
         else if (result.type === 'submit') submitFromInput(result.command);
         else render();
     });

--- a/js/text/ui/canvasInput.js
+++ b/js/text/ui/canvasInput.js
@@ -1,4 +1,5 @@
 import { hitTestAction, hitTestModalField, hitTestRegion } from './canvasLayout.js';
+import { createGuidedCreatorState, setCreatorName } from '../systems/characterCreationModel.js';
 
 export function createCanvasUiState(options = {}) {
     return {
@@ -9,6 +10,8 @@ export function createCanvasUiState(options = {}) {
         historyIndex: null,
         modalPage: options.modalPage ?? null,
         inputBuffer: options.inputBuffer ?? '',
+        creator: options.creator ?? null,
+        creatorIntro: options.creatorIntro ?? [],
         modalInputs: {
             accountName: options.modalInputs?.accountName ?? '',
             password: options.modalInputs?.password ?? '',
@@ -40,17 +43,18 @@ export function setActiveFeedback(uiState, text) {
 }
 
 export function setCanvasScreen(uiState, screen) {
-    uiState.screen = screen === 'game' ? 'game' : 'menu';
-    uiState.focusedRegion = 'input';
+    uiState.screen = ['game', 'creator', 'creatorIntro'].includes(screen) ? screen : 'menu';
+    uiState.focusedRegion = uiState.screen === 'creator' ? 'creatorName' : 'input';
     uiState.hoveredActionId = null;
     uiState.pressedActionId = null;
+    if (uiState.screen === 'creator') uiState.creator ??= createGuidedCreatorState();
     return uiState.screen;
 }
 
 export function setCanvasModal(uiState, modal, page = null) {
     uiState.modal = modal ?? null;
     uiState.modalPage = modal ? page : null;
-    uiState.focusedRegion = modal ? 'modal' : 'input';
+    uiState.focusedRegion = modal ? 'modal' : uiState.screen === 'creator' ? 'creatorName' : 'input';
     uiState.focusedModalField = defaultModalField(modal);
     if (!modal) clearModalInputs(uiState);
     uiState.hoveredActionId = null;
@@ -92,6 +96,7 @@ export function submitCommandInput(uiState, routeCommand) {
 export function applyCanvasKey(uiState, key, event = {}) {
     if (event.ctrlKey || event.metaKey || event.altKey) return { type: 'ignored' };
     if (uiState.modal && modalUsesFields(uiState.modal)) return applyModalKey(uiState, key);
+    if (uiState.screen === 'creator') return applyCreatorKey(uiState, key);
     switch (key) {
         case 'Enter': {
             const command = uiState.inputBuffer.trim();
@@ -164,6 +169,25 @@ export function handlePointerUp(uiState, layout, x, y) {
         return { type: 'action', actionId: hit.action.id, action: hit.action };
     }
     return { type: 'none' };
+}
+
+function applyCreatorKey(uiState, key) {
+    uiState.creator ??= createGuidedCreatorState();
+    switch (key) {
+        case 'Enter':
+            return { type: 'creator', intent: 'creator.next' };
+        case 'Backspace':
+            uiState.creator = setCreatorName(uiState.creator, String(uiState.creator.name ?? '').slice(0, -1));
+            return { type: 'edit' };
+        case 'Escape':
+            return { type: 'creator', intent: 'creator.cancel' };
+        default:
+            if (typeof key === 'string' && key.length === 1) {
+                uiState.creator = setCreatorName(uiState.creator, `${uiState.creator.name ?? ''}${key}`);
+                return { type: 'edit' };
+            }
+            return { type: 'ignored' };
+    }
 }
 
 function applyModalKey(uiState, key) {

--- a/js/text/ui/canvasInput.js
+++ b/js/text/ui/canvasInput.js
@@ -96,6 +96,10 @@ export function submitCommandInput(uiState, routeCommand) {
 export function applyCanvasKey(uiState, key, event = {}) {
     if (event.ctrlKey || event.metaKey || event.altKey) return { type: 'ignored' };
     if (uiState.modal && modalUsesFields(uiState.modal)) return applyModalKey(uiState, key);
+    if (uiState.modal && key === 'Escape') {
+        setCanvasModal(uiState, null);
+        return { type: 'modal' };
+    }
     if (uiState.screen === 'creator') return applyCreatorKey(uiState, key);
     switch (key) {
         case 'Enter': {

--- a/js/text/ui/canvasLayout.js
+++ b/js/text/ui/canvasLayout.js
@@ -1,4 +1,4 @@
-export function createCanvasLayout({ width, height, actions = [], menuActions = [], topActions = [], modal = null }) {
+export function createCanvasLayout({ width, height, actions = [], menuActions = [], topActions = [], modal = null, creatorActions = [] }) {
     const safeWidth = Math.max(320, Number(width) || 320);
     const safeHeight = Math.max(360, Number(height) || 360);
     const margin = 14;
@@ -20,6 +20,7 @@ export function createCanvasLayout({ width, height, actions = [], menuActions = 
     const main = rect(mainX, bodyTop, Math.max(120, mainRight - mainX), bodyHeight);
     const input = rect(margin, safeHeight - margin - inputHeight, safeWidth - margin * 2, inputHeight);
     const splash = rect(margin, margin, safeWidth - margin * 2, safeHeight - margin * 2);
+    const creatorName = rect(main.x + 18, Math.max(main.y + main.h - 104, main.y + 220), Math.min(360, main.w - 36), 38);
     const modalRect = createModalRect(safeWidth, safeHeight, margin, modal, menuActions.length);
 
     return {
@@ -36,8 +37,10 @@ export function createCanvasLayout({ width, height, actions = [], menuActions = 
             input,
             splash,
             modal: modalRect,
+            creatorName,
         },
         actionButtons: layoutActionButtons(sidebar, actions),
+        creatorButtons: layoutCreatorButtons(sidebar, main, input, creatorActions),
         menuButtons: layoutMenuButtons(splash, menuActions),
         modalButtons: layoutModalButtons(modalRect, menuActions, modal),
         modalCloseButton: layoutModalCloseButton(modalRect),
@@ -51,6 +54,7 @@ export function hitTestAction(layout, x, y) {
         ...layout.topButtons,
         ...(layout.modal ? [layout.modalCloseButton] : []),
         ...(layout.modal ? layout.modalButtons : []),
+        ...(!layout.modal ? layout.creatorButtons ?? [] : []),
         ...(!layout.modal ? layout.menuButtons : []),
         ...layout.actionButtons,
     ].filter(Boolean).find((button) => pointInRect(x, y, button.rect)) ?? null;
@@ -81,6 +85,69 @@ function layoutActionButtons(sidebar, actions) {
         action: item,
         rect: rect(sidebar.x + padding, startY + index * (buttonHeight + gap), sidebar.w - padding * 2, buttonHeight),
     }));
+}
+
+function layoutCreatorButtons(sidebar, main, input, actions) {
+    const stepActions = actions.filter((item) => item.region === 'steps');
+    const choiceActions = actions.filter((item) => item.region === 'choices');
+    const footerActions = actions.filter((item) => item.region === 'footer');
+    const introActions = actions.filter((item) => item.region === 'intro');
+    return [
+        ...layoutCreatorStepButtons(sidebar, stepActions),
+        ...layoutCreatorChoiceButtons(main, choiceActions),
+        ...layoutCreatorFooterButtons(input, footerActions),
+        ...layoutCreatorIntroButtons(main, introActions),
+    ];
+}
+
+function layoutCreatorStepButtons(sidebar, actions) {
+    const padding = 14;
+    const buttonHeight = 34;
+    const gap = 8;
+    const startY = sidebar.y + padding + 42;
+    return actions.map((item, index) => ({
+        action: item,
+        rect: rect(sidebar.x + padding, startY + index * (buttonHeight + gap), sidebar.w - padding * 2, buttonHeight),
+    }));
+}
+
+function layoutCreatorChoiceButtons(main, actions) {
+    if (!actions.length) return [];
+    const columns = main.w >= 620 ? 2 : 1;
+    const gap = 10;
+    const buttonHeight = 72;
+    const buttonWidth = Math.floor((main.w - 36 - gap * (columns - 1)) / columns);
+    const startX = main.x + 18;
+    const startY = main.y + 118;
+    return actions.map((item, index) => {
+        const column = index % columns;
+        const row = Math.floor(index / columns);
+        return {
+            action: item,
+            rect: rect(startX + column * (buttonWidth + gap), startY + row * (buttonHeight + gap), buttonWidth, buttonHeight),
+        };
+    });
+}
+
+function layoutCreatorFooterButtons(input, actions) {
+    if (!actions.length) return [];
+    const buttonHeight = 34;
+    const gap = 10;
+    const buttonWidth = Math.max(108, Math.min(154, Math.floor((input.w - 36 - gap * (actions.length - 1)) / actions.length)));
+    const totalWidth = actions.length * buttonWidth + (actions.length - 1) * gap;
+    const startX = input.x + input.w - totalWidth - 18;
+    const y = input.y + Math.floor((input.h - buttonHeight) / 2);
+    return actions.map((item, index) => ({ action: item, rect: rect(startX + index * (buttonWidth + gap), y, buttonWidth, buttonHeight) }));
+}
+
+function layoutCreatorIntroButtons(main, actions) {
+    if (!actions.length) return [];
+    const buttonWidth = Math.max(170, Math.min(240, Math.floor(main.w * 0.28)));
+    const buttonHeight = 38;
+    const gap = 12;
+    const startX = main.x + 24;
+    const y = main.y + main.h - 66;
+    return actions.map((item, index) => ({ action: item, rect: rect(startX + index * (buttonWidth + gap), y, buttonWidth, buttonHeight) }));
 }
 
 function layoutMenuButtons(splash, actions) {

--- a/js/text/ui/canvasRenderer.js
+++ b/js/text/ui/canvasRenderer.js
@@ -1,325 +1,146 @@
 import { calculateCombatProfile } from '../systems/statEngine.js';
+import { getCreatorStep, getCreatorSummary, validateCreator } from '../systems/characterCreationModel.js';
 import { CANVAS_THEME } from './uiTheme.js';
 
 export function createCanvasContextSnapshot(state) {
-    const player = state.player;
-    const combat = calculateCombatProfile(player);
-    return {
-        playerName: player.identity.name,
-        raceName: player.identity.raceName,
-        jobName: player.jobs.mainJobName,
-        level: player.jobs.level,
-        hp: player.resources.hp,
-        maxHp: combat.resources.maxHp,
-        mp: player.resources.mp,
-        maxMp: combat.resources.maxMp,
-        tp: player.resources.tp,
-        maxTp: combat.resources.maxTp,
-        location: state.location,
-        gridX: state.position?.x ?? '?',
-        gridY: state.position?.y ?? '?',
-    };
+  const player = state.player;
+  const combat = calculateCombatProfile(player);
+  return { playerName: player.identity.name, raceName: player.identity.raceName, jobName: player.jobs.mainJobName, level: player.jobs.level, hp: player.resources.hp, maxHp: combat.resources.maxHp, mp: player.resources.mp, maxMp: combat.resources.maxMp, tp: player.resources.tp, maxTp: combat.resources.maxTp, location: state.location, gridX: state.position?.x ?? '?', gridY: state.position?.y ?? '?' };
 }
 
 export function getVisibleLogLines(ctx, lines, rect, theme = CANVAS_THEME, scrollOffset = 0) {
-    const wrapped = [];
-    ctx.font = theme.font;
-    for (const line of lines) wrapped.push(...wrapText(ctx, line, rect.w));
-    const visibleCount = Math.max(1, Math.floor(rect.h / theme.lineHeight));
-    const maxOffset = Math.max(0, wrapped.length - visibleCount);
-    const offset = Math.max(0, Math.min(maxOffset, Number(scrollOffset) || 0));
-    const end = wrapped.length - offset;
-    return wrapped.slice(Math.max(0, end - visibleCount), end);
+  const wrapped = [];
+  ctx.font = theme.font;
+  for (const line of lines) wrapped.push(...wrapText(ctx, line, rect.w));
+  const visibleCount = Math.max(1, Math.floor(rect.h / theme.lineHeight));
+  const maxOffset = Math.max(0, wrapped.length - visibleCount);
+  const offset = Math.max(0, Math.min(maxOffset, Number(scrollOffset) || 0));
+  const end = wrapped.length - offset;
+  return wrapped.slice(Math.max(0, end - visibleCount), end);
 }
 
 export function renderCanvasApp(ctx, { layout, state, uiState, session = null, theme = CANVAS_THEME }) {
-    ctx.clearRect(0, 0, layout.width, layout.height);
-    drawBackground(ctx, layout, theme);
-    drawTopBar(ctx, layout, state, uiState, session, theme);
-    if (uiState.screen === 'menu') {
-        drawSplashMenu(ctx, layout, uiState, session, theme);
-        if (uiState.modal) drawModal(ctx, layout, uiState, theme);
-        return;
-    }
-    drawSidebar(ctx, layout, uiState, theme);
-    drawMainOutput(ctx, layout.panels.main, uiState, theme);
-    drawContext(ctx, layout.panels.context, state, uiState, theme);
-    drawInput(ctx, layout.panels.input, uiState, theme);
-    if (uiState.modal) drawModal(ctx, layout, uiState, theme);
+  ctx.clearRect(0, 0, layout.width, layout.height);
+  drawBackground(ctx, layout, theme);
+  drawTopBar(ctx, layout, state, uiState, session, theme);
+  if (uiState.screen === 'menu') { drawSplashMenu(ctx, layout, uiState, session, theme); if (uiState.modal) drawModal(ctx, layout, uiState, theme); return; }
+  if (uiState.screen === 'creator') { drawCreator(ctx, layout, uiState, theme); if (uiState.modal) drawModal(ctx, layout, uiState, theme); return; }
+  if (uiState.screen === 'creatorIntro') { drawCreatorIntro(ctx, layout, uiState, state, theme); if (uiState.modal) drawModal(ctx, layout, uiState, theme); return; }
+  drawSidebar(ctx, layout, uiState, theme);
+  drawMainOutput(ctx, layout.panels.main, uiState, theme);
+  drawContext(ctx, layout.panels.context, state, uiState, theme);
+  drawInput(ctx, layout.panels.input, uiState, theme);
+  if (uiState.modal) drawModal(ctx, layout, uiState, theme);
 }
 
 function drawSplashMenu(ctx, layout, uiState, session, theme) {
-    const topBottom = layout.panels.top.y + layout.panels.top.h;
-    const rect = { x: layout.panels.splash.x, y: topBottom + layout.gap, w: layout.panels.splash.w, h: Math.max(120, layout.panels.splash.h - topBottom - layout.gap) };
-    panel(ctx, rect, theme.panelDeep, theme.border);
-    const compact = layout.width < 700 || layout.height < 560;
-    const centerX = rect.x + rect.w / 2;
-    const titleY = rect.y + (compact ? 42 : 64);
-
-    ctx.font = compact ? theme.fontLarge : theme.fontTitle ?? '28px Consolas, monospace';
-    ctx.fillStyle = theme.accentBright;
-    ctx.textAlign = 'center';
-    ctx.fillText('FFXI Text RPG', centerX, titleY);
-
-    ctx.font = theme.font;
-    ctx.fillStyle = theme.muted;
-    const accounts = session?.accounts ?? [];
-    const subtitle = session?.loggedIn
-        ? `${session.displayName}${session.characterCount ? ` · ${session.characterCount} character${session.characterCount === 1 ? '' : 's'}` : ''}`
-        : accounts.length ? `${accounts.length} local account${accounts.length === 1 ? '' : 's'}` : '';
-    if (subtitle) ctx.fillText(subtitle, centerX, titleY + 26);
-
-    if (!uiState.modal) for (const button of layout.menuButtons) drawButton(ctx, button, uiState, theme);
-
-    const hintY = rect.y + rect.h - (compact ? 36 : 48);
-    if (uiState.inputBuffer && !uiState.modal) {
-        ctx.fillStyle = theme.text;
-        fitText(ctx, uiState.inputBuffer, rect.x + 24, hintY, rect.w - 48, 'center');
-    }
-    if (shouldShowFeedback(uiState.activeFeedback) && !uiState.modal) {
-        ctx.fillStyle = theme.accent;
-        fitText(ctx, uiState.activeFeedback, rect.x + 24, hintY + (uiState.inputBuffer ? 22 : 0), rect.w - 48, 'center');
-    }
-    ctx.textAlign = 'left';
+  const topBottom = layout.panels.top.y + layout.panels.top.h;
+  const rect = { x: layout.panels.splash.x, y: topBottom + layout.gap, w: layout.panels.splash.w, h: Math.max(120, layout.panels.splash.h - topBottom - layout.gap) };
+  panel(ctx, rect, theme.panelDeep, theme.border);
+  const centerX = rect.x + rect.w / 2;
+  ctx.font = layout.width < 700 ? theme.fontLarge : theme.fontTitle ?? '28px Consolas, monospace';
+  ctx.fillStyle = theme.accentBright;
+  ctx.textAlign = 'center';
+  ctx.fillText('FFXI Text RPG', centerX, rect.y + 64);
+  ctx.font = theme.font;
+  ctx.fillStyle = theme.muted;
+  const accounts = session?.accounts ?? [];
+  const subtitle = session?.loggedIn ? `${session.displayName}${session.characterCount ? ` · ${session.characterCount} character${session.characterCount === 1 ? '' : 's'}` : ''}` : accounts.length ? `${accounts.length} local account${accounts.length === 1 ? '' : 's'}` : '';
+  if (subtitle) ctx.fillText(subtitle, centerX, rect.y + 90);
+  if (!uiState.modal) for (const button of layout.menuButtons) drawButton(ctx, button, uiState, theme);
+  if (shouldShowFeedback(uiState.activeFeedback) && !uiState.modal) { ctx.fillStyle = theme.accent; fitText(ctx, uiState.activeFeedback, rect.x + 24, rect.y + rect.h - 48, rect.w - 48, 'center'); }
+  ctx.textAlign = 'left';
 }
 
 function drawModal(ctx, layout, uiState, theme) {
-    ctx.fillStyle = 'rgba(0, 0, 0, 0.48)';
-    ctx.fillRect(0, 0, layout.width, layout.height);
-    const rect = layout.panels.modal;
-    panel(ctx, rect, theme.panel, theme.accent);
-    drawCloseButton(ctx, layout.modalCloseButton, uiState, theme);
-    for (const field of layout.modalFields) drawModalField(ctx, field, uiState, theme);
-    for (const button of layout.modalButtons) drawButton(ctx, button, uiState, theme);
-    if (shouldShowFeedback(uiState.activeFeedback)) {
-        ctx.fillStyle = theme.accent;
-        fitText(ctx, uiState.activeFeedback, rect.x + 18, rect.y + rect.h - 8, rect.w - 36);
-    }
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.48)'; ctx.fillRect(0, 0, layout.width, layout.height);
+  const rect = layout.panels.modal; panel(ctx, rect, theme.panel, theme.accent); drawCloseButton(ctx, layout.modalCloseButton, uiState, theme);
+  for (const field of layout.modalFields) drawModalField(ctx, field, uiState, theme);
+  for (const button of layout.modalButtons) drawButton(ctx, button, uiState, theme);
+  if (shouldShowFeedback(uiState.activeFeedback)) { ctx.fillStyle = theme.accent; fitText(ctx, uiState.activeFeedback, rect.x + 18, rect.y + rect.h - 8, rect.w - 36); }
 }
 
 function drawCloseButton(ctx, button, uiState, theme) {
-    const { rect } = button;
-    const hovered = uiState.hoveredActionId === button.action.id;
-    const pressed = uiState.pressedActionId === button.action.id;
-    ctx.fillStyle = pressed ? theme.pressed : hovered ? theme.hover : theme.panel;
-    ctx.strokeStyle = hovered ? theme.accentBright : theme.border;
-    ctx.lineWidth = hovered ? 2 : 1;
-    roundedRect(ctx, rect.x, rect.y, rect.w, rect.h, 5);
-    ctx.fill();
-    ctx.stroke();
-    ctx.font = '18px Consolas, monospace';
-    ctx.fillStyle = theme.text;
-    ctx.textAlign = 'center';
-    ctx.fillText('×', rect.x + rect.w / 2, rect.y + 17);
-    ctx.textAlign = 'left';
+  const { rect } = button; const hovered = uiState.hoveredActionId === button.action.id; const pressed = uiState.pressedActionId === button.action.id;
+  ctx.fillStyle = pressed ? theme.pressed : hovered ? theme.hover : theme.panel; ctx.strokeStyle = hovered ? theme.accentBright : theme.border; ctx.lineWidth = hovered ? 2 : 1; roundedRect(ctx, rect.x, rect.y, rect.w, rect.h, 5); ctx.fill(); ctx.stroke();
+  ctx.font = '18px Consolas, monospace'; ctx.fillStyle = theme.text; ctx.textAlign = 'center'; ctx.fillText('×', rect.x + rect.w / 2, rect.y + 17); ctx.textAlign = 'left';
 }
 
 function drawModalField(ctx, field, uiState, theme) {
-    const focused = uiState.focusedModalField === field.id;
-    const value = modalFieldDisplayValue(field.id, uiState.modalInputs?.[field.id] ?? '');
-    ctx.font = theme.font;
-    ctx.fillStyle = focused ? theme.accentBright : theme.muted;
-    fitText(ctx, field.label, field.rect.x, field.rect.y - 7, field.rect.w);
-    ctx.fillStyle = theme.panelDeep;
-    ctx.strokeStyle = focused ? theme.accentBright : theme.border;
-    ctx.lineWidth = focused ? 2 : 1;
-    roundedRect(ctx, field.rect.x, field.rect.y, field.rect.w, field.rect.h, 6);
-    ctx.fill();
-    ctx.stroke();
-    ctx.fillStyle = value ? theme.text : theme.muted;
-    fitText(ctx, `${value}_`, field.rect.x + 12, field.rect.y + 23, field.rect.w - 24);
+  const focused = uiState.focusedModalField === field.id; const raw = String(uiState.modalInputs?.[field.id] ?? ''); const value = field.id === 'password' && raw ? '•'.repeat(raw.length) : raw;
+  ctx.font = theme.font; ctx.fillStyle = focused ? theme.accentBright : theme.muted; fitText(ctx, field.label, field.rect.x, field.rect.y - 7, field.rect.w);
+  ctx.fillStyle = theme.panelDeep; ctx.strokeStyle = focused ? theme.accentBright : theme.border; ctx.lineWidth = focused ? 2 : 1; roundedRect(ctx, field.rect.x, field.rect.y, field.rect.w, field.rect.h, 6); ctx.fill(); ctx.stroke();
+  ctx.fillStyle = value ? theme.text : theme.muted; fitText(ctx, `${value}_`, field.rect.x + 12, field.rect.y + 23, field.rect.w - 24);
 }
 
-function modalFieldDisplayValue(fieldId, value) {
-    if (fieldId !== 'password') return String(value ?? '');
-    return value ? '•'.repeat(String(value).length) : '';
-}
-
-function drawBackground(ctx, layout, theme) {
-    ctx.fillStyle = theme.background;
-    ctx.fillRect(0, 0, layout.width, layout.height);
-}
+function drawBackground(ctx, layout, theme) { ctx.fillStyle = theme.background; ctx.fillRect(0, 0, layout.width, layout.height); }
 
 function drawTopBar(ctx, layout, state, uiState, session, theme) {
-    const rect = layout.panels.top;
-    const snapshot = createCanvasContextSnapshot(state);
-    panel(ctx, rect, theme.panelSoft, theme.border);
-    ctx.font = theme.font;
-    ctx.fillStyle = theme.muted;
-    const account = session?.loggedIn ? session.displayName : '';
-    const status = uiState.screen === 'menu' ? account : `${snapshot.playerName} | ${snapshot.jobName} Lv.${snapshot.level} | ${snapshot.location} ${snapshot.gridX}:${snapshot.gridY}${account ? ` | ${account}` : ''}`;
-    if (status) fitText(ctx, status, rect.x + 58, rect.y + 24, rect.w - 210);
-    if (shouldShowFeedback(uiState.activeFeedback) && uiState.screen !== 'menu') {
-        ctx.fillStyle = theme.accent;
-        fitText(ctx, uiState.activeFeedback, rect.x + 58, rect.y + 42, rect.w - 210);
-    }
-    drawClock(ctx, rect, session, theme);
-    for (const button of layout.topButtons) drawButton(ctx, button, uiState, theme);
+  const rect = layout.panels.top; const snapshot = createCanvasContextSnapshot(state); panel(ctx, rect, theme.panelSoft, theme.border); ctx.font = theme.font; ctx.fillStyle = theme.muted;
+  const account = session?.loggedIn ? session.displayName : '';
+  const status = uiState.screen === 'menu' ? account : uiState.screen === 'creator' ? `Create Adventurer${account ? ` | ${account}` : ''}` : uiState.screen === 'creatorIntro' ? `${snapshot.playerName} begins${account ? ` | ${account}` : ''}` : `${snapshot.playerName} | ${snapshot.jobName} Lv.${snapshot.level} | ${snapshot.location} ${snapshot.gridX}:${snapshot.gridY}${account ? ` | ${account}` : ''}`;
+  if (status) fitText(ctx, status, rect.x + 58, rect.y + 24, rect.w - 210);
+  if (shouldShowFeedback(uiState.activeFeedback) && uiState.screen !== 'menu') { ctx.fillStyle = theme.accent; fitText(ctx, uiState.activeFeedback, rect.x + 58, rect.y + 42, rect.w - 210); }
+  drawClock(ctx, rect, session, theme); for (const button of layout.topButtons) drawButton(ctx, button, uiState, theme);
 }
 
 function drawClock(ctx, rect, session, theme) {
-    const settings = session?.settings ?? {};
-    if (!session?.loggedIn || settings.showClock === false) return;
-    const now = new Date();
-    const timeZone = settings.timeZone && settings.timeZone !== 'local' ? settings.timeZone : undefined;
-    const clock = new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit', hour12: settings.clockFormat !== '24h', timeZone }).format(now);
-    ctx.font = theme.font;
-    ctx.fillStyle = theme.accentBright;
-    fitText(ctx, clock, rect.x + rect.w - 120, rect.y + 32, 104, 'right');
+  const settings = session?.settings ?? {}; if (!session?.loggedIn || settings.showClock === false) return;
+  const clock = new Intl.DateTimeFormat(undefined, { hour: 'numeric', minute: '2-digit', hour12: settings.clockFormat !== '24h' }).format(new Date());
+  ctx.font = theme.font; ctx.fillStyle = theme.accentBright; fitText(ctx, clock, rect.x + rect.w - 120, rect.y + 32, 104, 'right');
 }
 
-function drawSidebar(ctx, layout, uiState, theme) {
-    const rect = layout.panels.sidebar;
-    panel(ctx, rect, theme.panel, theme.border);
-    ctx.font = theme.fontLarge;
-    ctx.fillStyle = theme.accent;
-    ctx.fillText('Actions', rect.x + 14, rect.y + 26);
-    for (const button of layout.actionButtons) drawButton(ctx, button, uiState, theme);
+function drawCreator(ctx, layout, uiState, theme) {
+  const sidebar = layout.panels.sidebar, main = layout.panels.main, input = layout.panels.input;
+  panel(ctx, sidebar, theme.panel, theme.border); panel(ctx, main, theme.panelDeep, theme.border); panel(ctx, input, theme.panelSoft, theme.border);
+  ctx.font = theme.fontLarge; ctx.fillStyle = theme.accent; ctx.fillText('Creation', sidebar.x + 14, sidebar.y + 26);
+  const step = getCreatorStep(uiState.creator); ctx.font = theme.fontLarge; ctx.fillStyle = theme.accentBright; fitText(ctx, creatorTitle(step), main.x + 18, main.y + 30, main.w - 36);
+  ctx.font = theme.font; ctx.fillStyle = theme.muted; drawParagraph(ctx, creatorHelp(step), main.x + 18, main.y + 56, main.w - 36, theme);
+  for (const button of layout.creatorButtons) drawButton(ctx, button, uiState, theme);
+  if (step === 'summary') drawCreatorSummary(ctx, layout, uiState, theme);
+  ctx.font = theme.font; ctx.fillStyle = theme.muted; fitText(ctx, step === 'summary' ? 'Enter your name, review, then create.' : 'Choose an option, then continue.', input.x + 18, input.y + 36, Math.max(80, input.w - 520));
 }
+
+function drawCreatorSummary(ctx, layout, uiState, theme) {
+  const summary = getCreatorSummary(uiState.creator); const main = layout.panels.main; const nameRect = layout.panels.creatorName;
+  drawLines(ctx, main.x + 18, main.y + 118, main.w - 36, [`Race: ${summary.race} (${summary.sex})`, `Job: ${summary.job} (${summary.jobAbbreviation})`, `Nation: ${summary.nation}`, `Starting City: ${summary.startingCity}`, `Starter Region: ${summary.starterRegion}`, `Maps: ${summary.startingMaps.join(', ')}`, `Key Items: ${summary.startingKeyItems.join(', ')}`], theme);
+  ctx.font = theme.font; ctx.fillStyle = theme.accent; ctx.fillText('Name', nameRect.x, nameRect.y - 7);
+  const focused = uiState.focusedRegion === 'creatorName'; ctx.fillStyle = focused ? theme.panelSoft : theme.panelDeep; ctx.strokeStyle = focused ? theme.accentBright : theme.border; ctx.lineWidth = focused ? 2 : 1; roundedRect(ctx, nameRect.x, nameRect.y, nameRect.w, nameRect.h, 6); ctx.fill(); ctx.stroke();
+  ctx.fillStyle = uiState.creator.name ? theme.text : theme.muted; fitText(ctx, `${uiState.creator.name || 'Type a name'}${focused ? '_' : ''}`, nameRect.x + 12, nameRect.y + 24, nameRect.w - 24);
+  const issues = validateCreator(uiState.creator); if (issues.length) { ctx.fillStyle = theme.accent; fitText(ctx, issues[0], nameRect.x, nameRect.y + nameRect.h + 20, main.w - 36); }
+}
+
+function drawCreatorIntro(ctx, layout, uiState, state, theme) {
+  const main = layout.panels.main; panel(ctx, main, theme.panelDeep, theme.border);
+  ctx.font = theme.fontTitle ?? '28px Consolas, monospace'; ctx.fillStyle = theme.accentBright; fitText(ctx, state.player.identity.name, main.x + 24, main.y + 48, main.w - 48);
+  ctx.font = theme.fontLarge; ctx.fillStyle = theme.accent; fitText(ctx, `${state.player.identity.raceName} ${state.player.jobs.mainJobName} of ${state.player.identity.nation}`, main.x + 24, main.y + 80, main.w - 48);
+  ctx.font = theme.font; ctx.fillStyle = theme.text; let y = main.y + 126; for (const paragraph of uiState.creatorIntro ?? []) y = drawParagraph(ctx, paragraph, main.x + 24, y + 2, main.w - 48, theme) + theme.lineHeight;
+  for (const button of layout.creatorButtons) drawButton(ctx, button, uiState, theme);
+}
+
+function creatorTitle(step) { return step === 'identity' ? 'Choose Race and Sex' : step === 'nation' ? 'Choose Starting City' : step === 'job' ? 'Choose Starting Job' : 'Review Adventurer'; }
+function creatorHelp(step) { return step === 'identity' ? 'Race changes allowed sex options. Appearance stays out of scope for this first pass.' : step === 'nation' ? 'Your city determines starting location, first region, maps, and early flavor.' : step === 'job' ? 'Only the six default starting jobs are shown. Advanced jobs remain progression unlocks.' : 'Name the character and confirm the final setup.'; }
+
+function drawSidebar(ctx, layout, uiState, theme) { const rect = layout.panels.sidebar; panel(ctx, rect, theme.panel, theme.border); ctx.font = theme.fontLarge; ctx.fillStyle = theme.accent; ctx.fillText('Actions', rect.x + 14, rect.y + 26); for (const button of layout.actionButtons) drawButton(ctx, button, uiState, theme); }
 
 function drawButton(ctx, button, uiState, theme) {
-    const { action, rect } = button;
-    const hovered = uiState.hoveredActionId === action.id;
-    const pressed = uiState.pressedActionId === action.id;
-    ctx.fillStyle = action.disabled ? theme.panelDeep : pressed ? theme.pressed : hovered ? theme.hover : theme.panelSoft;
-    ctx.strokeStyle = action.disabled ? theme.border : hovered ? theme.accent : theme.border;
-    ctx.lineWidth = hovered ? 2 : 1;
-    roundedRect(ctx, rect.x, rect.y, rect.w, rect.h, 6);
-    ctx.fill();
-    ctx.stroke();
-    if (action.id === 'menu') {
-        drawHamburgerIcon(ctx, rect, action.disabled ? theme.disabled : theme.text);
-        return;
-    }
-    ctx.font = theme.font;
-    ctx.fillStyle = action.disabled ? theme.disabled : theme.text;
-    fitText(ctx, action.label, rect.x + 12, rect.y + 22, rect.w - 24);
+  const { action, rect } = button; const hovered = uiState.hoveredActionId === action.id; const pressed = uiState.pressedActionId === action.id; const selected = Boolean(action.selected);
+  ctx.fillStyle = action.disabled ? theme.panelDeep : pressed ? theme.pressed : hovered ? theme.hover : selected ? theme.hover : theme.panelSoft; ctx.strokeStyle = action.disabled ? theme.border : selected ? theme.accentBright : hovered ? theme.accent : theme.border; ctx.lineWidth = hovered || selected ? 2 : 1; roundedRect(ctx, rect.x, rect.y, rect.w, rect.h, 6); ctx.fill(); ctx.stroke();
+  if (action.id === 'menu') { drawHamburgerIcon(ctx, rect, action.disabled ? theme.disabled : theme.text); return; }
+  ctx.font = theme.font; ctx.fillStyle = action.disabled ? theme.disabled : selected ? theme.accentBright : theme.text; fitText(ctx, action.label, rect.x + 12, rect.y + 22, rect.w - 24);
+  if (action.detail && rect.h > 50) { ctx.font = '12px Consolas, monospace'; ctx.fillStyle = action.disabled ? theme.disabled : theme.muted; fitText(ctx, action.detail, rect.x + 12, rect.y + 42, rect.w - 24); }
 }
 
-function drawHamburgerIcon(ctx, rect, color) {
-    const lineWidth = Math.max(14, Math.floor(rect.w * 0.48));
-    const startX = rect.x + Math.floor((rect.w - lineWidth) / 2);
-    const centerY = rect.y + Math.floor(rect.h / 2);
-    ctx.strokeStyle = color;
-    ctx.lineWidth = 2;
-    ctx.lineCap = 'round';
-    for (const offset of [-7, 0, 7]) {
-        ctx.beginPath();
-        ctx.moveTo(startX, centerY + offset);
-        ctx.lineTo(startX + lineWidth, centerY + offset);
-        ctx.stroke();
-    }
-    ctx.lineCap = 'butt';
-}
+function drawHamburgerIcon(ctx, rect, color) { const lineWidth = Math.max(14, Math.floor(rect.w * 0.48)); const startX = rect.x + Math.floor((rect.w - lineWidth) / 2); const centerY = rect.y + Math.floor(rect.h / 2); ctx.strokeStyle = color; ctx.lineWidth = 2; ctx.lineCap = 'round'; for (const offset of [-7, 0, 7]) { ctx.beginPath(); ctx.moveTo(startX, centerY + offset); ctx.lineTo(startX + lineWidth, centerY + offset); ctx.stroke(); } ctx.lineCap = 'butt'; }
 
-function drawMainOutput(ctx, rect, uiState, theme) {
-    const isHovered = uiState.hoveredRegion === 'main';
-    panel(ctx, rect, theme.panelDeep, isHovered ? theme.accent : theme.border);
-    ctx.font = theme.font;
-    ctx.fillStyle = theme.accent;
-    ctx.fillText('Output Log', rect.x + 14, rect.y + 26);
-    if (uiState.outputScrollOffset > 0) {
-        ctx.fillStyle = theme.muted;
-        fitText(ctx, `Scrolled +${uiState.outputScrollOffset} lines`, rect.x + 110, rect.y + 26, rect.w - 124);
-    }
-    const inner = { x: rect.x + 14, y: rect.y + 44, w: rect.w - 28, h: rect.h - 58 };
-    drawWrappedLog(ctx, inner, uiState.outputLines, theme, uiState.outputScrollOffset);
-}
-
-function drawContext(ctx, rect, state, uiState, theme) {
-    if (!rect.w || !rect.h) return;
-    panel(ctx, rect, theme.panel, theme.border);
-    const snapshot = createCanvasContextSnapshot(state);
-    const lines = ['Context', '', `${snapshot.playerName}`, `${snapshot.raceName} ${snapshot.jobName} Lv.${snapshot.level}`, `HP ${snapshot.hp}/${snapshot.maxHp}`, `MP ${snapshot.mp}/${snapshot.maxMp}`, `TP ${snapshot.tp}/${snapshot.maxTp}`, '', `Location: ${snapshot.location}`, `Grid: ${snapshot.gridX}:${snapshot.gridY}`, '', 'History', ...uiState.commandHistory.slice(-7).map((command) => `> ${command}`)];
-    drawLines(ctx, rect.x + 14, rect.y + 26, rect.w - 28, lines, theme);
-}
-
-function drawInput(ctx, rect, uiState, theme) {
-    const focused = uiState.focusedRegion === 'input';
-    const hovered = uiState.hoveredRegion === 'input';
-    const pressed = uiState.pressedRegion === 'input';
-    const border = focused ? theme.accentBright : hovered ? theme.accent : theme.border;
-    const fill = pressed ? theme.pressed : focused ? theme.panelSoft : theme.panelDeep;
-    panel(ctx, rect, fill, border);
-    ctx.font = theme.font;
-    ctx.fillStyle = focused ? theme.accentBright : theme.accent;
-    ctx.fillText('>', rect.x + 16, rect.y + 36);
-    ctx.fillStyle = theme.text;
-    const cursor = focused ? '_' : '';
-    fitText(ctx, `${uiState.inputBuffer}${cursor}`, rect.x + 40, rect.y + 36, rect.w - 56);
-}
-
-function drawWrappedLog(ctx, rect, lines, theme, scrollOffset = 0) {
-    const visible = getVisibleLogLines(ctx, lines, rect, theme, scrollOffset);
-    ctx.fillStyle = theme.text;
-    visible.forEach((line, index) => ctx.fillText(line, rect.x, rect.y + theme.lineHeight * (index + 1)));
-}
-
-function drawLines(ctx, x, y, maxWidth, lines, theme) {
-    ctx.font = theme.font;
-    let offset = 0;
-    for (const line of lines) {
-        ctx.fillStyle = line === 'Context' || line === 'History' ? theme.accent : theme.text;
-        fitText(ctx, line, x, y + offset, maxWidth);
-        offset += theme.lineHeight;
-    }
-}
-
-function wrapText(ctx, text, maxWidth) {
-    if (!text) return [''];
-    const words = String(text).split(/\s+/);
-    const lines = [];
-    let current = '';
-    for (const word of words) {
-        const candidate = current ? `${current} ${word}` : word;
-        if (ctx.measureText(candidate).width <= maxWidth || !current) current = candidate;
-        else { lines.push(current); current = word; }
-    }
-    lines.push(current);
-    return lines;
-}
-
-function panel(ctx, rect, fillStyle, strokeStyle) {
-    ctx.fillStyle = fillStyle;
-    ctx.strokeStyle = strokeStyle;
-    ctx.lineWidth = 1;
-    roundedRect(ctx, rect.x, rect.y, rect.w, rect.h, 8);
-    ctx.fill();
-    ctx.stroke();
-}
-
-function fitText(ctx, text, x, y, maxWidth, align = 'left') {
-    const previousAlign = ctx.textAlign;
-    ctx.textAlign = align;
-    const value = String(text ?? '');
-    const drawX = align === 'center' ? x + maxWidth / 2 : align === 'right' ? x + maxWidth : x;
-    if (ctx.measureText(value).width <= maxWidth) {
-        ctx.fillText(value, drawX, y);
-        ctx.textAlign = previousAlign;
-        return;
-    }
-    let trimmed = value;
-    while (trimmed.length > 1 && ctx.measureText(`${trimmed}...`).width > maxWidth) trimmed = trimmed.slice(0, -1);
-    ctx.fillText(`${trimmed}...`, drawX, y);
-    ctx.textAlign = previousAlign;
-}
-
-function shouldShowFeedback(feedback) {
-    const value = String(feedback ?? '').trim();
-    return Boolean(value && value !== 'Main menu opened.');
-}
-
-function roundedRect(ctx, x, y, width, height, radius) {
-    const r = Math.min(radius, width / 2, height / 2);
-    ctx.beginPath();
-    ctx.moveTo(x + r, y);
-    ctx.lineTo(x + width - r, y);
-    ctx.quadraticCurveTo(x + width, y, x + width, y + r);
-    ctx.lineTo(x + width, y + height - r);
-    ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
-    ctx.lineTo(x + r, y + height);
-    ctx.quadraticCurveTo(x, y + height, x, y + height - r);
-    ctx.lineTo(x, y + r);
-    ctx.quadraticCurveTo(x, y, x + r, y);
-    ctx.closePath();
-}
+function drawMainOutput(ctx, rect, uiState, theme) { const isHovered = uiState.hoveredRegion === 'main'; panel(ctx, rect, theme.panelDeep, isHovered ? theme.accent : theme.border); ctx.font = theme.font; ctx.fillStyle = theme.accent; ctx.fillText('Output Log', rect.x + 14, rect.y + 26); const inner = { x: rect.x + 14, y: rect.y + 44, w: rect.w - 28, h: rect.h - 58 }; drawWrappedLog(ctx, inner, uiState.outputLines, theme, uiState.outputScrollOffset); }
+function drawContext(ctx, rect, state, uiState, theme) { if (!rect.w || !rect.h) return; panel(ctx, rect, theme.panel, theme.border); const s = createCanvasContextSnapshot(state); drawLines(ctx, rect.x + 14, rect.y + 26, rect.w - 28, ['Context', '', s.playerName, `${s.raceName} ${s.jobName} Lv.${s.level}`, `HP ${s.hp}/${s.maxHp}`, `MP ${s.mp}/${s.maxMp}`, `TP ${s.tp}/${s.maxTp}`, '', `Location: ${s.location}`, `Grid: ${s.gridX}:${s.gridY}`, '', 'History', ...uiState.commandHistory.slice(-7).map((command) => `> ${command}`)], theme); }
+function drawInput(ctx, rect, uiState, theme) { const focused = uiState.focusedRegion === 'input'; const border = focused ? theme.accentBright : uiState.hoveredRegion === 'input' ? theme.accent : theme.border; panel(ctx, rect, focused ? theme.panelSoft : theme.panelDeep, border); ctx.font = theme.font; ctx.fillStyle = focused ? theme.accentBright : theme.accent; ctx.fillText('>', rect.x + 16, rect.y + 36); ctx.fillStyle = theme.text; fitText(ctx, `${uiState.inputBuffer}${focused ? '_' : ''}`, rect.x + 40, rect.y + 36, rect.w - 56); }
+function drawWrappedLog(ctx, rect, lines, theme, scrollOffset = 0) { const visible = getVisibleLogLines(ctx, lines, rect, theme, scrollOffset); ctx.fillStyle = theme.text; visible.forEach((line, index) => ctx.fillText(line, rect.x, rect.y + theme.lineHeight * (index + 1))); }
+function drawLines(ctx, x, y, maxWidth, lines, theme) { ctx.font = theme.font; let offset = 0; for (const line of lines) { ctx.fillStyle = line === 'Context' || line === 'History' ? theme.accent : theme.text; fitText(ctx, line, x, y + offset, maxWidth); offset += theme.lineHeight; } }
+function drawParagraph(ctx, text, x, y, maxWidth, theme) { ctx.font = theme.font; const lines = wrapText(ctx, text, maxWidth); lines.forEach((line, index) => ctx.fillText(line, x, y + theme.lineHeight * index)); return y + theme.lineHeight * lines.length; }
+function wrapText(ctx, text, maxWidth) { if (!text) return ['']; const words = String(text).split(/\s+/); const lines = []; let current = ''; for (const word of words) { const candidate = current ? `${current} ${word}` : word; if (ctx.measureText(candidate).width <= maxWidth || !current) current = candidate; else { lines.push(current); current = word; } } lines.push(current); return lines; }
+function panel(ctx, rect, fillStyle, strokeStyle) { ctx.fillStyle = fillStyle; ctx.strokeStyle = strokeStyle; ctx.lineWidth = 1; roundedRect(ctx, rect.x, rect.y, rect.w, rect.h, 8); ctx.fill(); ctx.stroke(); }
+function fitText(ctx, text, x, y, maxWidth, align = 'left') { const previousAlign = ctx.textAlign; ctx.textAlign = align; const value = String(text ?? ''); const drawX = align === 'center' ? x + maxWidth / 2 : align === 'right' ? x + maxWidth : x; if (ctx.measureText(value).width <= maxWidth) { ctx.fillText(value, drawX, y); ctx.textAlign = previousAlign; return; } let trimmed = value; while (trimmed.length > 1 && ctx.measureText(`${trimmed}...`).width > maxWidth) trimmed = trimmed.slice(0, -1); ctx.fillText(`${trimmed}...`, drawX, y); ctx.textAlign = previousAlign; }
+function shouldShowFeedback(feedback) { const value = String(feedback ?? '').trim(); return Boolean(value && value !== 'Main menu opened.'); }
+function roundedRect(ctx, x, y, width, height, radius) { const r = Math.min(radius, width / 2, height / 2); ctx.beginPath(); ctx.moveTo(x + r, y); ctx.lineTo(x + width - r, y); ctx.quadraticCurveTo(x + width, y, x + width, y + r); ctx.lineTo(x + width, y + height - r); ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height); ctx.lineTo(x + r, y + height); ctx.quadraticCurveTo(x, y + height, x, y + height - r); ctx.lineTo(x, y + r); ctx.quadraticCurveTo(x, y, x + r, y); ctx.closePath(); }

--- a/js/text/ui/uiActions.js
+++ b/js/text/ui/uiActions.js
@@ -1,6 +1,7 @@
 import { isCommandIntent } from './uiIntentDispatcher.js';
 import {
     CREATOR_STEPS,
+    createGuidedCreatorState,
     getCreatorStep,
     getNationOptions,
     getRaceOptions,
@@ -34,10 +35,10 @@ export function createActionList(state, actions = GLOBAL_ACTIONS) {
 }
 
 export function createCreatorActionList(uiState) {
-    const creator = uiState.creator;
+    const creator = uiState.creator ?? createGuidedCreatorState();
     const step = getCreatorStep(creator);
     const issues = validateCreator(creator);
-    const actions = [
+    return [
         ...CREATOR_STEPS.map((item, index) => uiAction(`creatorStep:${item}`, stepLabel(item), 'creator.goto', { stepIndex: index }, { region: 'steps', selected: item === step })),
         ...choiceActionsForStep(step, creator),
         uiAction('creatorCancel', 'Cancel', 'creator.cancel', {}, { region: 'footer' }),
@@ -47,7 +48,6 @@ export function createCreatorActionList(uiState) {
             ? uiAction('creatorCreate', 'Create', 'creator.confirm', {}, { region: 'footer', disabled: issues.length > 0 })
             : uiAction('creatorNext', 'Next', 'creator.next', {}, { region: 'footer' }),
     ];
-    return actions;
 }
 
 export function createCreatorIntroActionList() {

--- a/js/text/ui/uiActions.js
+++ b/js/text/ui/uiActions.js
@@ -1,4 +1,13 @@
 import { isCommandIntent } from './uiIntentDispatcher.js';
+import {
+    CREATOR_STEPS,
+    getCreatorStep,
+    getNationOptions,
+    getRaceOptions,
+    getSexOptions,
+    getStartingJobOptions,
+    validateCreator,
+} from '../systems/characterCreationModel.js';
 
 export const GLOBAL_ACTIONS = Object.freeze([
     commandAction('character', 'Character', 'character'),
@@ -24,6 +33,30 @@ export function createActionList(state, actions = GLOBAL_ACTIONS) {
     return actions.map((item) => ({ ...item, disabled: isActionDisabled(item, state) }));
 }
 
+export function createCreatorActionList(uiState) {
+    const creator = uiState.creator;
+    const step = getCreatorStep(creator);
+    const issues = validateCreator(creator);
+    const actions = [
+        ...CREATOR_STEPS.map((item, index) => uiAction(`creatorStep:${item}`, stepLabel(item), 'creator.goto', { stepIndex: index }, { region: 'steps', selected: item === step })),
+        ...choiceActionsForStep(step, creator),
+        uiAction('creatorCancel', 'Cancel', 'creator.cancel', {}, { region: 'footer' }),
+        uiAction('creatorBack', 'Back', 'creator.back', {}, { region: 'footer', disabled: creator.stepIndex <= 0 }),
+        uiAction('creatorReset', 'Reset', 'creator.reset', {}, { region: 'footer' }),
+        step === 'summary'
+            ? uiAction('creatorCreate', 'Create', 'creator.confirm', {}, { region: 'footer', disabled: issues.length > 0 })
+            : uiAction('creatorNext', 'Next', 'creator.next', {}, { region: 'footer' }),
+    ];
+    return actions;
+}
+
+export function createCreatorIntroActionList() {
+    return [
+        uiAction('creatorBegin', 'Begin Adventure', 'creator.begin', {}, { region: 'intro' }),
+        uiAction('creatorViewCharacter', 'View Character', 'creator.begin', { command: 'character' }, { region: 'intro' }),
+    ];
+}
+
 export function createMenuActionList(session, modal = null, modalPage = null) {
     if (modal === 'mainMenu') return createMainMenuActions(session);
     if (modal === 'login') return createLoginActions(session);
@@ -45,8 +78,20 @@ export function createMenuActionList(session, modal = null, modalPage = null) {
             characterId: character.id,
             displayName: character.name,
         })),
-        commandAction('newCharacter', characters.length ? 'New Character' : 'Create Character', '/newcharacter', { screenAfter: 'game', clearFeedback: true }),
+        uiAction('newCharacter', characters.length ? 'New Character' : 'Create Character', 'creator.open'),
     ];
+}
+
+function choiceActionsForStep(step, creator) {
+    if (step === 'identity') {
+        return [
+            ...getRaceOptions().map((race) => uiAction(`race:${race.id}`, race.name, 'creator.selectRace', { raceId: race.id }, { region: 'choices', detail: race.blurb, tags: race.tags, selected: race.id === creator.raceId })),
+            ...getSexOptions(creator).map((sex) => uiAction(`sex:${sex.id}`, `Sex: ${sex.name}`, 'creator.selectSex', { sex: sex.id }, { region: 'choices', selected: sex.id === creator.sex })),
+        ];
+    }
+    if (step === 'nation') return getNationOptions().map((nation) => uiAction(`nation:${nation.id}`, nation.name, 'creator.selectNation', { nationId: nation.id }, { region: 'choices', detail: nation.blurb, tags: nation.tags, selected: nation.id === creator.nationId }));
+    if (step === 'job') return getStartingJobOptions().map((job) => uiAction(`job:${job.id}`, `${job.name} (${job.abbreviation})`, 'creator.selectJob', { mainJobId: job.id }, { region: 'choices', detail: job.blurb, tags: job.tags, selected: job.id === creator.mainJobId }));
+    return [];
 }
 
 function createMainMenuActions(session) {
@@ -131,11 +176,20 @@ function commandAction(id, label, command, payload = {}) {
     return Object.freeze({ id, label, command, intent: 'command.route', payload: Object.freeze({ command, ...payload }), kind: 'command' });
 }
 
-function uiAction(id, label, intent, payload = {}) {
-    return Object.freeze({ id, label, command: payload.command ?? id, intent, payload: Object.freeze(payload), kind: 'ui' });
+function uiAction(id, label, intent, payload = {}, extra = {}) {
+    return Object.freeze({ id, label, command: payload.command ?? id, intent, payload: Object.freeze(payload), kind: 'ui', ...extra });
+}
+
+function stepLabel(step) {
+    if (step === 'identity') return 'Race / Sex';
+    if (step === 'nation') return 'Starting City';
+    if (step === 'job') return 'Starting Job';
+    if (step === 'summary') return 'Summary';
+    return step;
 }
 
 function isActionDisabled(actionRecord, state) {
+    if (actionRecord.disabled) return true;
     if (actionRecord.id === 'battle') return state?.activeBattle?.phase !== 'active';
     if (actionRecord.intent === 'settings.noop') return true;
     return false;

--- a/js/text/ui/uiIntentDispatcher.js
+++ b/js/text/ui/uiIntentDispatcher.js
@@ -1,4 +1,4 @@
-import { replaceState as replaceGameState } from '../gameState.js';
+import { createNewGameState, replaceState as replaceGameState } from '../gameState.js';
 import {
     appendOutput,
     clearModalInputs,
@@ -7,6 +7,18 @@ import {
     setCanvasScreen,
     setModalPage,
 } from './canvasInput.js';
+import {
+    advanceCreatorStep,
+    createCreatorGameOptions,
+    createGuidedCreatorState,
+    describeCreatorOpening,
+    normalizeCreatorState,
+    selectCreatorJob,
+    selectCreatorNation,
+    selectCreatorRace,
+    selectCreatorSex,
+    validateCreator,
+} from '../systems/characterCreationModel.js';
 
 export function createIntentResult({ ok = true, message = '', data = null } = {}) {
     return { ok, message, data };
@@ -60,6 +72,18 @@ export function dispatchUiIntent(request = {}) {
         case 'settings.gmtUp': return updateSetting(context, { gmtOffset: clampGmt((context.session.settings?.gmtOffset ?? 0) + 1) });
         case 'settings.cycleDaylightSavings': return updateSetting(context, { daylightSavings: nextValue(context.session.settings?.daylightSavings, DST_MODES) });
         case 'settings.noop': return ok(context);
+        case 'creator.open': return openCreator(context);
+        case 'creator.goto': return updateCreator(context, { stepIndex: context.payload.stepIndex });
+        case 'creator.selectRace': return updateCreator(context, (creator) => selectCreatorRace(creator, context.payload.raceId));
+        case 'creator.selectSex': return updateCreator(context, (creator) => selectCreatorSex(creator, context.payload.sex));
+        case 'creator.selectNation': return updateCreator(context, (creator) => selectCreatorNation(creator, context.payload.nationId));
+        case 'creator.selectJob': return updateCreator(context, (creator) => selectCreatorJob(creator, context.payload.mainJobId));
+        case 'creator.next': return updateCreator(context, (creator) => advanceCreatorStep(creator, 1));
+        case 'creator.back': return updateCreator(context, (creator) => advanceCreatorStep(creator, -1));
+        case 'creator.reset': return resetCreator(context);
+        case 'creator.cancel': return cancelCreator(context);
+        case 'creator.confirm': return confirmCreator(context);
+        case 'creator.begin': return beginCreatedCharacter(context);
         case 'command.route': return routeCommand(context);
         default: return fail(context, `Unknown intent: ${context.intent || 'none'}`);
     }
@@ -198,10 +222,72 @@ function updateSetting(context, updates) {
     return ok(context, { settings: result.settings });
 }
 
+function openCreator(context) {
+    refreshSession(context);
+    if (!context.session.loggedIn) return feedback(context, 'Login or create a local account first.');
+    context.uiState.creator = createGuidedCreatorState();
+    context.uiState.creatorIntro = [];
+    setCanvasModal(context.uiState, null);
+    setCanvasScreen(context.uiState, 'creator');
+    setActiveFeedback(context.uiState, 'Choose race and sex.');
+    return ok(context, { creator: context.uiState.creator });
+}
+
+function updateCreator(context, updater) {
+    context.uiState.creator ??= createGuidedCreatorState();
+    const next = typeof updater === 'function' ? updater(context.uiState.creator) : { ...context.uiState.creator, ...updater };
+    context.uiState.creator = normalizeCreatorState(next);
+    setActiveFeedback(context.uiState, '');
+    return ok(context, { creator: context.uiState.creator });
+}
+
+function resetCreator(context) {
+    context.uiState.creator = createGuidedCreatorState();
+    setActiveFeedback(context.uiState, 'Character creation reset.');
+    return ok(context, { creator: context.uiState.creator });
+}
+
+function cancelCreator(context) {
+    context.uiState.creator = null;
+    context.uiState.creatorIntro = [];
+    setCanvasScreen(context.uiState, 'menu');
+    setActiveFeedback(context.uiState, 'Character creation cancelled.');
+    return ok(context);
+}
+
+function confirmCreator(context) {
+    context.uiState.creator = normalizeCreatorState(context.uiState.creator ?? createGuidedCreatorState());
+    const issues = validateCreator(context.uiState.creator);
+    if (issues.length) return feedback(context, issues[0]);
+    const nextState = createNewGameState(createCreatorGameOptions(context.uiState.creator));
+    const replaceState = context.services.replaceState ?? replaceGameState;
+    replaceState(context.state, nextState);
+    const saveGame = context.services.saveGame;
+    const saved = saveGame ? saveGame(context.state) : false;
+    refreshSession(context);
+    context.uiState.creatorIntro = describeCreatorOpening(context.uiState.creator);
+    setCanvasScreen(context.uiState, 'creatorIntro');
+    const message = saved ? `Created ${context.state.player.identity.name}. Character saved.` : `Created ${context.state.player.identity.name}. Save unavailable.`;
+    setActiveFeedback(context.uiState, message);
+    return ok(context, { character: context.state, saved, message });
+}
+
+function beginCreatedCharacter(context) {
+    setCanvasScreen(context.uiState, 'game');
+    const message = `Begin ${context.state.player.identity.name}'s adventure.`;
+    setActiveFeedback(context.uiState, message);
+    if (context.payload.command) {
+        context.payload.command = String(context.payload.command);
+        return routeCommand(context);
+    }
+    return ok(context, { message });
+}
+
 function routeCommand(context) {
     const command = String(context.payload.command ?? '').trim();
     if (!command) return fail(context, 'No command to route.');
     if (!context.session.loggedIn && !command.startsWith('/account')) return feedback(context, 'Login or create a local account first.');
+    if (command === '/newcharacter' || command === 'newcharacter') return openCreator(context);
     const commandAdapter = context.services.commandAdapter ?? context.services.routeCommand;
     if (!commandAdapter) return fail(context, 'Command adapter unavailable.');
     const response = commandAdapter(command, context.payload.action ?? null);

--- a/tests/canvasUi.test.js
+++ b/tests/canvasUi.test.js
@@ -211,6 +211,14 @@ test('escape opens menu from game screen or closes a modal', () => {
     assert.equal(uiState.modalPage, null);
 });
 
+test('escape closes a non-field modal before creator cancellation', () => {
+    const uiState = createCanvasUiState({ screen: 'creator', modal: 'mainMenu' });
+
+    assert.deepEqual(applyCanvasKey(uiState, 'Escape'), { type: 'modal' });
+    assert.equal(uiState.modal, null);
+    assert.equal(uiState.screen, 'creator');
+});
+
 test('canvas menu action list shows only new account when logged out with no accounts', () => {
     const loggedOut = createMenuActionList({ loggedIn: false, accounts: [] });
 

--- a/tests/canvasUi.test.js
+++ b/tests/canvasUi.test.js
@@ -294,8 +294,8 @@ test('canvas menu action list shows character selection and creation after login
     assert.equal(findActionById('character:character-1', loggedIn).payload.characterId, 'character-1');
     assert.equal(findActionById('character:character-1', loggedIn).payload.displayName, 'Aldo');
     assert.equal(findActionById('newCharacter', loggedIn).label, 'New Character');
-    assert.equal(findActionById('newCharacter', loggedIn).intent, 'command.route');
-    assert.deepEqual(findActionById('newCharacter', loggedIn).payload, { command: '/newcharacter', screenAfter: 'game', clearFeedback: true });
+    assert.equal(findActionById('newCharacter', loggedIn).intent, 'creator.open');
+    assert.deepEqual(findActionById('newCharacter', loggedIn).payload, {});
     assert.equal(findActionById('settings', loggedIn), null);
     assert.equal(findActionById('logout', loggedIn), null);
 });

--- a/tests/guidedCharacterCreation.test.js
+++ b/tests/guidedCharacterCreation.test.js
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createNewGameState } from '../js/text/gameState.js';
+import {
+    advanceCreatorStep,
+    createCreatorGameOptions,
+    createGuidedCreatorState,
+    describeCreatorOpening,
+    getCreatorSummary,
+    getRaceOptions,
+    getStartingJobOptions,
+    selectCreatorRace,
+    selectCreatorSex,
+    setCreatorName,
+    validateCreator,
+} from '../js/text/systems/characterCreationModel.js';
+
+test('guided creator exposes meaningful race and starting job choices', () => {
+    assert.equal(getRaceOptions().length, 5);
+    assert.deepEqual(getStartingJobOptions().map((job) => job.id), ['warrior', 'monk', 'whiteMage', 'blackMage', 'redMage', 'thief']);
+});
+
+test('guided creator enforces allowed race sex combinations', () => {
+    let creator = createGuidedCreatorState({ raceId: 'hume', sex: 'female' });
+    creator = selectCreatorRace(creator, 'galka');
+
+    assert.equal(creator.raceId, 'galka');
+    assert.equal(creator.sex, 'male');
+    assert.equal(selectCreatorSex(creator, 'female').sex, 'male');
+});
+
+test('guided creator builds summary and game-state options', () => {
+    let creator = createGuidedCreatorState({ nationId: 'bastok', mainJobId: 'monk', raceId: 'galka' });
+    creator = setCreatorName(creator, 'Stone Son');
+    creator = advanceCreatorStep(creator, 3);
+
+    assert.deepEqual(validateCreator(creator), []);
+    assert.match(getCreatorSummary(creator).startingCity, /Bastok Markets/);
+
+    const state = createNewGameState(createCreatorGameOptions(creator));
+    assert.equal(state.player.identity.name, 'Stone Son');
+    assert.equal(state.currentPlaceId, 'bastok-markets');
+    assert.equal(state.player.jobs.mainJobId, 'monk');
+});
+
+test('guided creator requires a name before final confirmation', () => {
+    const creator = createGuidedCreatorState();
+    assert.match(validateCreator(creator).join('\n'), /Name is required/);
+    assert.match(describeCreatorOpening(setCreatorName(creator, 'Ashen'))[0], /Ashen/);
+});


### PR DESCRIPTION
## Summary
- Adds a guided character creation model and player-facing presentation content for race, sex, nation, job, summary, and opening narrative.
- Replaces the canvas menu's Create Character action with a dedicated creator screen instead of routing through the output log prompt flow.
- Adds creator-specific canvas layout regions, input handling, UI actions, and intent routing.
- Adds a post-confirmation intro screen before entering normal gameplay.
- Adds model tests for creator choices, validation, summary, and game-state creation.

## Notes
- This is the first pass and intentionally keeps appearance, advanced jobs, subjobs, and detailed stat previews out of scope.
- The old command-based creator still exists as a fallback/debug route; the canvas UI now opens the guided flow.

## Test status
- Not run from this environment.