### PR TITLE
Add conservative skill gain hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ All notable reset-branch changes are tracked here.
 - Starter equipment catalog with conservative stat modifiers, placeholder weapon delay metadata, and intentional-simplification requirement notes.
 - Sparse skill rank/cap foundation with `getSkillCap` and `getEffectiveSkill` helpers for later combat and magic skill work.
 - Character-owned skill progression storage under `player.progression.skills[skillId]`.
+- Conservative skill-gain resolver helpers for main-hand, ranged/ammo, and placeholder spell skill inference.
+- Deterministic +1 learned skill hooks for basic attacks, placeholder weapon skills, and placeholder spell casts, with concise battle-log output only when a skill increases.
 - Text-first `skills`, `skill <id>`, `inspect skills`, and `inspect skill <id>` command output.
 - Validation for flat character-owned skill ids and non-negative integer skill values, including explicit rejection of nested job-keyed skill maps.
 - Equipment catalog validation for requirement shapes, unknown jobs/races/slots, array-based flags/effects, modifier keys, and required confidence/source metadata.
@@ -80,7 +82,7 @@ All notable reset-branch changes are tracked here.
 - `inspect <target>` command for player, stats, inventory, NPC, enemy, state, log, version, systems, database, maps, zone, atlas, grid, travel, controls, and storage inspection.
 - `validate` command for current state validation.
 - `version`, `systems`, `databases`, `tick`, `maps`, `map`, `zones`, `zone`, `atlas`, `grid`, `move`, `controls`, `travel`, `wait`, `containers`, `container`, `transfer`, `equip`, `unequip`, `equipSources`, `here`, `talk`, `shop`, `buy`, `guild`, `quest`, `discovered`, `fastpoi`, and `zonefast` commands.
-- Node test coverage for command parsing, validation, entity factories, stat calculations, baseline pipeline, versioning, database registry, tick dispatch, zone graph, starter maps, world-data validation, travel flow, atlas discovery, controls, aggro checks, POI discovery, shop transactions, inventory transfers, equipment commands, save accounts, slash commands, UI panel helpers, deterministic RNG, battle rewards, item schema/stacking, and basic battle flow.
+- Node test coverage for command parsing, validation, entity factories, stat calculations, baseline pipeline, versioning, database registry, tick dispatch, zone graph, starter maps, world-data validation, travel flow, atlas discovery, controls, aggro checks, POI discovery, shop transactions, inventory transfers, equipment commands, save accounts, slash commands, UI panel helpers, deterministic RNG, battle rewards, item schema/stacking, basic battle flow, and conservative skill gains from combat actions.
 - Node test coverage for canvas UI action mapping, clickable layout bounds, hit testing, command dispatch, keyboard input, and command history.
 - Node test coverage for equipment eligibility rejections, atomic failed equips, two-handed/offhand conflicts, item inspection, equipment catalog validation, and skill cap helpers.
 - Architecture, roadmap, baseline pipeline, system catalog, research reference, and thread handoff documents for the rebuild.
@@ -97,9 +99,9 @@ All notable reset-branch changes are tracked here.
 - Updated shell intro text to guide users toward `/menu`, `/newcharacter`, `/commands`, and `/help`.
 - Rebuilt initial game state around structured player, NPC, enemy, place, coordinate, atlas, map, travel, inventory, item, POI, and account-save state.
 - Refactored command routing to operate on parsed command objects instead of whole-command strings.
-- Updated app/package version to `0.4.3`, account save version to `4`, game state version to `3`, data version to `13`, and codename to `Item Behavior Selling`.
+- Updated app/package version to `0.4.4`, account save version to `4`, game state version to `3`, data version to `13`, and codename to `Conservative Skill Gains`.
 - Replaced San d’Oria placeholder numeric city grids with alphanumeric topology coordinates and direction-aware exits.
-- Updated data/system version tracking for item schema, item behavior, equipment catalog, equipment eligibility, item inspection, shop transactions, validation, skill caps, and skill progression.
+- Updated data/system version tracking for item schema, item behavior, equipment catalog, equipment eligibility, item inspection, shop transactions, validation, skill caps, skill progression, and combat actions.
 - Added `canvasUi` system version tracking.
 - Updated `getEffectiveSkill` to read character-owned skill values and report missing skills as current value `0` against the active job cap.
 - Refreshed README, roadmap, and handoff documentation for the current post-0.5 foundation state.
@@ -114,5 +116,5 @@ All notable reset-branch changes are tracked here.
 - Backwards compatibility with the old browser UI and old save shape is intentionally not preserved beyond the current raw-save migration path.
 - `base64-json-v1` save storage is encoded, not strong encryption.
 - Current formulas are conservative approximations until exact researched formulas are migrated deliberately.
-- `skillCaps.js` remains scaffold-only and is not wired into combat or magic calculations.
-- Current recommended next pass is conservative skill plumbing and deeper item behavior application: isolated skill-gain hooks, skill-cap formula wiring, and tests. Latent/enchantment/charge/ranged-ammo behavior remains metadata-only until action semantics are explicit.
+- `skillCaps.js` remains formula-scaffold-only: skill gains can clamp against current job caps, but learned/effective skill values are not wired into combat or magic calculations.
+- Current recommended next pass is conservative formula and item behavior application planning: skill-cap formula wiring and metadata behavior application should remain scoped and tested. Latent/enchantment/charge/ranged-ammo behavior remains metadata-only until action semantics are explicit.

--- a/README.md
+++ b/README.md
@@ -2,20 +2,20 @@
 
 A text-only RPG foundation inspired by Final Fantasy XI systems.
 
-This branch intentionally resets the project around a stable canvas-first text shell, structured entities, account/character save slots, conservative stat engines, parser-backed commands, validation helpers, version tracking, benchmarks, a database registry, seeded world graph, starter city maps, alphanumeric San d’Oria coordinate topology, coordinate atlas, travel scaffold, compass navigation controls, inventory/storage containers, item schema and stacking, POI discovery, starter shops/guild hooks, equipment commands and eligibility checks, deterministic combat, battle rewards, EXP tables, level-up rules, character-owned skill progression scaffolding, skill-cap scaffolding, and implementation-first documentation.
+This branch intentionally resets the project around a stable canvas-first text shell, structured entities, account/character save slots, conservative stat engines, parser-backed commands, validation helpers, version tracking, benchmarks, a database registry, seeded world graph, starter city maps, alphanumeric San d’Oria coordinate topology, coordinate atlas, travel scaffold, compass navigation controls, inventory/storage containers, item schema and stacking, POI discovery, starter shops/guild hooks, equipment commands and eligibility checks, deterministic combat, battle rewards, EXP tables, level-up rules, character-owned skill progression scaffolding, isolated skill-gain hooks, skill-cap scaffolding, and implementation-first documentation.
 
 Backwards compatibility with the previous UI/save shape is not considered until explicitly reintroduced.
 
-This pass adds item behavior inspection helpers and conservative shop selling. Latent effects, enchantments, charges, and ranged/ammo behavior remain metadata-only and are not wired into combat formulas yet.
+This pass adds conservative skill-gain hooks for basic attacks, placeholder weapon skills, and placeholder spell casts. Skill gains update character-owned learned values and battle-log text, but learned skill values are not wired into damage, accuracy, magic, enemy AI, or item behavior formulas yet.
 
 ## Current version
 
 ```text
-App/package: 0.4.3
+App/package: 0.4.4
 Account Save: 4
 Game State: 3
 Data: 13
-Codename: Item Behavior Selling
+Codename: Conservative Skill Gains
 ```
 
 `VERSION.save` remains as a backward-compatible alias for `VERSION.accountSave` while callers migrate to the clearer name.
@@ -322,7 +322,7 @@ docs/
 - Attribute/resource/derived-stat/skill/equipment/currency constants.
 - Conservative stat calculation engine.
 - Character-owned current skill storage under `player.progression.skills[skillId]`.
-- Sparse skill rank/cap helper data and text-first `skills`, `skill <id>`, `inspect skills`, and `inspect skill <id>` commands for future combat and magic skill progression.
+- Sparse skill rank/cap helper data, deterministic +1 skill-gain hooks for eligible combat actions, and text-first `skills`, `skill <id>`, `inspect skills`, and `inspect skill <id>` commands for current learned skill inspection.
 - Simple battle-state engine with deterministic RNG injection.
 - Battle reward resolution for EXP, gil, loot rolls, Inventory insertion, duplicate payout prevention, and progression engine integration.
 - Conservative EXP table data, level-up rules, EXP-to-next tracking, level-cap behavior, and HP/MP/resource refresh after level-up.
@@ -350,9 +350,9 @@ Current formulas are conservative placeholders. They exist to make the architect
 
 ## Current next best pass
 
-The current recommended next pass is conservative skill plumbing and deeper item behavior application:
+The current recommended next pass is conservative formula and item-behavior application planning:
 
 1. Keep latent effects, enchantments, charges, and ranged/ammo behavior metadata inspection-only until combat and action semantics are explicit.
-2. Add isolated skill-gain hooks only after the character-owned skill-state rules are covered.
-3. Wire skill caps into combat and magic calculations only after current skill state, gain flow, and formula confidence are explicit.
+2. Wire skill caps into combat and magic calculations only after current skill state, gain flow, and formula confidence are explicit.
+3. Keep skill-gain pacing deterministic until a tested RNG policy is introduced.
 4. Add key-item item records and unlock/permission validation.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -150,6 +150,7 @@ js/text/
     menuDescriptions.js
     poiEngine.js
     shopEngine.js
+    skillProgressionEngine.js
     statEngine.js
     statusEngine.js
     statFormulaDescriptions.js
@@ -236,7 +237,9 @@ Equipment catalog entries are static templates. Runtime inventory records remain
 
 ### Skill caps
 
-`js/text/data/skillCaps.js` owns the current sparse skill rank/cap scaffold. It exposes `getSkillCap(jobId, skillId, level)` and `getEffectiveSkill(player, skillId)` for future combat and magic integration. The cap formula is explicitly placeholder metadata, so battle and command handlers should not bake it in as exact FFXI behavior.
+`js/text/data/skillCaps.js` owns the current sparse skill rank/cap scaffold. It exposes `getSkillCap(jobId, skillId, level)` and `getEffectiveSkill(player, skillId)` for skill inspection, conservative gain clamping, and future combat/magic integration. The cap formula is explicitly placeholder metadata, so battle and command handlers should not bake it in as exact FFXI behavior.
+
+`js/text/systems/skillProgressionEngine.js` owns character skill state and conservative gain resolution. It can infer main-hand, ranged/ammo, and placeholder spell skills, then add deterministic +1 learned skill for eligible combat actions while clamping to the current main-job cap. These learned/effective skill values are not used in damage, accuracy, magic potency, enemy AI, or item behavior formulas yet.
 
 ### POI engine
 
@@ -266,7 +269,7 @@ The battle engine owns battle-local state:
 - magic burst placeholder
 - log
 
-Combat actions and battle rewards exist. Rewards currently cover victory EXP, gil, deterministic loot rolls, Inventory insertion through container rules, failed loot storage reporting, progression integration, and duplicate payout prevention.
+Combat actions and battle rewards exist. Player basic attacks, placeholder weapon skills, and placeholder spell casts may append concise skill-gain log lines after eligible actions. Rewards currently cover victory EXP, gil, deterministic loot rolls, Inventory insertion through container rules, failed loot storage reporting, progression integration, and duplicate payout prevention.
 
 ### Status engine
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -119,8 +119,8 @@ Target: 0.5.x.
 - [x] Combat and magic skill cap data-helper foundation.
 - [x] Character-owned current skill state and inspection commands.
 - [x] Validation for flat `player.progression.skills[skillId]` values.
+- [x] Isolated deterministic skill-gain hooks for basic attacks, placeholder weapon skills, and placeholder spell casts.
 - [ ] Wire combat and magic skill caps into formulas.
-- [ ] Skill gain hooks.
 - [ ] Progression flags for maps, teleport points, mounts, trusts, quests, missions, achievements.
 
 ## Phase 6: Combat, enemies, loot, and drops
@@ -219,9 +219,9 @@ Target: ongoing.
 
 ## Current recommended next pass
 
-The next best implementation pass is conservative skill plumbing and deeper item behavior application:
+The next best implementation pass is conservative formula and item behavior application planning:
 
 1. Keep latent effects, enchantments, charges, and ranged/ammo records metadata-only until action/combat semantics are explicit.
-2. Add isolated skill-gain hooks only after the character-owned skill-state rules are covered.
-3. Wire skill caps into combat and magic formulas only after current skill state, skill-gain flow, and confidence labels are explicit.
+2. Wire skill caps into combat and magic formulas only after current skill state, skill-gain flow, and confidence labels are explicit.
+3. Keep skill-gain pacing deterministic until a tested RNG policy is introduced.
 4. Add validation/tests before expanding loot tables or applying item behavior in combat.

--- a/docs/THREAD_HANDOFF.md
+++ b/docs/THREAD_HANDOFF.md
@@ -35,11 +35,11 @@ js/text/version.js
 Current state at handoff:
 
 ```text
-App/package: 0.4.3
+App/package: 0.4.4
 Account Save: 4
 Game State: 3
 Data: 13
-Codename: Item Behavior Selling
+Codename: Conservative Skill Gains
 ```
 
 Major active system versions:
@@ -62,9 +62,9 @@ inventoryTransfers: 0.5.1
 itemSchema: 0.6.0
 itemStacking: 0.5.1
 skillCaps: 0.5.1
-skillProgression: 0.5.1
+skillProgression: 0.5.2
 battleEngine: 0.5.0
-combatActions: 0.5.0
+combatActions: 0.5.1
 battleRewards: 0.5.2
 progression: 0.5.3
 expTables: 0.5.2
@@ -336,9 +336,10 @@ Rules:
 - Container transfers are atomic and enforce source access, destination access, capacity, item-kind, and stack rules.
 - Inventory quantity removal is used by shop selling so gil is credited only after item removal succeeds.
 - Latent effects, enchantments, charges, and ranged/ammo behavior are inspectable metadata only; they are not wired into combat formulas yet.
-- Sparse skill rank/cap helpers exist for later combat and magic skill progression.
+- Sparse skill rank/cap helpers exist for current skill-gain clamping and later combat/magic formula integration.
 - Character-owned current skills live in `player.progression.skills[skillId]`. Do not reintroduce per-job skill storage maps.
 - `skills`, `skill <id>`, `inspect skills`, and `inspect skill <id>` describe current character-owned skill values against the active main-job cap scaffold.
+- Basic attacks, placeholder weapon skills, and placeholder spell casts can add deterministic +1 learned skill when the active main job has room under its current cap.
 
 Temporary limitation: Mog House is currently a boolean access context, not a real zone/interior yet.
 
@@ -384,6 +385,7 @@ Implemented:
 - deterministic RNG injection for battle attacks and tests
 - basic attack flow
 - placeholder weapon skill/cast commands
+- deterministic skill-gain hooks for basic attacks, placeholder weapon skills, and placeholder spell casts
 - starter loot tables
 - victory reward resolution for EXP, gil, loot rolls, Inventory insertion, and duplicate payout prevention
 - status lifecycle scaffold
@@ -394,7 +396,7 @@ Not implemented yet:
 - enemy AI turn depth
 - death/KO flow
 - real magic/recast/cast-time integration
-- combat/magic skill-up pacing and skill-cap use in damage or magic formulas
+- random/retail-like skill-up pacing and skill-cap use in damage or magic formulas
 
 ## Important tests
 
@@ -410,8 +412,10 @@ tests/rewardEngine.test.js
 tests/rngEngine.test.js
 tests/shopEngine.test.js
 tests/skillCaps.test.js
+tests/skillProgressionEngine.test.js
 tests/skillCommandRouter.test.js
 tests/skillProgressionValidation.test.js
+tests/combatActionEngine.test.js
 tests/poiEngine.test.js
 tests/travelEngine.test.js
 tests/atlasAndControls.test.js
@@ -443,14 +447,14 @@ docs/RESEARCH_REFERENCES.md
 
 ## Current recommended next pass
 
-The next best implementation pass is conservative skill plumbing and deeper item behavior application:
+The next best implementation pass is conservative formula and item behavior application planning:
 
 1. Keep latent effects, enchantments, charges, and ranged/ammo records metadata-only until their action/combat semantics are explicit.
-2. Add isolated skill-gain hooks, but avoid random pacing until the rule is tested and confidence-labeled.
-3. Decide how skill caps feed combat and magic formulas before touching battle command handlers.
+2. Decide how skill caps feed combat and magic formulas before using learned/effective skill values in formulas.
+3. Keep skill-gain pacing deterministic unless a tested RNG policy is added.
 4. Keep formula-sensitive values labeled as exact, approximate, simplified, or placeholder.
 
-Important: `skillCaps.js` is scaffold-only. Even though current skills now live on the character, do not wire those caps into combat or magic calculations until current skill semantics and the cap/skill-gain flow are covered by tests.
+Important: `skillCaps.js` still should not be treated as exact retail formula data. Current skills now live on the character and can increase through isolated hooks, but do not wire those caps into combat or magic calculations until the formula semantics are explicitly designed and tested.
 
 ## Rules for future agents
 

--- a/js/text/systems/combatActionEngine.js
+++ b/js/text/systems/combatActionEngine.js
@@ -5,6 +5,7 @@ import {
     performBasicAttack,
 } from './battleEngine.js';
 import { resolveBattleRewards } from './rewardEngine.js';
+import { describeSkillGainResult, resolveSkillGainForAction } from './skillProgressionEngine.js';
 
 export function startEncounter(state, enemyId, options = {}) {
     if (state.activeBattle?.phase === 'active') {
@@ -42,6 +43,7 @@ export function performPlayerAttack(state, targetQuery = null) {
     if (!player || !target) return 'No valid target.';
 
     performBasicAttack(battle, player.id, target.id);
+    appendSkillGainLog(state, battle, { actionType: 'basicAttack' });
     if (battle.phase === 'active') performEnemyAutoActions(battle);
     syncPlayerFromBattle(state);
     return describeBattleTurn(battle);
@@ -60,6 +62,7 @@ export function performWeaponSkill(state, skillName = 'Weapon Skill', targetQuer
     appendBattleLog(battle, `${player.identity.name} uses ${skillName}.`);
     performBasicAttack(battle, player.id, target.id);
     performBasicAttack(battle, player.id, target.id);
+    appendSkillGainLog(state, battle, { actionType: 'weaponSkill', actionName: skillName });
     if (battle.phase === 'active') performEnemyAutoActions(battle);
     syncPlayerFromBattle(state);
     return describeBattleTurn(battle);
@@ -94,6 +97,7 @@ export function castSpell(state, spellName = 'Cure', targetQuery = null) {
         }
     }
 
+    appendSkillGainLog(state, battle, { actionType: 'spell', spellName: spellName || 'Cure' });
     if (battle.phase === 'active') performEnemyAutoActions(battle);
     syncPlayerFromBattle(state);
     return describeBattleTurn(battle);
@@ -151,6 +155,13 @@ function syncPlayerFromBattle(state) {
         appendBattleLog(state.activeBattle, `Battle ended: ${state.activeBattle.phase}.`);
         state.activeBattle.endLogged = true;
     }
+}
+
+function appendSkillGainLog(state, battle, actionContext) {
+    const result = resolveSkillGainForAction(state, actionContext);
+    const message = describeSkillGainResult(result);
+    if (message) appendBattleLog(battle, message);
+    return result;
 }
 
 function getPlayerCombatant(battle) {

--- a/js/text/systems/skillProgressionEngine.js
+++ b/js/text/systems/skillProgressionEngine.js
@@ -1,5 +1,46 @@
 import { getEffectiveSkill, getSkillCap, getSkillRank, SKILL_CAP_METADATA } from '../data/skillCaps.js';
 import { SKILL_KEYS } from '../data/systemConstants.js';
+import { enrichEquipmentItem } from '../data/equipmentCatalog.js';
+
+const MAIN_HAND_SKILL_BY_WEAPON_CATEGORY = Object.freeze({
+    handToHand: 'handToHand',
+    unarmed: 'handToHand',
+    dagger: 'dagger',
+    sword: 'sword',
+    greatSword: 'greatSword',
+    axe: 'axe',
+    greatAxe: 'greatAxe',
+    scythe: 'scythe',
+    polearm: 'polearm',
+    katana: 'katana',
+    greatKatana: 'greatKatana',
+    club: 'club',
+    staff: 'staff',
+});
+
+const RANGED_SKILL_BY_WEAPON_CATEGORY = Object.freeze({
+    bow: 'archery',
+    archery: 'archery',
+    gun: 'marksmanship',
+    crossbow: 'marksmanship',
+    firearm: 'marksmanship',
+    marksmanship: 'marksmanship',
+    throwing: 'throwing',
+});
+
+const HEALING_SPELL_TERMS = Object.freeze([
+    'cure',
+    'curaga',
+    'cura',
+    'raise',
+    'regen',
+    'poisona',
+    'paralyna',
+    'blindna',
+    'silena',
+    'erase',
+    'cursna',
+]);
 
 export function createSkillState(overrides = {}) {
     const skills = {};
@@ -43,6 +84,71 @@ export function addLearnedSkill(player, skillId, amount, options = {}) {
     return { ok: true, skillId, before: current, gained, learned, cap };
 }
 
+export function inferMainHandSkill(player) {
+    const item = player?.equipment?.mainHand;
+    if (!item) return 'handToHand';
+    return inferWeaponSkill(item, MAIN_HAND_SKILL_BY_WEAPON_CATEGORY);
+}
+
+export function inferRangedSkill(player) {
+    const ranged = player?.equipment?.ranged;
+    const ammo = player?.equipment?.ammo;
+    return inferWeaponSkill(ranged, RANGED_SKILL_BY_WEAPON_CATEGORY)
+        ?? inferWeaponSkill(ammo, RANGED_SKILL_BY_WEAPON_CATEGORY);
+}
+
+export function inferSpellSkill(spellName) {
+    const normalized = normalizeToken(spellName || '');
+    if (!normalized) return null;
+    if (HEALING_SPELL_TERMS.some((term) => normalized.includes(term))) return 'healingMagic';
+    return 'elementalMagic';
+}
+
+export function resolveSkillGainForAction(state, actionContext = {}) {
+    const player = state?.player;
+    if (!player) return { ok: false, gained: false, reason: 'No player found.' };
+
+    const skillId = resolveActionSkill(player, actionContext);
+    if (!skillId) return { ok: true, gained: false, reason: 'No eligible skill for action.' };
+    if (!SKILL_KEYS.includes(skillId)) return { ok: false, gained: false, skillId, reason: `Unknown skill: ${skillId}` };
+
+    const current = getEffectiveSkillForCurrentJob(player, skillId);
+    if (current.cap <= 0) {
+        return {
+            ok: true,
+            gained: false,
+            reason: 'Skill has no current job cap.',
+            skillId,
+            before: current.learned,
+            learned: current.learned,
+            cap: current.cap,
+        };
+    }
+    if (current.learned >= current.cap) {
+        return {
+            ok: true,
+            gained: false,
+            reason: 'Skill is capped for current job.',
+            skillId,
+            before: current.learned,
+            learned: current.learned,
+            cap: current.cap,
+        };
+    }
+
+    const gain = Math.max(1, Math.floor(Number(actionContext.amount) || 1));
+    const result = addLearnedSkill(player, skillId, gain);
+    return {
+        ...result,
+        gained: result.ok && result.learned > result.before,
+    };
+}
+
+export function describeSkillGainResult(result) {
+    if (!result?.gained) return '';
+    return `Skill gained: ${result.skillId} ${result.before} -> ${result.learned} / cap ${result.cap}.`;
+}
+
 export function getEffectiveSkillForCurrentJob(player, skillId) {
     ensureSkillState(player);
     return getEffectiveSkill(player, skillId);
@@ -82,6 +188,45 @@ function describeSkillLine(entry, player) {
 function normalizeSkillValue(value) {
     const number = Number(value);
     return Number.isFinite(number) ? Math.max(0, Math.floor(number)) : 0;
+}
+
+function resolveActionSkill(player, actionContext = {}) {
+    if (actionContext.skillId) return actionContext.skillId;
+    const actionType = actionContext.actionType ?? actionContext.type;
+    if (actionType === 'basicAttack' || actionType === 'weaponSkill') return inferMainHandSkill(player);
+    if (actionType === 'rangedAttack') return inferRangedSkill(player);
+    if (actionType === 'spell') return inferSpellSkill(actionContext.spellName);
+    return null;
+}
+
+function inferWeaponSkill(item, skillMap) {
+    if (!item) return null;
+    const normalized = enrichEquipmentItem(item);
+    const category = normalizeCategory(normalized.weaponCategory);
+    if (category && skillMap[category]) return skillMap[category];
+
+    const tags = normalized.tags ?? [];
+    for (const tag of tags) {
+        const tagCategory = normalizeCategory(tag);
+        if (skillMap[tagCategory]) return skillMap[tagCategory];
+    }
+    return null;
+}
+
+function normalizeCategory(value) {
+    const normalized = normalizeToken(value);
+    const alias = {
+        h2h: 'handToHand',
+        handtohand: 'handToHand',
+        greatsword: 'greatSword',
+        greataxe: 'greatAxe',
+        greatkatana: 'greatKatana',
+    }[normalized];
+    return alias ?? normalized;
+}
+
+function normalizeToken(value) {
+    return String(value ?? '').trim().toLowerCase().replace(/[\s_-]+/g, '');
 }
 
 function isPlainObject(value) {

--- a/js/text/version.js
+++ b/js/text/version.js
@@ -1,10 +1,10 @@
 export const VERSION = Object.freeze({
-    app: '0.4.3',
+    app: '0.4.4',
     accountSave: 4,
     gameState: 3,
     data: 13,
     benchmark: 1,
-    codename: 'Item Behavior Selling',
+    codename: 'Conservative Skill Gains',
     compatibility: 'no-backwards-compatibility',
     released: false,
 
@@ -13,7 +13,7 @@ export const VERSION = Object.freeze({
 });
 
 export const SYSTEM_VERSIONS = Object.freeze({
-    commandShell: '0.4.3',
+    commandShell: '0.4.4',
     canvasUi: '0.7.0',
     uiIntents: '0.1.1',
     slashCommands: '0.4.1',
@@ -29,12 +29,12 @@ export const SYSTEM_VERSIONS = Object.freeze({
     statEngine: '0.4.0',
     statusEngine: '0.1.0',
     battleEngine: '0.5.0',
-    combatActions: '0.5.0',
+    combatActions: '0.5.1',
     battleRewards: '0.5.2',
     progression: '0.5.4',
     expTables: '0.5.2',
     jobSwitching: '0.5.3',
-    skillProgression: '0.5.1',
+    skillProgression: '0.5.2',
     liveTick: '0.2.0',
     maps: '0.4.0',
     zones: '0.4.0',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffxi-text-rpg",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "type": "module",
   "description": "Text-only RPG foundation inspired by Final Fantasy XI systems.",

--- a/tests/combatActionEngine.test.js
+++ b/tests/combatActionEngine.test.js
@@ -2,13 +2,16 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { createCommandRouter } from '../js/text/commandRouter.js';
-import { createInitialState } from '../js/text/gameState.js';
+import { createInitialState, createNewGameState } from '../js/text/gameState.js';
 import {
     castSpell,
     performPlayerAttack,
     performWeaponSkill,
     startEncounter,
 } from '../js/text/systems/combatActionEngine.js';
+import { equipItem } from '../js/text/systems/equipmentEngine.js';
+import { addItemToContainer } from '../js/text/systems/inventoryEngine.js';
+import { getLearnedSkill, setLearnedSkill } from '../js/text/systems/skillProgressionEngine.js';
 
 
 test('startEncounter creates an active battle', () => {
@@ -30,11 +33,66 @@ test('performPlayerAttack advances battle log', () => {
     assert.match(result, /Battle/);
 });
 
+test('basic attack with Bronze Sword gains sword skill', () => {
+    const state = createInitialState();
+    equipCatalogItem(state, 'bronze-sword', 'Bronze Sword', ['weapon', 'sword', 'starter']);
+    startEncounter(state, 'Forest Hare');
+
+    const result = performPlayerAttack(state);
+
+    assert.equal(getLearnedSkill(state.player, 'sword'), 1);
+    assert.match(result, /Skill gained: sword 0 -> 1 \/ cap 2\./);
+});
+
+test('skills command reflects skill gains after combat actions', () => {
+    const state = createInitialState();
+    equipCatalogItem(state, 'bronze-sword', 'Bronze Sword', ['weapon', 'sword', 'starter']);
+    startEncounter(state, 'Forest Hare');
+    performPlayerAttack(state);
+
+    const router = createCommandRouter(state, commandServices());
+
+    assert.match(router('skills'), /sword: learned 1/);
+});
+
+test('basic attack with Bronze Axe gains axe skill', () => {
+    const state = createInitialState();
+    equipCatalogItem(state, 'bronze-axe', 'Bronze Axe', ['weapon', 'axe', 'starter']);
+    startEncounter(state, 'Forest Hare');
+
+    const result = performPlayerAttack(state);
+
+    assert.equal(getLearnedSkill(state.player, 'axe'), 1);
+    assert.match(result, /Skill gained: axe 0 -> 1 \/ cap 3\./);
+});
+
+test('basic attack with no main-hand weapon gains handToHand for jobs with a cap', () => {
+    const state = createNewGameState({ mainJobId: 'monk' });
+    startEncounter(state, 'Forest Hare');
+
+    const result = performPlayerAttack(state);
+
+    assert.equal(getLearnedSkill(state.player, 'handToHand'), 1);
+    assert.match(result, /Skill gained: handToHand 0 -> 1 \/ cap 3\./);
+});
+
 test('weapon skill requires TP', () => {
     const state = createInitialState();
     startEncounter(state, 'Forest Hare');
 
     assert.match(performWeaponSkill(state, 'Fast Blade'), /Not enough TP/);
+});
+
+test('weapon skill gains the equipped main-hand weapon skill once', () => {
+    const state = createInitialState();
+    equipCatalogItem(state, 'bronze-sword', 'Bronze Sword', ['weapon', 'sword', 'starter']);
+    startEncounter(state, 'Forest Hare');
+    getBattlePlayer(state).resources.tp = 1000;
+
+    const result = performWeaponSkill(state, 'Fast Blade');
+
+    assert.equal(getLearnedSkill(state.player, 'sword'), 1);
+    assert.match(result, /Skill gained: sword 0 -> 1 \/ cap 2\./);
 });
 
 test('cast spell requires active battle', () => {
@@ -43,16 +101,64 @@ test('cast spell requires active battle', () => {
     assert.equal(castSpell(state, 'Cure'), 'You are not in battle.');
 });
 
+test('Cure-like spells gain healing magic', () => {
+    const state = createNewGameState({ mainJobId: 'whiteMage' });
+    startEncounter(state, 'Forest Hare');
+    getBattlePlayer(state).resources.mp = 100;
+
+    const result = castSpell(state, 'Cure');
+
+    assert.equal(getLearnedSkill(state.player, 'healingMagic'), 1);
+    assert.match(result, /Skill gained: healingMagic 0 -> 1 \/ cap 3\./);
+});
+
+test('offensive placeholder spells gain elemental magic', () => {
+    const state = createNewGameState({ mainJobId: 'blackMage' });
+    startEncounter(state, 'Forest Hare');
+    getBattlePlayer(state).resources.mp = 100;
+
+    const result = castSpell(state, 'Fire');
+
+    assert.equal(getLearnedSkill(state.player, 'elementalMagic'), 1);
+    assert.match(result, /Skill gained: elementalMagic 0 -> 1 \/ cap 3\./);
+});
+
+test('skill gain clamps at current job cap and omits capped spam', () => {
+    const state = createInitialState();
+    equipCatalogItem(state, 'bronze-axe', 'Bronze Axe', ['weapon', 'axe', 'starter']);
+    setLearnedSkill(state.player, 'axe', 3);
+    startEncounter(state, 'Forest Hare');
+
+    const result = performPlayerAttack(state);
+
+    assert.equal(getLearnedSkill(state.player, 'axe'), 3);
+    assert.doesNotMatch(result, /Skill gained:/);
+});
+
 test('router exposes encounter battle attack and slash commands', () => {
     const state = createInitialState();
-    const router = createCommandRouter(state, {
-        saveGame: () => true,
-        clearSave: () => {},
-        reload: () => {},
-    });
+    const router = createCommandRouter(state, commandServices());
 
     assert.match(router('encounter Forest Hare'), /Battle/);
     assert.match(router('battle'), /Battle/);
     assert.match(router('attack'), /Battle/);
     assert.match(router('/attack'), /Battle/);
 });
+
+function equipCatalogItem(state, id, name, tags) {
+    addItemToContainer(state.player.inventoryState, 'inventory', { id, name, kind: 'equipment', quantity: 1, tags });
+    const result = equipItem(state, name);
+    assert.match(result, new RegExp(`Equipped ${name}`));
+}
+
+function getBattlePlayer(state) {
+    return state.activeBattle.combatants.find((combatant) => combatant.type === 'player');
+}
+
+function commandServices() {
+    return {
+        saveGame: () => true,
+        clearSave: () => {},
+        reload: () => {},
+    };
+}

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -8,25 +8,26 @@ import { describeSystemVersions, describeVersion, VERSION } from '../js/text/ver
 
 
 test('version manifest exposes explicit app account save game state data and benchmark versions', () => {
-    assert.equal(VERSION.app, '0.4.3');
+    assert.equal(VERSION.app, '0.4.4');
     assert.equal(VERSION.accountSave, 4);
     assert.equal(VERSION.gameState, 3);
     assert.equal(VERSION.data, 13);
     assert.equal(VERSION.benchmark, 1);
     assert.equal(VERSION.save, VERSION.accountSave);
-    assert.match(describeVersion(), /App: 0.4.3/);
+    assert.match(describeVersion(), /App: 0.4.4/);
     assert.match(describeVersion(), /Account Save: 4/);
     assert.match(describeVersion(), /Game State: 3/);
-    assert.match(describeVersion(), /Codename: Item Behavior Selling/);
+    assert.match(describeVersion(), /Codename: Conservative Skill Gains/);
     assert.match(describeSystemVersions(), /characterCreation/);
     assert.match(describeSystemVersions(), /canvasUi: 0.7.0/);
+    assert.match(describeSystemVersions(), /combatActions: 0.5.1/);
     assert.match(describeSystemVersions(), /battleRewards: 0.5.2/);
     assert.match(describeSystemVersions(), /itemSchema: 0.6.0/);
     assert.match(describeSystemVersions(), /itemBehavior: 0.1.0/);
     assert.match(describeSystemVersions(), /equipmentEligibility: 0.5.0/);
     assert.match(describeSystemVersions(), /shopTransactions: 0.3.8/);
     assert.match(describeSystemVersions(), /skillCaps: 0.5.1/);
-    assert.match(describeSystemVersions(), /skillProgression: 0.5.1/);
+    assert.match(describeSystemVersions(), /skillProgression: 0.5.2/);
     assert.match(describeSystemVersions(), /leveling: 0.5.3/);
 });
 


### PR DESCRIPTION
## Summary
- Adds conservative skill progression helpers for main-hand, ranged/ammo, and placeholder spell skill inference.
- Adds a deterministic skill-gain resolver that increments learned skill by +1 per eligible action and clamps to the current main-job cap.
- Hooks skill gains into basic attacks, placeholder weapon skills, and placeholder spell casts without changing damage, accuracy, magic formulas, enemy AI, or item behavior application.
- Appends concise battle-log output only when a skill actually increases.

## Version/docs
- Bumps app/package to `0.4.4` with codename `Conservative Skill Gains`.
- Bumps `skillProgression` to `0.5.2` and `combatActions` to `0.5.1`.
- Updates README, ROADMAP, THREAD_HANDOFF, ARCHITECTURE, CHANGELOG, and pipeline assertions.

## Tests/checks
- `npm.cmd test` passed, 233/233.
- `npm.cmd run benchmark` passed.
- `npm.cmd run check` passed.
- `git diff --check` passed with existing LF-to-CRLF warnings only.

## Known limitations
- Learned/effective skill values are not wired into damage, accuracy, magic potency, enemy AI, or item behavior formulas yet.
- Spell skill inference is intentionally placeholder-only until a real spell database exists.
- Weapon-skill unlock tables and retail/random skill-up pacing are not implemented.
- Ranged skill inference helper exists, but no ranged combat action is wired in this pass.