### PR TITLE
Implement item behavior metadata and shop selling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable reset-branch changes are tracked here.
 - `/menu`, `/commands`, `/help`, `/newcharacter`, `/characters`, `/load`, `/save`, `/account`, and `/reset` commands.
 - Prompt-based character creation from `/newcharacter`, with natural non-slash answers while prompts are active.
 - Slash-router tests for FFXI macro-style browser commands such as `/macrohelp`, `/ma`, `/ws`, and `/item`.
-- Encoded local account/character save model under `ffxiTextRpgAccount`.
+- Encoded local account/character save model under `ffxiTextRpgAccounts` with active session state under `ffxiTextRpgAccountSession`.
 - Multiple local character save slots with character summaries and last-active-character tracking.
 - Legacy raw `ffxiTextRpgSave` migration into the encoded account save model.
 - Account/save tests for encoding, slot listing, character loading, active character restore, save clearing, and inventory reference relinking.
@@ -45,6 +45,8 @@ All notable reset-branch changes are tracked here.
 - POI discovery and same-zone POI fast travel.
 - Starter shop catalogs, guild service hooks, and quest/mission hooks.
 - Shop buying into Inventory through the container system.
+- Runtime item behavior helpers for conservative sell eligibility/value, latent metadata, enchantment metadata, charge metadata, and ranged/ammo metadata inspection.
+- Conservative shop selling from Inventory with current-shop requirements, `noSell`/key-item/zero-value rejection, stack quantity removal, and wallet credit after successful removal.
 - Inventory container framework for Inventory, Mog Safe, Mog Safe 2, Storage, Mog Locker, Mog Satchel, Mog Sack, Mog Case, and Mog Wardrobes 1-8.
 - Mog House-only access rules for Mog Safe and Storage.
 - Furniture-derived Storage capacity for Mog House furniture.
@@ -95,9 +97,9 @@ All notable reset-branch changes are tracked here.
 - Updated shell intro text to guide users toward `/menu`, `/newcharacter`, `/commands`, and `/help`.
 - Rebuilt initial game state around structured player, NPC, enemy, place, coordinate, atlas, map, travel, inventory, item, POI, and account-save state.
 - Refactored command routing to operate on parsed command objects instead of whole-command strings.
-- Updated app/package version to `0.4.2`, account save version to `4`, game state version to `3`, data version to `13`, and codename to `San d’Oria Coordinate Compass`.
+- Updated app/package version to `0.4.3`, account save version to `4`, game state version to `3`, data version to `13`, and codename to `San d’Oria Coordinate Compass`.
 - Replaced San d’Oria placeholder numeric city grids with alphanumeric topology coordinates and direction-aware exits.
-- Updated data/system version tracking for item schema, equipment catalog, equipment eligibility, item inspection, validation, skill caps, and skill progression.
+- Updated data/system version tracking for item schema, item behavior, equipment catalog, equipment eligibility, item inspection, shop transactions, validation, skill caps, and skill progression.
 - Added `canvasUi` system version tracking.
 - Updated `getEffectiveSkill` to read character-owned skill values and report missing skills as current value `0` against the active job cap.
 - Refreshed README, roadmap, and handoff documentation for the current post-0.5 foundation state.
@@ -113,4 +115,4 @@ All notable reset-branch changes are tracked here.
 - `base64-json-v1` save storage is encoded, not strong encryption.
 - Current formulas are conservative approximations until exact researched formulas are migrated deliberately.
 - `skillCaps.js` remains scaffold-only and is not wired into combat or magic calculations.
-- Current recommended next pass is item behavior modules plus conservative skill plumbing: item behavior rules, isolated skill-gain hooks, skill-cap formula wiring, and tests.
+- Current recommended next pass is conservative skill plumbing and deeper item behavior application: isolated skill-gain hooks, skill-cap formula wiring, and tests. Latent/enchantment/charge/ranged-ammo behavior remains metadata-only until action semantics are explicit.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,7 +97,7 @@ All notable reset-branch changes are tracked here.
 - Updated shell intro text to guide users toward `/menu`, `/newcharacter`, `/commands`, and `/help`.
 - Rebuilt initial game state around structured player, NPC, enemy, place, coordinate, atlas, map, travel, inventory, item, POI, and account-save state.
 - Refactored command routing to operate on parsed command objects instead of whole-command strings.
-- Updated app/package version to `0.4.3`, account save version to `4`, game state version to `3`, data version to `13`, and codename to `San d’Oria Coordinate Compass`.
+- Updated app/package version to `0.4.3`, account save version to `4`, game state version to `3`, data version to `13`, and codename to `Item Behavior Selling`.
 - Replaced San d’Oria placeholder numeric city grids with alphanumeric topology coordinates and direction-aware exits.
 - Updated data/system version tracking for item schema, item behavior, equipment catalog, equipment eligibility, item inspection, shop transactions, validation, skill caps, and skill progression.
 - Added `canvasUi` system version tracking.

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ This branch intentionally resets the project around a stable canvas-first text s
 
 Backwards compatibility with the previous UI/save shape is not considered until explicitly reintroduced.
 
+This pass adds item behavior inspection helpers and conservative shop selling. Latent effects, enchantments, charges, and ranged/ammo behavior remain metadata-only and are not wired into combat formulas yet.
+
 ## Current version
 
 ```text
-App/package: 0.4.2
+App/package: 0.4.3
 Account Save: 4
 Game State: 3
 Data: 13
@@ -121,6 +123,7 @@ shop <name>
 move <dir>
 stop
 buy <item>
+sell <item> [quantity]
 guild <name>
 quest <name>
 discovered
@@ -173,10 +176,11 @@ A completed and confirmed character is saved automatically into the local accoun
 
 ## Save model
 
-Local saves are stored under:
+Local accounts and active-account session state are stored under:
 
 ```text
-ffxiTextRpgAccount
+ffxiTextRpgAccounts
+ffxiTextRpgAccountSession
 ```
 
 The save payload is encoded as:
@@ -311,9 +315,9 @@ docs/
 - Common item schema, item normalization, stack metadata, and stack-aware container insertion.
 - Normalized equipment template fields for family/archetype/subtype, allowed slots, weapon category/delay, requirements, flags, always-on effects, latent/enchantment/augment scaffolds, charges, and confidence/source metadata.
 - Container transfer rules with access, capacity, item-kind, and stack-handling validation.
-- Shop buying into Inventory.
+- Shop buying into Inventory and conservative shop selling from Inventory.
 - Equip/unequip commands using Inventory and accessible Wardrobes, with job/race/level/slot eligibility and two-handed/offhand conflict checks.
-- Text-first `item <query>` and `inspect item <query>` inspection for accessible inventory, wardrobe, and equipped items.
+- Text-first `item <query>` and `inspect item <query>` inspection for accessible inventory, wardrobe, equipped items, and item behavior metadata.
 - Starter equipment catalog with conservative stat modifiers and explicit placeholder/intentional-simplification metadata.
 - Attribute/resource/derived-stat/skill/equipment/currency constants.
 - Conservative stat calculation engine.
@@ -346,9 +350,9 @@ Current formulas are conservative placeholders. They exist to make the architect
 
 ## Current next best pass
 
-The current recommended next pass is item behavior modules and conservative skill plumbing:
+The current recommended next pass is conservative skill plumbing and deeper item behavior application:
 
-1. Implement item behaviors for latent effects, enchantments, charges, ranged/ammo, and sell/vendor restrictions in small rule modules.
+1. Keep latent effects, enchantments, charges, and ranged/ammo behavior metadata inspection-only until combat and action semantics are explicit.
 2. Add isolated skill-gain hooks only after the character-owned skill-state rules are covered.
 3. Wire skill caps into combat and magic calculations only after current skill state, gain flow, and formula confidence are explicit.
 4. Add key-item item records and unlock/permission validation.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ App/package: 0.4.3
 Account Save: 4
 Game State: 3
 Data: 13
-Codename: San d’Oria Coordinate Compass
+Codename: Item Behavior Selling
 ```
 
 `VERSION.save` remains as a backward-compatible alias for `VERSION.accountSave` while callers migrate to the clearer name.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,10 +65,11 @@ js/text/systems/ffxiCommandAdapter.js
 js/text/save.js
 ```
 
-The current browser save key is:
+The current browser account and session save keys are:
 
 ```text
-ffxiTextRpgAccount
+ffxiTextRpgAccounts
+ffxiTextRpgAccountSession
 ```
 
 The saved payload is encoded as:
@@ -145,6 +146,7 @@ js/text/
     equipmentEngine.js
     ffxiCommandAdapter.js
     inventoryEngine.js
+    itemBehaviorEngine.js
     menuDescriptions.js
     poiEngine.js
     shopEngine.js
@@ -247,7 +249,9 @@ The POI engine owns:
 
 ### Shop engine
 
-The shop engine currently supports buying only. Purchases spend gil, create/enrich items, and add them into Inventory through container rules. Selling is intentionally a placeholder until item value/flags/vendor restrictions are defined.
+The shop engine supports buying and conservative selling. Purchases spend gil, create/enrich items, and add them into Inventory through container rules. Selling requires a current shop POI, only sells from Inventory, rejects key items, `noSell`, and zero-value items by default, removes the item quantity first, and credits gil only after removal succeeds.
+
+`itemBehaviorEngine.js` owns sell eligibility/value helpers and metadata-only item behavior inspection for latent effects, enchantments, charges, and ranged/ammo flags. Those behavior records are not wired into combat formulas yet.
 
 ### Battle engine
 
@@ -262,7 +266,7 @@ The battle engine owns battle-local state:
 - magic burst placeholder
 - log
 
-Combat actions exist, but battle rewards are not implemented yet.
+Combat actions and battle rewards exist. Rewards currently cover victory EXP, gil, deterministic loot rolls, Inventory insertion through container rules, failed loot storage reporting, progression integration, and duplicate payout prevention.
 
 ### Status engine
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -102,8 +102,8 @@ Status: starter framework implemented.
 - [x] Equipment validation by job/race/level.
 - [x] Item flag/effect schema foundation: rare, exclusive, key item, no sell, latent, enchantment, charges.
 - [x] Item command inspection.
-- [ ] Runtime behavior for latent effects, enchantments, charges, ranged/ammo, and restricted selling.
-- [ ] Selling and vendor restrictions.
+- [x] Runtime behavior metadata inspection for latent effects, enchantments, charges, ranged/ammo, and restricted selling.
+- [x] Conservative selling and vendor restrictions.
 
 ## Phase 5: Leveling, skills, and progression
 
@@ -219,9 +219,9 @@ Target: ongoing.
 
 ## Current recommended next pass
 
-The next best implementation pass is item behavior modules plus conservative skill plumbing:
+The next best implementation pass is conservative skill plumbing and deeper item behavior application:
 
-1. Implement item behavior rules for latent effects, enchantments, charges, ranged/ammo, and selling restrictions.
+1. Keep latent effects, enchantments, charges, and ranged/ammo records metadata-only until action/combat semantics are explicit.
 2. Add isolated skill-gain hooks only after the character-owned skill-state rules are covered.
 3. Wire skill caps into combat and magic formulas only after current skill state, skill-gain flow, and confidence labels are explicit.
-4. Add validation/tests for any new item behavior before expanding loot tables.
+4. Add validation/tests before expanding loot tables or applying item behavior in combat.

--- a/docs/THREAD_HANDOFF.md
+++ b/docs/THREAD_HANDOFF.md
@@ -39,7 +39,7 @@ App/package: 0.4.3
 Account Save: 4
 Game State: 3
 Data: 13
-Codename: San d’Oria Coordinate Compass
+Codename: Item Behavior Selling
 ```
 
 Major active system versions:

--- a/docs/THREAD_HANDOFF.md
+++ b/docs/THREAD_HANDOFF.md
@@ -35,7 +35,7 @@ js/text/version.js
 Current state at handoff:
 
 ```text
-App/package: 0.4.2
+App/package: 0.4.3
 Account Save: 4
 Game State: 3
 Data: 13
@@ -54,7 +54,8 @@ playerEntity: 0.5.4
 statEngine: 0.4.0
 equipmentCommands: 0.5.0
 equipmentEligibility: 0.5.0
-itemInspection: 0.5.0
+itemInspection: 0.5.1
+itemBehavior: 0.1.0
 equipmentCatalog: 0.6.0
 inventoryContainers: 0.5.1
 inventoryTransfers: 0.5.1
@@ -70,7 +71,7 @@ expTables: 0.5.2
 jobSwitching: 0.5.3
 leveling: 0.5.3
 loot: 0.5.0
-shops/shopTransactions: 0.3.7
+shops/shopTransactions: 0.3.8
 coordinates/navigation: 0.1.0
 pois/poiDiscovery/poiFastTravel: 0.3.5
 travel/gridMovement/zoneAtlas: 0.4.0
@@ -146,6 +147,7 @@ here
 talk Ashene
 shop Ashene
 buy Bronze Sword
+sell Bronze Sword
 zonefast
 move n
 travel West Ronfaure
@@ -184,10 +186,11 @@ File:
 js/text/save.js
 ```
 
-LocalStorage key:
+LocalStorage keys:
 
 ```text
-ffxiTextRpgAccount
+ffxiTextRpgAccounts
+ffxiTextRpgAccountSession
 ```
 
 Encoding:
@@ -207,7 +210,7 @@ Save structure includes:
 
 Legacy migration:
 
-- Old raw `ffxiTextRpgSave` is read only if no account save exists.
+- Old raw `ffxiTextRpgSave` and legacy single-account `ffxiTextRpgAccount` are read only for migration when no current account save exists.
 - Valid legacy saves are migrated into the encoded account model.
 - Save load must call `reviveGameState()` to relink `player.inventory` to `player.inventoryState.containers.inventory.items`.
 
@@ -254,13 +257,14 @@ js/text/systems/aggroEngine.js
 Implemented:
 
 - starter cities and starter outdoor/dungeon hooks
-- coordinate grids
-- connection grids
+- San d'Oria city topology coordinates with explicit alphanumeric nodes and exits
+- legacy numeric grids for non-San d'Oria wilderness/city areas until those zones are expanded
+- connection grids / departure and arrival coordinates
 - zone graph
 - direct travel command
 - travel restrictions scaffold
-- atlas discovery with unknown unvisited grids
-- 8-way grid movement
+- atlas discovery with unknown unvisited coordinates/grids
+- 8-way coordinate movement where topology exists, with legacy numeric movement elsewhere
 - foot-travel aggro scaffold
 
 ### POIs, shops, guilds, quests
@@ -274,6 +278,7 @@ js/text/data/guildServices.js
 js/text/data/questHooks.js
 js/text/systems/poiEngine.js
 js/text/systems/shopEngine.js
+js/text/systems/itemBehaviorEngine.js
 ```
 
 Implemented:
@@ -286,8 +291,10 @@ Implemented:
 - starter guild service/recipe previews
 - starter quest/mission hooks
 - buying from shops into Inventory
+- conservative selling from Inventory at current shop POIs
+- item behavior metadata helpers for sell restrictions, latent effects, enchantments, charges, and ranged/ammo records
 
-Selling is intentionally not implemented yet.
+Selling intentionally stays conservative: key items, `noSell`, and zero-value items are rejected by default; `noTrade`, `noDrop`, and `noAuction` are described as metadata but are not enforced as shop-sale restrictions yet.
 
 ### Inventory, items, storage, wardrobes
 
@@ -299,6 +306,7 @@ js/text/data/inventoryContainers.js
 js/text/data/skillCaps.js
 js/text/data/mogHouseFurniture.js
 js/text/systems/inventoryEngine.js
+js/text/systems/itemBehaviorEngine.js
 ```
 
 Implemented containers:
@@ -326,6 +334,8 @@ Rules:
 - Item normalization adds kind, quantity, stackable, maxStack, tags, source, template metadata, family/archetype/subtype, requirements, flags, effects, latent/enchantment/augment scaffolds, charges, modifiers, and equipmentSlot/allowedSlots fields.
 - Stackable consumables/materials/misc items merge into existing stacks when possible.
 - Container transfers are atomic and enforce source access, destination access, capacity, item-kind, and stack rules.
+- Inventory quantity removal is used by shop selling so gil is credited only after item removal succeeds.
+- Latent effects, enchantments, charges, and ranged/ammo behavior are inspectable metadata only; they are not wired into combat formulas yet.
 - Sparse skill rank/cap helpers exist for later combat and magic skill progression.
 - Character-owned current skills live in `player.progression.skills[skillId]`. Do not reintroduce per-job skill storage maps.
 - `skills`, `skill <id>`, `inspect skills`, and `inspect skill <id>` describe current character-owned skill values against the active main-job cap scaffold.
@@ -349,7 +359,7 @@ Implemented:
 - replacement gear returns safely
 - slot inference from `equipmentSlot` or tags
 - eligibility validation by job, race, level, allowed slot, two-handed/offhand conflicts, and ranged/ammo slot constraints
-- `item <query>` and `inspect item <query>` for text-first item template/runtime inspection
+- `item <query>` and `inspect item <query>` for text-first item template/runtime/behavior inspection
 - starter equipment modifiers affect combat profile
 
 Starter gear bonuses, eligibility, and delay values are conservative placeholders or intentional simplifications, not exact FFXI formulas.
@@ -433,9 +443,9 @@ docs/RESEARCH_REFERENCES.md
 
 ## Current recommended next pass
 
-The next best implementation pass is item behavior modules plus conservative skill plumbing:
+The next best implementation pass is conservative skill plumbing and deeper item behavior application:
 
-1. Add item behavior modules for latent effects, enchantments, charges, ranged/ammo, and sell restrictions.
+1. Keep latent effects, enchantments, charges, and ranged/ammo records metadata-only until their action/combat semantics are explicit.
 2. Add isolated skill-gain hooks, but avoid random pacing until the rule is tested and confidence-labeled.
 3. Decide how skill caps feed combat and magic formulas before touching battle command handlers.
 4. Keep formula-sensitive values labeled as exact, approximate, simplified, or placeholder.

--- a/js/text/commandRouter.js
+++ b/js/text/commandRouter.js
@@ -94,7 +94,7 @@ const HELP_TEXT = [
     '  talk [name]          Talk/interact with a POI at this coordinate and discover it.',
     '  shop [name]          Use shop action at this coordinate where supported.',
     '  buy <item>           Buy an item from the current shop POI into Inventory.',
-    '  sell <item>          Placeholder for future sell flow.',
+    '  sell <item> [qty]    Sell one or more Inventory items to the current shop POI.',
     '  guild [name]         Use guild action at this coordinate where supported.',
     '  quest [name]         Use quest/mission action at this coordinate where supported.',
     '  discovered           List discovered POIs in this zone.',

--- a/js/text/systems/equipmentEngine.js
+++ b/js/text/systems/equipmentEngine.js
@@ -7,6 +7,13 @@ import {
     findItemInContainer,
     isContainerAccessible,
 } from './inventoryEngine.js';
+import {
+    describeCharges,
+    describeEnchantments,
+    describeItemBehavior,
+    describeLatentEffects,
+    describeRangedAmmoBehavior,
+} from './itemBehaviorEngine.js';
 
 const DEFAULT_EQUIP_SEARCH_CONTAINERS = Object.freeze(['inventory', 'wardrobe1', 'wardrobe2', 'wardrobe3', 'wardrobe4', 'wardrobe5', 'wardrobe6', 'wardrobe7', 'wardrobe8']);
 
@@ -197,6 +204,9 @@ function describeItemInspection(item, sourceLabel = 'unknown') {
     }
 
     lines.push(`Flags: ${normalized.flags.length ? normalized.flags.join(', ') : 'none'}`);
+    lines.push('Behavior metadata:');
+    lines.push(...splitLines(describeItemBehavior(normalized)));
+    lines.push(...splitLines(describeRangedAmmoBehavior(normalized)));
     lines.push('Always-on modifiers:');
     lines.push(...describeModifierBlock(normalized.modifiers));
     lines.push('Effects:');
@@ -276,10 +286,10 @@ function describeModifierBlock(modifiers = {}) {
 function describeEffects(item) {
     const lines = [];
     lines.push(...(item.effects?.length ? item.effects.map((effect) => `- ${effect.id}: ${effect.type} (${effect.trigger}) confidence=${effect.confidence}`) : ['- always-on effects: none beyond modifiers']));
-    lines.push(...(item.latentEffects?.length ? item.latentEffects.map((effect) => `- latent ${effect.id}: condition=${JSON.stringify(effect.condition)} confidence=${effect.confidence}`) : ['- latent: none']));
-    lines.push(...(item.enchantments?.length ? item.enchantments.map((entry) => `- enchantment ${entry.id}: ${entry.type} confidence=${entry.confidence}`) : ['- enchantments: none']));
+    lines.push(...splitLines(describeLatentEffects(item)));
+    lines.push(...splitLines(describeEnchantments(item)));
     lines.push(...(item.augments?.length ? item.augments.map((entry) => `- augment ${entry.id}: ${entry.type} confidence=${entry.confidence}`) : ['- augments: none']));
-    lines.push(item.charges ? `- charges: ${item.charges.current}/${item.charges.max}, recast ${item.charges.recastSeconds}s, cooldown ${item.charges.cooldownSeconds}s` : '- charges: none');
+    lines.push(...splitLines(describeCharges(item)));
     return lines;
 }
 
@@ -304,4 +314,8 @@ function normalizeQuery(value) {
 function formatSigned(value) {
     const number = Number(value) || 0;
     return number > 0 ? `+${number}` : String(number);
+}
+
+function splitLines(value) {
+    return String(value ?? '').split('\n').filter(Boolean);
 }

--- a/js/text/systems/inventoryEngine.js
+++ b/js/text/systems/inventoryEngine.js
@@ -110,6 +110,33 @@ export function findItemInContainer(inventoryState, containerId, itemQuery) {
     return { ok: true, item: container.items[index], index, container };
 }
 
+export function removeItemQuantityFromContainer(inventoryState, containerId, itemQuery, quantity = 1) {
+    const found = findItemInContainer(inventoryState, containerId, itemQuery);
+    if (!found.ok) return found;
+
+    const amount = Math.max(1, Number.parseInt(quantity, 10) || 1);
+    const normalizedItem = normalizeItem(found.item);
+    const available = Math.max(1, Number.parseInt(found.item.quantity, 10) || normalizedItem.quantity || 1);
+    if (amount > available) {
+        return { ok: false, reason: `Only ${available} ${normalizedItem.name} available in ${containerId}.`, item: found.item, available };
+    }
+
+    const removedItem = { ...normalizedItem, quantity: amount };
+    if (amount >= available || !normalizedItem.stackable) {
+        found.container.items.splice(found.index, 1);
+    } else {
+        found.item.quantity = available - amount;
+    }
+
+    return {
+        ok: true,
+        item: removedItem,
+        quantity: amount,
+        containerId,
+        remaining: Math.max(0, available - amount),
+    };
+}
+
 export function transferItemBetweenContainers(state, itemQuery, fromContainerId = 'inventory', toContainerId = 'inventory', context = {}) {
     const inventoryState = state.player?.inventoryState ?? state.inventoryState;
     if (!inventoryState) return 'No inventory container state found.';

--- a/js/text/systems/itemBehaviorEngine.js
+++ b/js/text/systems/itemBehaviorEngine.js
@@ -1,0 +1,131 @@
+import { ITEM_KINDS, hasItemFlag, normalizeItem } from '../data/itemSchema.js';
+
+const DEFAULT_SELL_RATE = 0.5;
+const METADATA_ONLY_RESTRICTION_FLAGS = Object.freeze(['noTrade', 'noDrop', 'noAuction']);
+
+export function canSellItem(item, vendorContext = {}) {
+    const normalized = normalizeItem(item);
+    if (normalized.kind === ITEM_KINDS.KEY_ITEM || hasItemFlag(normalized, 'keyItem')) {
+        return { ok: false, item: normalized, reason: `${normalized.name} is a key item and cannot be sold.` };
+    }
+    if (hasItemFlag(normalized, 'noSell')) {
+        return { ok: false, item: normalized, reason: `${normalized.name} is marked noSell and cannot be sold.` };
+    }
+
+    const baseValue = getBaseValueGil(normalized);
+    if (baseValue <= 0 && !vendorContext.allowZeroValueSell) {
+        return { ok: false, item: normalized, reason: `${normalized.name} has no vendor value and cannot be sold.` };
+    }
+
+    return {
+        ok: true,
+        item: normalized,
+        sellValueGil: calculateSellValue(normalized, vendorContext),
+    };
+}
+
+export function calculateSellValue(item, vendorContext = {}) {
+    const normalized = normalizeItem(item);
+    const baseValue = getBaseValueGil(normalized);
+    if (baseValue <= 0) {
+        return vendorContext.allowZeroValueSell
+            ? Math.max(0, Number.parseInt(vendorContext.zeroValueSellGil, 10) || 0)
+            : 0;
+    }
+
+    const rawRate = Number(vendorContext.sellRate ?? DEFAULT_SELL_RATE);
+    const rate = Number.isFinite(rawRate) ? Math.max(0, Math.min(1, rawRate)) : DEFAULT_SELL_RATE;
+    return Math.max(1, Math.floor(baseValue * rate));
+}
+
+export function describeItemBehavior(item, vendorContext = {}) {
+    const normalized = normalizeItem(item);
+    const sellCheck = canSellItem(normalized, vendorContext);
+    const metadataOnlyFlags = METADATA_ONLY_RESTRICTION_FLAGS.filter((flag) => hasItemFlag(normalized, flag));
+    const lines = [
+        sellCheck.ok
+            ? `- selling: allowed, estimated ${sellCheck.sellValueGil} gil each`
+            : `- selling: restricted - ${sellCheck.reason}`,
+    ];
+
+    if (metadataOnlyFlags.length) {
+        lines.push(`- metadata-only restrictions: ${metadataOnlyFlags.join(', ')} (not enforced for shop selling yet)`);
+    }
+    if (normalized.metadata?.source || normalized.metadata?.notes) {
+        lines.push(`- item metadata: ${describeMetadata(normalized.metadata)}`);
+    }
+
+    return lines.join('\n');
+}
+
+export function describeLatentEffects(item) {
+    const normalized = normalizeItem(item);
+    if (!normalized.latentEffects?.length) return '- latent effects: none';
+    return normalized.latentEffects
+        .map((effect) => `- latent ${effect.id}: condition=${describeCondition(effect.condition)}; modifiers=${describeModifierSummary(effect.modifiers)}; ${describeMetadata(effect)}`)
+        .join('\n');
+}
+
+export function describeEnchantments(item) {
+    const normalized = normalizeItem(item);
+    if (!normalized.enchantments?.length) return '- enchantments: none';
+    return normalized.enchantments
+        .map((entry) => `- enchantment ${entry.id}: type=${entry.type}; condition=${describeCondition(entry.condition)}; modifiers=${describeModifierSummary(entry.modifiers)}; ${describeMetadata(entry)}`)
+        .join('\n');
+}
+
+export function describeCharges(item) {
+    const normalized = normalizeItem(item);
+    if (!normalized.charges) return '- charges: none';
+    const charges = normalized.charges;
+    return `- charges: ${charges.current}/${charges.max}, recast ${charges.recastSeconds}s, cooldown ${charges.cooldownSeconds}s; ${describeMetadata(charges)}`;
+}
+
+export function describeRangedAmmoBehavior(item) {
+    const normalized = normalizeItem(item);
+    const markers = [];
+    if (hasItemFlag(normalized, 'rangedWeapon')) markers.push('rangedWeapon flag');
+    if (hasItemFlag(normalized, 'ammo')) markers.push('ammo flag');
+    if (normalized.tags?.includes('ranged')) markers.push('ranged tag');
+    if (normalized.tags?.includes('ammo')) markers.push('ammo tag');
+    if (normalized.equipmentSlot === 'ranged') markers.push('ranged slot');
+    if (normalized.equipmentSlot === 'ammo') markers.push('ammo slot');
+
+    if (!markers.length) return '- ranged/ammo: none';
+
+    const details = [
+        `markers=${markers.join(', ')}`,
+        `weaponCategory=${normalized.weaponCategory ?? 'none'}`,
+        `weaponDelay=${normalized.weaponDelay ?? 'none'}`,
+    ];
+    return `- ranged/ammo: ${details.join('; ')}`;
+}
+
+function getBaseValueGil(item) {
+    return Math.max(0, Number.parseInt(item?.valueGil, 10) || 0);
+}
+
+function describeCondition(condition) {
+    return condition ? JSON.stringify(condition) : 'none';
+}
+
+function describeMetadata(metadata = {}) {
+    const parts = [`confidence=${metadata.confidence ?? 'placeholder'}`];
+    if (metadata.source) parts.push(`source=${metadata.source}`);
+    if (metadata.notes) parts.push(`notes=${metadata.notes}`);
+    return parts.join('; ');
+}
+
+function describeModifierSummary(modifiers = {}) {
+    const entries = [];
+    for (const [category, block] of Object.entries(modifiers ?? {})) {
+        const values = Object.entries(block ?? {}).filter(([, value]) => Number(value) !== 0);
+        if (values.length) entries.push(`${category}(${values.map(([key, value]) => `${key} ${formatSigned(value)}`).join(', ')})`);
+    }
+    return entries.length ? entries.join(', ') : 'none';
+}
+
+function formatSigned(value) {
+    const number = Number(value) || 0;
+    return number > 0 ? `+${number}` : String(number);
+}

--- a/js/text/systems/shopEngine.js
+++ b/js/text/systems/shopEngine.js
@@ -87,11 +87,11 @@ function findCatalogItem(catalog, itemQuery) {
 function parseSellRequest(itemQuery) {
     const text = String(itemQuery ?? '').trim();
     if (!text) return { itemQuery: '', quantity: 1 };
-    const match = text.match(/^(.*?)(?:\s+x?(\d+))$/i);
+    const match = text.match(/^(.*?)\s+(?:(?:x(\d+))|(?:qty\s+(\d+)))$/i);
     if (!match || !match[1].trim()) return { itemQuery: text, quantity: 1 };
     return {
         itemQuery: match[1].trim(),
-        quantity: Math.max(1, Number.parseInt(match[2], 10) || 1),
+        quantity: Math.max(1, Number.parseInt(match[2] ?? match[3], 10) || 1),
     };
 }
 

--- a/js/text/systems/shopEngine.js
+++ b/js/text/systems/shopEngine.js
@@ -1,7 +1,8 @@
 import { enrichEquipmentItem } from '../data/equipmentCatalog.js';
 import { getShopCatalogForPoi } from '../data/shopCatalogs.js';
 import { getContextualPois } from '../data/pointsOfInterest.js';
-import { addItemToContainer } from './inventoryEngine.js';
+import { canSellItem } from './itemBehaviorEngine.js';
+import { addItemToContainer, findItemInContainer, removeItemQuantityFromContainer } from './inventoryEngine.js';
 import { discoverPoi } from './poiEngine.js';
 
 export function buyFromCurrentShop(state, itemQuery = '', shopQuery = '') {
@@ -38,8 +39,36 @@ export function buyFromCurrentShop(state, itemQuery = '', shopQuery = '') {
     ].join('\n');
 }
 
-export function sellToCurrentShop(_state, _itemQuery = '') {
-    return 'Selling is not implemented yet. The shop transaction framework currently supports buying only.';
+export function sellToCurrentShop(state, itemQuery = '', shopQuery = '') {
+    const shopPoi = findCurrentShopPoi(state, shopQuery);
+    if (!shopPoi) return 'There is no matching shop at this coordinate.';
+
+    const catalog = getShopCatalogForPoi(shopPoi.id);
+    if (!catalog) return `${shopPoi.name} has no shop catalog yet.`;
+
+    const inventoryState = state.player?.inventoryState;
+    if (!inventoryState) return 'No inventory container state found.';
+
+    const request = parseSellRequest(itemQuery);
+    if (!request.itemQuery) return 'Sell what? Use: sell <item> [quantity].';
+
+    const found = findItemInContainer(inventoryState, 'inventory', request.itemQuery);
+    if (!found.ok) return found.reason;
+
+    const eligibility = canSellItem(found.item, { shopPoi, catalog });
+    if (!eligibility.ok) return eligibility.reason;
+
+    const removeResult = removeItemQuantityFromContainer(inventoryState, 'inventory', request.itemQuery, request.quantity);
+    if (!removeResult.ok) return removeResult.reason;
+
+    const gilEarned = eligibility.sellValueGil * removeResult.quantity;
+    state.player.wallet.gil = (state.player.wallet.gil ?? 0) + gilEarned;
+    discoverPoi(state, shopPoi);
+
+    return [
+        `Sold ${removeResult.item.name}${removeResult.quantity > 1 ? ` x${removeResult.quantity}` : ''} for ${gilEarned} gil.`,
+        `Gil now: ${state.player.wallet.gil}`,
+    ].join('\n');
 }
 
 function findCurrentShopPoi(state, shopQuery = '') {
@@ -53,6 +82,17 @@ function findCatalogItem(catalog, itemQuery) {
     const normalized = normalize(itemQuery);
     if (!normalized) return null;
     return catalog.items.find((item) => normalize(item.id) === normalized || normalize(item.name).includes(normalized)) ?? null;
+}
+
+function parseSellRequest(itemQuery) {
+    const text = String(itemQuery ?? '').trim();
+    if (!text) return { itemQuery: '', quantity: 1 };
+    const match = text.match(/^(.*?)(?:\s+x?(\d+))$/i);
+    if (!match || !match[1].trim()) return { itemQuery: text, quantity: 1 };
+    return {
+        itemQuery: match[1].trim(),
+        quantity: Math.max(1, Number.parseInt(match[2], 10) || 1),
+    };
 }
 
 function createInventoryItemFromShopItem(item, shopPoi, catalog) {

--- a/js/text/version.js
+++ b/js/text/version.js
@@ -1,5 +1,5 @@
 export const VERSION = Object.freeze({
-    app: '0.4.2',
+    app: '0.4.3',
     accountSave: 4,
     gameState: 3,
     data: 13,
@@ -13,7 +13,7 @@ export const VERSION = Object.freeze({
 });
 
 export const SYSTEM_VERSIONS = Object.freeze({
-    commandShell: '0.4.2',
+    commandShell: '0.4.3',
     canvasUi: '0.7.0',
     uiIntents: '0.1.1',
     slashCommands: '0.4.1',
@@ -49,17 +49,18 @@ export const SYSTEM_VERSIONS = Object.freeze({
     poiDiscovery: '0.3.5',
     poiFastTravel: '0.3.5',
     zoneFastTravel: '0.3.5',
-    shops: '0.3.7',
-    shopTransactions: '0.3.7',
+    shops: '0.3.8',
+    shopTransactions: '0.3.8',
     guilds: '0.3.5',
     questHooks: '0.3.5',
     inventoryContainers: '0.5.1',
     inventoryTransfers: '0.5.1',
     itemSchema: '0.6.0',
+    itemBehavior: '0.1.0',
     itemStacking: '0.5.1',
     equipmentCommands: '0.5.0',
     equipmentEligibility: '0.5.0',
-    itemInspection: '0.5.0',
+    itemInspection: '0.5.1',
     equipmentCatalog: '0.6.0',
     skillCaps: '0.5.1',
     mogHouseStorage: '0.3.8',

--- a/js/text/version.js
+++ b/js/text/version.js
@@ -4,7 +4,7 @@ export const VERSION = Object.freeze({
     gameState: 3,
     data: 13,
     benchmark: 1,
-    codename: 'San d’Oria Coordinate Compass',
+    codename: 'Item Behavior Selling',
     compatibility: 'no-backwards-compatibility',
     released: false,
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffxi-text-rpg",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "description": "Text-only RPG foundation inspired by Final Fantasy XI systems.",

--- a/tests/equipmentEngine.test.js
+++ b/tests/equipmentEngine.test.js
@@ -257,6 +257,55 @@ test('item inspection shows requirements flags effects and confidence notes', ()
     assert.match(output, /weaponDelay: placeholder/);
 });
 
+test('item inspection shows behavior metadata for latent enchantment charges and ranged ammo', () => {
+    const state = createInitialState();
+    addItemToContainer(state.player.inventoryState, 'inventory', {
+        id: 'training-bow',
+        name: 'Training Bow',
+        kind: 'equipment',
+        equipmentSlot: 'ranged',
+        allowedSlots: ['ranged'],
+        weaponCategory: 'bow',
+        weaponDelay: 360,
+        valueGil: 120,
+        tags: ['weapon', 'ranged'],
+        flags: ['equipmentOnly', 'rangedWeapon', 'latent', 'enchantment', 'chargeBased'],
+        latentEffects: [{
+            id: 'latent-clear-weather',
+            condition: { weather: 'clear' },
+            modifiers: { derived: { accuracy: 2 } },
+            confidence: 'intentionalSimplification',
+            source: 'test fixture',
+            notes: 'Metadata only.',
+        }],
+        enchantments: [{
+            id: 'enchantment-focus',
+            type: 'temporaryModifier',
+            modifiers: { derived: { rangedAccuracy: 3 } },
+            confidence: 'placeholder',
+            source: 'test fixture',
+        }],
+        charges: {
+            max: 3,
+            current: 2,
+            recastSeconds: 60,
+            cooldownSeconds: 30,
+            confidence: 'placeholder',
+            source: 'test fixture',
+        },
+    });
+
+    const output = inspectItem(state, 'Training Bow');
+
+    assert.match(output, /Behavior metadata:/);
+    assert.match(output, /selling: allowed, estimated 60 gil each/);
+    assert.match(output, /ranged\/ammo: markers=rangedWeapon flag, ranged tag, ranged slot/);
+    assert.match(output, /latent latent-clear-weather: condition=\{"weather":"clear"\}/);
+    assert.match(output, /modifiers=derived\(accuracy \+2\)/);
+    assert.match(output, /enchantment enchantment-focus: type=temporaryModifier/);
+    assert.match(output, /charges: 2\/3, recast 60s, cooldown 30s/);
+});
+
 test('item inspection searches accessible non-wardrobe containers for consumables and materials', () => {
     const state = createInitialState();
     const inventoryState = state.player.inventoryState;

--- a/tests/itemBehaviorEngine.test.js
+++ b/tests/itemBehaviorEngine.test.js
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    calculateSellValue,
+    canSellItem,
+    describeItemBehavior,
+    describeRangedAmmoBehavior,
+} from '../js/text/systems/itemBehaviorEngine.js';
+
+test('item behavior selling allows metadata-only trade restrictions by default', () => {
+    const item = {
+        id: 'auction-tagged-hide',
+        name: 'Auction Tagged Hide',
+        kind: 'material',
+        valueGil: 9,
+        flags: ['noTrade', 'noDrop', 'noAuction'],
+    };
+
+    const result = canSellItem(item);
+    const description = describeItemBehavior(item);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.sellValueGil, 4);
+    assert.match(description, /metadata-only restrictions: noTrade, noDrop, noAuction/);
+    assert.match(description, /not enforced for shop selling yet/);
+});
+
+test('item behavior sell value is conservative with minimum one gil for valued items', () => {
+    assert.equal(calculateSellValue({ id: 'tiny-shell', name: 'Tiny Shell', kind: 'material', valueGil: 1 }), 1);
+    assert.equal(calculateSellValue({ id: 'wild-rabbit-hide', name: 'Wild Rabbit Hide', kind: 'material', valueGil: 8 }), 4);
+});
+
+test('item behavior describes ranged and ammo metadata without combat wiring', () => {
+    const description = describeRangedAmmoBehavior({
+        id: 'training-arrow',
+        name: 'Training Arrow',
+        kind: 'equipment',
+        equipmentSlot: 'ammo',
+        flags: ['ammo'],
+        tags: ['ammo'],
+    });
+
+    assert.match(description, /ammo flag/);
+    assert.match(description, /ammo tag/);
+    assert.match(description, /ammo slot/);
+});

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -8,20 +8,22 @@ import { describeSystemVersions, describeVersion, VERSION } from '../js/text/ver
 
 
 test('version manifest exposes explicit app account save game state data and benchmark versions', () => {
-    assert.equal(VERSION.app, '0.4.2');
+    assert.equal(VERSION.app, '0.4.3');
     assert.equal(VERSION.accountSave, 4);
     assert.equal(VERSION.gameState, 3);
     assert.equal(VERSION.data, 13);
     assert.equal(VERSION.benchmark, 1);
     assert.equal(VERSION.save, VERSION.accountSave);
-    assert.match(describeVersion(), /App: 0.4.2/);
+    assert.match(describeVersion(), /App: 0.4.3/);
     assert.match(describeVersion(), /Account Save: 4/);
     assert.match(describeVersion(), /Game State: 3/);
     assert.match(describeSystemVersions(), /characterCreation/);
     assert.match(describeSystemVersions(), /canvasUi: 0.7.0/);
     assert.match(describeSystemVersions(), /battleRewards: 0.5.2/);
     assert.match(describeSystemVersions(), /itemSchema: 0.6.0/);
+    assert.match(describeSystemVersions(), /itemBehavior: 0.1.0/);
     assert.match(describeSystemVersions(), /equipmentEligibility: 0.5.0/);
+    assert.match(describeSystemVersions(), /shopTransactions: 0.3.8/);
     assert.match(describeSystemVersions(), /skillCaps: 0.5.1/);
     assert.match(describeSystemVersions(), /skillProgression: 0.5.1/);
     assert.match(describeSystemVersions(), /leveling: 0.5.3/);

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -17,6 +17,7 @@ test('version manifest exposes explicit app account save game state data and ben
     assert.match(describeVersion(), /App: 0.4.3/);
     assert.match(describeVersion(), /Account Save: 4/);
     assert.match(describeVersion(), /Game State: 3/);
+    assert.match(describeVersion(), /Codename: Item Behavior Selling/);
     assert.match(describeSystemVersions(), /characterCreation/);
     assert.match(describeSystemVersions(), /canvasUi: 0.7.0/);
     assert.match(describeSystemVersions(), /battleRewards: 0.5.2/);

--- a/tests/shopEngine.test.js
+++ b/tests/shopEngine.test.js
@@ -136,6 +136,81 @@ test('sellToCurrentShop removes one stack item by default and adds gil after rem
     assert.equal(state.player.wallet.gil, 14);
 });
 
+test('sellToCurrentShop does not misparse +1 item names as quantity', () => {
+    const state = createInitialState();
+    moveToAshene(state);
+    state.player.wallet.gil = 10;
+    addItemToContainer(state.player.inventoryState, 'inventory', {
+        id: 'bronze-harness-plus-one',
+        name: 'Bronze Harness +1',
+        kind: 'equipment',
+        valueGil: 120,
+    });
+
+    const result = sellToCurrentShop(state, 'Bronze Harness +1');
+
+    assert.match(result, /Sold Bronze Harness \+1 for 60 gil/);
+    assert.equal(state.player.wallet.gil, 70);
+    assert.equal(state.player.inventory.length, 0);
+});
+
+test('sellToCurrentShop supports explicit x quantity syntax', () => {
+    const state = createInitialState();
+    moveToAshene(state);
+    state.player.wallet.gil = 10;
+    addItemToContainer(state.player.inventoryState, 'inventory', {
+        id: 'wild-rabbit-hide',
+        name: 'Wild Rabbit Hide',
+        kind: 'material',
+        quantity: 3,
+        valueGil: 8,
+    });
+
+    const result = sellToCurrentShop(state, 'Wild Rabbit Hide x2');
+
+    assert.match(result, /Sold Wild Rabbit Hide x2 for 8 gil/);
+    assert.equal(state.player.wallet.gil, 18);
+    assert.equal(state.player.inventory[0].quantity, 1);
+});
+
+test('sellToCurrentShop supports explicit qty quantity syntax', () => {
+    const state = createInitialState();
+    moveToAshene(state);
+    state.player.wallet.gil = 10;
+    addItemToContainer(state.player.inventoryState, 'inventory', {
+        id: 'wild-rabbit-hide',
+        name: 'Wild Rabbit Hide',
+        kind: 'material',
+        quantity: 3,
+        valueGil: 8,
+    });
+
+    const result = sellToCurrentShop(state, 'Wild Rabbit Hide qty 2');
+
+    assert.match(result, /Sold Wild Rabbit Hide x2 for 8 gil/);
+    assert.equal(state.player.wallet.gil, 18);
+    assert.equal(state.player.inventory[0].quantity, 1);
+});
+
+test('sellToCurrentShop treats bare trailing numbers as part of the item name', () => {
+    const state = createInitialState();
+    moveToAshene(state);
+    state.player.wallet.gil = 10;
+    addItemToContainer(state.player.inventoryState, 'inventory', {
+        id: 'numbered-hide-5',
+        name: 'Numbered Hide 5',
+        kind: 'material',
+        quantity: 1,
+        valueGil: 20,
+    });
+
+    const result = sellToCurrentShop(state, 'Numbered Hide 5');
+
+    assert.match(result, /Sold Numbered Hide 5 for 10 gil/);
+    assert.equal(state.player.wallet.gil, 20);
+    assert.equal(state.player.inventory.length, 0);
+});
+
 test('sellToCurrentShop does not add gil when quantity removal fails', () => {
     const state = createInitialState();
     moveToAshene(state);
@@ -148,7 +223,7 @@ test('sellToCurrentShop does not add gil when quantity removal fails', () => {
         valueGil: 8,
     });
 
-    const result = sellToCurrentShop(state, 'Wild Rabbit Hide 5');
+    const result = sellToCurrentShop(state, 'Wild Rabbit Hide x5');
 
     assert.match(result, /Only 2 Wild Rabbit Hide available/);
     assert.equal(state.player.wallet.gil, 10);

--- a/tests/shopEngine.test.js
+++ b/tests/shopEngine.test.js
@@ -5,7 +5,8 @@ import { createCommandRouter } from '../js/text/commandRouter.js';
 import { createInitialState } from '../js/text/gameState.js';
 import { getPoisForPlace } from '../js/text/data/pointsOfInterest.js';
 import { setPositionAndDiscover } from '../js/text/systems/atlasEngine.js';
-import { buyFromCurrentShop } from '../js/text/systems/shopEngine.js';
+import { addItemToContainer } from '../js/text/systems/inventoryEngine.js';
+import { buyFromCurrentShop, sellToCurrentShop } from '../js/text/systems/shopEngine.js';
 
 function moveToAshene(state) {
     const ashene = getPoisForPlace('southern-sandoria').find((poi) => poi.name === 'Ashene');
@@ -61,6 +62,118 @@ test('buyFromCurrentShop respects inventory capacity', () => {
     assert.equal(inventory.length, 30);
 });
 
+test('sellToCurrentShop rejects noSell item without mutating inventory or gil', () => {
+    const state = createInitialState();
+    moveToAshene(state);
+    state.player.wallet.gil = 10;
+    addItemToContainer(state.player.inventoryState, 'inventory', {
+        id: 'royal-keepsake',
+        name: 'Royal Keepsake',
+        kind: 'misc',
+        valueGil: 100,
+        flags: ['noSell'],
+    });
+
+    const result = sellToCurrentShop(state, 'Royal Keepsake');
+
+    assert.match(result, /noSell/);
+    assert.equal(state.player.wallet.gil, 10);
+    assert.equal(state.player.inventory.length, 1);
+});
+
+test('sellToCurrentShop rejects key items', () => {
+    const state = createInitialState();
+    moveToAshene(state);
+    addItemToContainer(state.player.inventoryState, 'inventory', {
+        id: 'gate-pass',
+        name: 'Gate Pass',
+        kind: 'keyItem',
+        valueGil: 100,
+    });
+
+    const result = sellToCurrentShop(state, 'Gate Pass');
+
+    assert.match(result, /key item/i);
+    assert.equal(state.player.inventory.length, 1);
+});
+
+test('sellToCurrentShop rejects zero-value items unless explicitly allowed', () => {
+    const state = createInitialState();
+    moveToAshene(state);
+    state.player.wallet.gil = 5;
+    addItemToContainer(state.player.inventoryState, 'inventory', {
+        id: 'weathered-note',
+        name: 'Weathered Note',
+        kind: 'misc',
+        valueGil: 0,
+    });
+
+    const result = sellToCurrentShop(state, 'Weathered Note');
+
+    assert.match(result, /no vendor value/i);
+    assert.equal(state.player.wallet.gil, 5);
+    assert.equal(state.player.inventory.length, 1);
+});
+
+test('sellToCurrentShop removes one stack item by default and adds gil after removal', () => {
+    const state = createInitialState();
+    moveToAshene(state);
+    state.player.wallet.gil = 10;
+    addItemToContainer(state.player.inventoryState, 'inventory', {
+        id: 'wild-rabbit-hide',
+        name: 'Wild Rabbit Hide',
+        kind: 'material',
+        quantity: 3,
+        valueGil: 8,
+    });
+
+    const result = sellToCurrentShop(state, 'Wild Rabbit Hide');
+
+    assert.match(result, /Sold Wild Rabbit Hide for 4 gil/);
+    assert.match(result, /Gil now: 14/);
+    assert.equal(state.player.inventory.length, 1);
+    assert.equal(state.player.inventory[0].quantity, 2);
+    assert.equal(state.player.wallet.gil, 14);
+});
+
+test('sellToCurrentShop does not add gil when quantity removal fails', () => {
+    const state = createInitialState();
+    moveToAshene(state);
+    state.player.wallet.gil = 10;
+    addItemToContainer(state.player.inventoryState, 'inventory', {
+        id: 'wild-rabbit-hide',
+        name: 'Wild Rabbit Hide',
+        kind: 'material',
+        quantity: 2,
+        valueGil: 8,
+    });
+
+    const result = sellToCurrentShop(state, 'Wild Rabbit Hide 5');
+
+    assert.match(result, /Only 2 Wild Rabbit Hide available/);
+    assert.equal(state.player.wallet.gil, 10);
+    assert.equal(state.player.inventory.length, 1);
+    assert.equal(state.player.inventory[0].quantity, 2);
+});
+
+test('sellToCurrentShop requires a current shop POI', () => {
+    const state = createInitialState();
+    state.player.wallet.gil = 10;
+    addItemToContainer(state.player.inventoryState, 'inventory', {
+        id: 'wild-rabbit-hide',
+        name: 'Wild Rabbit Hide',
+        kind: 'material',
+        quantity: 1,
+        valueGil: 8,
+    });
+
+    const result = sellToCurrentShop(state, 'Wild Rabbit Hide');
+
+    assert.match(result, /no matching shop/i);
+    assert.equal(state.player.wallet.gil, 10);
+    assert.equal(state.player.inventory.length, 1);
+});
+
 test('router exposes buy and sell commands', () => {
     const state = createInitialState();
     moveToAshene(state);
@@ -74,5 +187,6 @@ test('router exposes buy and sell commands', () => {
     assert.match(router('shop Ashene'), /Bronze Sword/);
     assert.match(router('buy Bronze Sword'), /Bought Bronze Sword/);
     assert.match(router('inventory'), /Bronze Sword/);
-    assert.match(router('sell Bronze Sword'), /Selling is not implemented/);
+    assert.match(router('sell Bronze Sword'), /Sold Bronze Sword for 38 gil/);
+    assert.match(router('inventory'), /empty/);
 });


### PR DESCRIPTION
## Summary
- Adds `itemBehaviorEngine` helpers for sell eligibility, conservative sell value, item behavior summaries, latent effect metadata, enchantment metadata, charge metadata, and ranged/ammo metadata.
- Keeps latent effects, enchantments, charges, and ranged/ammo records as inspection metadata only; this PR does not wire them into combat formulas or action execution.
- Adds safe Inventory quantity removal support so selling can decrement stacks or remove single items through the container state.

## Selling rules implemented
- Replaces the `sellToCurrentShop` placeholder with conservative shop selling support.
- Requires a current shop POI and an Inventory item match.
- Rejects key items, `noSell` items, and zero-value items unless explicitly allowed by vendor context.
- Uses `floor(valueGil * 0.5)` as default sell value, with a minimum of 1 gil when `valueGil > 0`.
- Sells one item by default and supports explicit trailing quantity syntax with `x<number>` or `qty <number>`.
- Does not treat bare trailing numbers as quantity, preserving item names such as `Bronze Harness +1` and numbered item names.
- Removes/decrements item quantity before crediting gil, so wallet changes happen only after successful removal.
- Leaves `noTrade`, `noDrop`, and `noAuction` as metadata-only notes rather than enforced sale restrictions in this pass.

## Item inspection metadata added
- Adds a Behavior metadata section to item inspection output.
- Shows sell restrictions/value estimates, metadata-only trade/drop/auction flags, latent effect details, enchantment details, charges, and ranged/ammo markers where present.
- Preserves existing confidence/source notes.

## Version bump
- App/package: `0.4.2` -> `0.4.3`.
- Codename: `Item Behavior Selling`.
- `itemBehavior`: `0.1.0`.
- `itemInspection`: `0.5.1`.
- `shops` / `shopTransactions`: `0.3.8`.
- `gameState` remains `3`; `data` remains `13`.

## Tests/checks run
- `npm.cmd test` passed, 225/225.
- `npm.cmd run benchmark` passed.
- `npm.cmd run check` passed.
- `git diff --check` passed.

## Docs updated
- Updated README, CHANGELOG, ROADMAP, ARCHITECTURE, and THREAD_HANDOFF for item behavior metadata and conservative shop selling.
- Fixed stale THREAD_HANDOFF localStorage key references to mention `ffxiTextRpgAccounts` and `ffxiTextRpgAccountSession`.
- Clarified THREAD_HANDOFF world/travel wording around San d'Oria topology coordinates versus legacy numeric grids.
- Updated ARCHITECTURE so battle rewards are no longer described as unimplemented.

## Known limitations
- Latent effects, enchantments, charges, and ranged/ammo behavior are metadata-only and are not applied to combat formulas yet.
- Key-item item records and deeper unlock/permission validation remain future work.
- Vendor-specific buyback, per-vendor restrictions, reputation/fame pricing, and exact retail economy behavior are not implemented.
- `noTrade`, `noDrop`, and `noAuction` are described but not enforced as selling restrictions yet.