### PR TITLE
Define development direction and version roadmap to 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,33 @@
 # FFXI Text RPG
 
-A text-only RPG foundation inspired by Final Fantasy XI systems.
+A text-first fantasy life RPG foundation inspired by the weight, preparation, progression, jobs, equipment, travel, and earned accomplishment of Final Fantasy XI.
 
-This branch intentionally resets the project around a stable canvas-first text shell, structured entities, account/character save slots, conservative stat engines, parser-backed commands, validation helpers, version tracking, benchmarks, a database registry, seeded world graph, starter city maps, alphanumeric San d’Oria coordinate topology, coordinate atlas, travel scaffold, compass navigation controls, inventory/storage containers, item schema and stacking, POI discovery, starter shops/guild hooks, equipment commands and eligibility checks, deterministic combat, battle rewards, EXP tables, level-up rules, character-owned skill progression scaffolding, isolated skill-gain hooks, skill-cap scaffolding, and implementation-first documentation.
+The project is **not** intended to become a text transcription of retail FFXI. The long-term direction is a persistent life/adventure RPG built around simulated time, measurable mastery, livelihoods, projects, infrastructure, relationships, logical equipment/preparation, dangerous expeditions, and a continuous character who can develop across multiple disciplines.
 
-Backwards compatibility with the previous UI/save shape is not considered until explicitly reintroduced.
+Core progression law:
 
-This pass adds conservative skill-gain hooks for basic attacks, placeholder weapon skills, and placeholder spell casts. Skill gains update character-owned learned values and battle-log text, but learned skill values are not wired into damage, accuracy, magic, enemy AI, or item behavior formulas yet.
+```text
+effort -> mastery -> efficiency -> capability -> larger ambition
+```
+
+The active browser UI remains canvas-first and text-led. Limited icons, tokens, meters, cards, and diagrams are welcome when they improve comprehension without creating a full graphical-world production burden.
+
+## Read these first
+
+For a new development session, use this order:
+
+1. `docs/DEVELOPMENT_DIRECTION.md` — authoritative game/design direction.
+2. `docs/VERSIONING_AND_RELEASE_ROADMAP.md` — four-part product-version protocol and detailed path to 1.0.
+3. `docs/ROADMAP.md` — current implementation summary and phase index.
+4. `docs/THREAD_HANDOFF.md` — concise repo state and next implementation sequence.
+5. `docs/ARCHITECTURE.md` — runtime/module boundaries.
+6. `CHANGELOG.md` — notable historical changes.
+
+The older `docs/planning/DEVELOPMENT_PIPELINE_AND_MILESTONES.md` is historical planning from the earlier formula/item-behavior phase. Its milestone order is superseded.
 
 ## Current version
+
+Historical runtime baseline:
 
 ```text
 App/package: 0.4.4
@@ -18,24 +37,36 @@ Data: 13
 Codename: Conservative Skill Gains
 ```
 
-`VERSION.save` remains as a backward-compatible alias for `VERSION.accountSave` while callers migrate to the clearer name.
+`js/text/version.js` remains the current runtime/system manifest.
 
-See `js/text/version.js` for the authoritative runtime/system version map.
+A new four-part product protocol is planned:
+
+```text
+MAJOR.PHASE.TRACK.REVISION
+```
+
+Example:
+
+```text
+0.5.300.4
+```
+
+The product version will be decoupled from `package.json.version` because npm uses three-part SemVer. See `docs/VERSIONING_AND_RELEASE_ROADMAP.md` before changing version numbers.
 
 ## Running
 
-Do not open `index.html` directly with a `file://` URL. The browser blocks ES module imports from local files, so the canvas shell must be served over localhost.
+Do not open `index.html` directly with a `file://` URL. ES module imports require serving the project over localhost.
 
-On Windows, use these launchers from the repo root:
+On Windows, from the repo root:
 
 ```text
 Start Server.cmd  - starts the local server
 Play.cmd          - opens http://127.0.0.1:4173/
 ```
 
-Start the server first, then use `Play.cmd` to open the game. The older `server.cmd` still works as a compatibility wrapper around `Start Server.cmd`; `server.ps1` remains available for PowerShell.
+The older `server.cmd` remains a compatibility wrapper; `server.ps1` is also available.
 
-Or run the npm script directly:
+Or run:
 
 ```bash
 npm run serve
@@ -47,7 +78,7 @@ Then open:
 http://127.0.0.1:4173/
 ```
 
-No build step is required. The visible game UI is rendered into one canvas; HTML is only the host layer.
+No build step is required.
 
 Suggested local repo path for Codex desktop work:
 
@@ -57,7 +88,7 @@ C:\Codex\ffxi-text-rpg
 
 ## Development
 
-Node 20+ is recommended for tests and benchmarks.
+Node 20+ is recommended.
 
 ```bash
 npm test
@@ -65,105 +96,139 @@ npm run benchmark
 npm run check
 ```
 
-## Important handoff docs
+## Product direction in brief
 
-Read these first in a new thread or fresh development session:
+### Continuous character, not magical job switching
 
-1. `docs/THREAD_HANDOFF.md` - concise current-state handoff and next-pass guidance.
-2. `docs/ARCHITECTURE.md` - runtime/module boundaries.
-3. `docs/ROADMAP.md` - versioned implementation plan.
-4. `docs/BASELINE_PIPELINE.md` - full baseline pipeline expectations.
-5. `docs/SYSTEM_CATALOG.md` - system/data registry notes.
-6. `CHANGELOG.md` - notable reset-branch changes.
+Jobs remain recognizable disciplines/training traditions, but changing equipment should not magically transform the character.
 
-## Canvas UI Command Policy
-
-The active browser UI is canvas-first. It draws the title/status bar, command buttons, output log, context panel, and command input inside `#game-canvas`.
-
-The left-side canvas includes a 3x3 compass rose that dispatches navigation intents directly. Stable gameplay sidebar buttons still route through `commandRouter.js` commands:
+Long-term vocabulary:
 
 ```text
-character
+Jobs describe.
+Capabilities enable.
+Loadouts constrain and enhance.
+```
+
+A character may learn capabilities associated with multiple disciplines and use them when the real prerequisites are satisfied: proficiency, equipment, focus, ammunition, tools, reagents, resources, condition, preparation, and context.
+
+Some prerequisites are hard requirements; some allow use at a penalty; some are enhancers. The current `mainJob`/support-job model is transitional and should be migrated incrementally rather than removed in a broad rewrite.
+
+### Long fictional time, short real waiting
+
+Simulation time and wall-clock time should be separate.
+
+The game may contain meaningful fictional grind, but the player should be able to pause, fast-forward, advance to completion, or advance until a meaningful interrupt. End-of-day review should make slow cumulative progress legible.
+
+### Logical resource scaling
+
+Repeated identical construction should not become exponentially more expensive merely because another copy already exists.
+
+Advanced resource demand should come from larger structures, renovations, specialization, logistics, automation, capacity, transport, maintenance, and prestige/regional projects.
+
+### Life and adventure are one loop
+
+The first representative target is **A Week Beyond the West Gate**: a multi-day slice combining origin, home foothold, livelihood, shop/economy, project progress, preparation, travel, danger/combat, recovery, end-of-day review, and a permanent accomplishment.
+
+## Current architecture
+
+```text
+index.html
+  -> js/main.js
+      -> createCanvasApp(canvas)
+          -> loadActiveCharacter() or createInitialState()
+          -> createCommandRouter(state)
+          -> createSlashCommandRouter(state)
+          -> canvas layout/input/render loop
+```
+
+Game logic should remain separate from canvas/DOM rendering.
+
+Primary areas:
+
+```text
+js/text/
+  commandRouter.js
+  slashCommandRouter.js
+  gameState.js
+  save.js
+  version.js
+  data/
+  entities/
+  systems/
+  ui/
+tests/
+docs/
+```
+
+## Current implemented foundation
+
+The repo already contains useful scaffolds for:
+
+- canvas-first text UI and command adapters;
+- account/character local saves;
+- character creation;
+- structured player/NPC/enemy entities;
+- places, San d'Oria coordinates, navigation, atlas discovery, travel, and aggro;
+- POIs, shops, guild hooks, and starter quest hooks;
+- inventory/storage/wardrobes;
+- item normalization, equipment, item inspection, buying, and selling;
+- character-owned skills and deterministic skill-gain hooks;
+- battle state, attacks, placeholder WS/cast actions, rewards, EXP, gil, and loot;
+- status effects and wall-clock tick scaffold;
+- validation, tests, benchmarks, database registry, and system version tracking.
+
+The existing breadth is a foundation, not evidence that the product is close to complete.
+
+## Command compatibility
+
+The canvas input accepts bare gameplay commands and leading-slash account/menu or compatible FFXI-style commands.
+
+Representative gameplay commands:
+
+```text
+look
 stats
-job
 skills
 inventory
 equipment
-maps
-look
 here
+move n
+travel West Ronfaure
+wait 60
 battle
-help
+item Bronze Sword
+inspect item Bronze Sword
+equip Bronze Sword
+shop Ashene
+buy Bronze Sword
+sell Bronze Sword
 validate
 save
 ```
 
-The canvas command input accepts existing bare commands and still accepts slash commands where the slash router owns account/menu behavior:
+Representative account/menu commands:
 
 ```text
-look
-stats
-skills
-skill <id>
-inspect skills
-inspect skill <id>
-inventory
-item <query>
-inspect item <query>
-equipment
-containers
-container <id>
-transfer <item> from <source> to <destination>
-equip <item> [to slot] [from container]
-unequip <slot> [to container]
-equipSources
-here
-talk <name>
-shop <name>
-move <dir>
-stop
-buy <item>
-sell <item> [quantity]
-guild <name>
-quest <name>
-discovered
-fastpoi <name>
-zonefast
-maps
-map <id>
-zones
-zone <id|name>
-atlas <id|name>
-grid
-move <n|ne|e|se|s|sw|w|nw>
-travel <destination>
-wait <seconds>
-controls
-tick
-version
-systems
-databases
-validate
-log
+/menu
+/commands
+/help
+/newcharacter
+/characters
+/load <name|number>
+/save
+/account
+/reset
 ```
 
-Slash forms like `/menu`, `/commands`, `/newcharacter`, `/characters`, `/load <name|number>`, `/save`, `/account`, and `/reset` are still accepted by the canvas input.
+The normal game should eventually be discoverable through UI/actions without requiring command memorization; typed commands remain a powerful adapter and debugging interface.
 
-## Canvas UI Shell
+## Current character creation
 
-The browser shell remains text-first, but the visible UI is drawn on canvas. The first pass includes a top status bar, left clickable command sidebar, main output log, right context/history panel on desktop widths, and a bottom command input row.
-
-## Character creation
-
-Use:
+The current transitional flow is:
 
 ```text
 /newcharacter
-```
-
-The command starts prompt-based character creation. While prompts are active, answers are natural text and do not require `/`. The current prompt order is name, nation, race, sex, starting job, then confirmation:
-
-```text
 CharacterName
 sandoria
 hume
@@ -172,187 +237,62 @@ warrior
 yes
 ```
 
-A completed and confirmed character is saved automatically into the local account save.
+Future 0.6 work moves toward origins/starting circumstances and discipline/capability progression rather than a magical current-job identity.
 
 ## Save model
 
-Local accounts and active-account session state are stored under:
+Current localStorage keys:
 
 ```text
 ffxiTextRpgAccounts
 ffxiTextRpgAccountSession
 ```
 
-The save payload is encoded as:
+Encoding:
 
 ```text
 base64-json-v1
 ```
 
-This is encoded storage, not strong encryption. It keeps player data from being plain readable JSON at a glance, but it is not secure against anyone with browser/devtools access. Real encryption should use a password-derived key or platform key later.
+This is encoded storage, not strong encryption.
 
-The old single-save key:
+`reviveGameState()` currently restores object-reference compatibility after JSON load, including relinking `player.inventory` to the Inventory container.
 
-```text
-ffxiTextRpgSave
-```
-
-is read only for migration when no account save exists, then removed after account save creation.
-
-## Current architecture
-
-```text
-index.html
-css/style.css
-Start Server.cmd
-Play.cmd
-server.cmd
-server.ps1
-js/main.js
-js/text/
-  slashCommandRouter.js    UI-facing slash command wrapper
-  commandRouter.js         internal command parsing and dispatch
-  gameState.js             initial state and text descriptions
-  save.js                  encoded account/character localStorage adapter
-  sidebar.js               legacy DOM sidebar/HUD helper, inactive in current entry path
-  topBar.js                legacy DOM top bar helper, inactive in current entry path
-  ui/
-    canvasApp.js           browser canvas shell bootstrap
-    canvasRenderer.js      canvas drawing only
-    canvasLayout.js        pure panel/button bounds and hit testing
-    canvasInput.js         canvas pointer/keyboard state helpers
-    uiActions.js           pure button-to-command registry
-    uiTheme.js             canvas color/type constants
-  textShell.js             legacy DOM shell helper, inactive in current entry path
-  uiPanels.js              legacy reusable DOM panel helpers and feedback classifier
-  version.js               app/account-save/game-state/data/system version manifest
-  commands/
-    parser.js
-  data/
-    actionControls.js
-    databaseRegistry.js
-    equipmentCatalog.js
-    expTables.js
-    guildServices.js
-    inventoryContainers.js
-    itemSchema.js
-    jobs.js
-    lootTables.js
-    maps.js
-    mogHouseFurniture.js
-    nations.js
-    places.js
-    pointsOfInterest.js
-    questHooks.js
-    races.js
-    seedEntities.js
-    shopCatalogs.js
-    skillCaps.js
-    systemConstants.js
-  entities/
-    entityFactory.js
-  systems/
-    aggroEngine.js
-    atlasEngine.js
-    battleEngine.js
-    characterCreator.js
-    combatActionEngine.js
-    equipmentEngine.js
-    ffxiCommandAdapter.js
-    inventoryEngine.js
-    menuDescriptions.js
-    poiEngine.js
-    progressionEngine.js
-    rewardEngine.js
-    rng.js
-    shopEngine.js
-    skillProgressionEngine.js
-    statEngine.js
-    statusEngine.js
-    tickEngine.js
-    travelEngine.js
-    validation.js
-scripts/
-  benchmark.js
-  serve.js
-tests/
-  *.test.js
-docs/
-  ARCHITECTURE.md
-  BASELINE_PIPELINE.md
-  RESEARCH_REFERENCES.md
-  ROADMAP.md
-  SYSTEM_CATALOG.md
-  THREAD_HANDOFF.md
-```
-
-## Implemented foundation
-
-- Canvas-first browser shell with command-backed clickable buttons and keyboard command input.
-- Canvas-rendered top bar with character/location/status summary.
-- Account profile and multiple encoded local character save slots.
-- Canvas-rendered action sidebar, output log, context/history panel, and bottom command row.
-- Prompt-based character creation from `/newcharacter`.
-- Argument-aware command parser.
-- Pure canvas UI action, layout, hit-testing, and keyboard input helpers.
-- Local static dev server for browser module loading over localhost.
-- Windows launchers: `Start Server.cmd`, `Play.cmd`, compatibility `server.cmd`, and `server.ps1`.
-- Structured player, NPC, and enemy entities.
-- Race seed definitions.
-- Job seed definitions for standard FFXI player jobs through Rune Fencer.
-- Three starter city clusters: San d’Oria, Bastok, and Windurst.
-- Starter city maps, starter region maps, and starter dungeon-hook maps.
-- Seeded places, coordinate systems, map IDs, connection grids, and zone connections.
-- Zone atlas discovery where unvisited grids remain unknown until visited.
-- 8-way grid movement inside zones.
-- Foot-travel aggro risk scaffold based on grid spawn rules, spawn count, and aggro types.
-- Text HUD/control metadata for HP/MP/TP bars, live tick bar, 8-way nav keypad, and action groups.
-- Direct travel engine with restrictions, departure coordinates, arrival coordinates, atlas recording, and manual time advancement.
-- Starter-city POIs, same-zone POI discovery, and same-zone POI fast travel.
-- Starter shop catalogs, guild service hooks, and quest/mission hooks.
-- Inventory container framework: Inventory, Mog Safe, Mog Safe 2, Storage, Mog Locker, Mog Satchel, Mog Sack, Mog Case, and Mog Wardrobes 1-8.
-- Mog House-only Storage/Mog Safe access and furniture-derived Storage capacity.
-- Common item schema, item normalization, stack metadata, and stack-aware container insertion.
-- Normalized equipment template fields for family/archetype/subtype, allowed slots, weapon category/delay, requirements, flags, always-on effects, latent/enchantment/augment scaffolds, charges, and confidence/source metadata.
-- Container transfer rules with access, capacity, item-kind, and stack-handling validation.
-- Shop buying into Inventory and conservative shop selling from Inventory.
-- Equip/unequip commands using Inventory and accessible Wardrobes, with job/race/level/slot eligibility and two-handed/offhand conflict checks.
-- Text-first `item <query>` and `inspect item <query>` inspection for accessible inventory, wardrobe, equipped items, and item behavior metadata.
-- Starter equipment catalog with conservative stat modifiers and explicit placeholder/intentional-simplification metadata.
-- Attribute/resource/derived-stat/skill/equipment/currency constants.
-- Conservative stat calculation engine.
-- Character-owned current skill storage under `player.progression.skills[skillId]`.
-- Sparse skill rank/cap helper data, deterministic +1 skill-gain hooks for eligible combat actions, and text-first `skills`, `skill <id>`, `inspect skills`, and `inspect skill <id>` commands for current learned skill inspection.
-- Simple battle-state engine with deterministic RNG injection.
-- Battle reward resolution for EXP, gil, loot rolls, Inventory insertion, duplicate payout prevention, and progression engine integration.
-- Conservative EXP table data, level-up rules, EXP-to-next tracking, level-cap behavior, and HP/MP/resource refresh after level-up.
-- Status effect lifecycle engine.
-- Live tick engine scaffold.
-- Version manifest and system version tracking.
-- Database registry for enemies, NPCs, places, zones, travel, quests, achievements, items, key items, magic, loot, leveling, trusts, crafting, mounts, and tick channels.
-- Baseline benchmark harness.
-- Game-state, world-data, equipment-catalog, item-requirement, modifier-key, flag/effect, skill-rank, and character-owned skill-state validation helpers.
-- Node test harness using the built-in `node:test` runner.
+Ordered save migrations are a required 0.4 closeout step before large amounts of new persistent simulation state are added.
 
 ## Formula policy
 
-Current formulas are conservative placeholders. They exist to make the architecture executable and testable. Exact FFXI-like formulas should be added only after they are sourced, understood, marked with confidence, and covered by tests.
+Current formulas are conservative scaffolds.
+
+Formula confidence should be explicit:
+
+- exact / sourced;
+- researched approximation;
+- intentional simplification;
+- placeholder.
+
+Formula refinement matters, but it no longer leads the product roadmap. Improve formulas when they materially improve a meaningful gameplay loop.
 
 ## Rebuild rules
 
-- Keep the active runtime text based.
-- Keep game logic separate from canvas/DOM rendering.
+- Keep the active runtime text-first.
+- Keep game logic separate from rendering.
 - Prefer small modules over giant files.
-- Preserve reusable legacy data only when it can be migrated cleanly.
-- Do not preserve backwards compatibility unless explicitly instructed.
-- Document every new engine, schema, or pipeline change.
-- Every major runtime system should have validation, tests, benchmark coverage, and version tracking.
+- Keep stable IDs and data-driven content where practical.
+- Preserve command compatibility while letting UI actions dispatch the same gameplay semantics.
+- Do not add full event sourcing merely to support lightweight semantic events.
+- Do not store new saves as raw plain JSON.
+- Add explicit migrations when persistent schema changes.
+- Do not claim exact FFXI behavior without source/confidence notes.
+- Add tests/version/docs for major runtime changes.
+- Pre-1.0 backwards compatibility is not automatic; migration/reset decisions must be explicit.
 
-## Current next best pass
+## Current next implementation target
 
-The current recommended next pass is conservative formula and item-behavior application planning:
+After the direction/version planning branch is reviewed and merged, the next runtime target is `0.4.200`:
 
-1. Keep latent effects, enchantments, charges, and ranged/ammo behavior metadata inspection-only until combat and action semantics are explicit.
-2. Wire skill caps into combat and magic calculations only after current skill state, gain flow, and formula confidence are explicit.
-3. Keep skill-gain pacing deterministic until a tested RNG policy is introduced.
-4. Add key-item item records and unlock/permission validation.
+1. introduce the authoritative four-part product-version field;
+2. decouple it from private npm package SemVer;
+3. update version display/tests/docs;
+4. proceed to ordered persistence migrations (`0.4.300`);
+5. then add structured action/event seams before beginning deterministic world time in 0.5.

--- a/docs/DEVELOPMENT_DIRECTION.md
+++ b/docs/DEVELOPMENT_DIRECTION.md
@@ -1,0 +1,357 @@
+# Development Direction
+
+This document is the design north star for the project. It defines what the game is trying to become, the design laws that should survive implementation changes, and the architectural direction that future work should follow.
+
+It supersedes the earlier assumption that the project roadmap should primarily be driven by reconstructing FFXI formulas or feature breadth. FFXI remains an important source of tone, weight, progression philosophy, jobs, equipment, travel danger, and long-form accomplishment, but the project is not intended to become a text transcription of retail FFXI.
+
+## Product identity
+
+The target is a long-form, text-first fantasy life RPG in which an ordinary character gradually builds a livelihood, home, skills, relationships, reputation, and material capability while venturing into an increasingly dangerous world.
+
+The intended experience combines:
+
+- the weight, preparation, danger, mastery, and earned accomplishment associated with older FFXI;
+- the incremental life-building structure of games such as Rune Factory and Fantasy Life;
+- the measurable long-horizon progress of incremental games without requiring real-world waiting;
+- tabletop-style presentation where prose and imagination do most of the rendering while icons, tokens, cards, meters, and diagrams communicate state;
+- a deterministic, testable simulation foundation that can support large amounts of authored content without tying game logic to the UI.
+
+The player should feel that they are developing one continuous person and one persistent life, not switching between disconnected game modes.
+
+## Core progression law
+
+The primary progression loop is:
+
+```text
+effort -> mastery -> efficiency -> capability -> larger ambition
+```
+
+Progression should not primarily be:
+
+```text
+effort -> arbitrary larger denominator -> same activity again
+```
+
+Repeated work may take substantial simulated time and may require substantial resources, but it should leave measurable residue: improved proficiency, better tools, better infrastructure, new options, reduced labor, improved yield, safer travel, better preparation, or access to more ambitious work.
+
+Earlier chores should eventually consume less player attention because the character has earned ways to perform them more efficiently.
+
+## Long-duration play without real-time punishment
+
+The game should support long fictional timescales and meaningful grind while respecting real player time.
+
+Simulation time and wall-clock time are separate concepts.
+
+A four-hour fictional task should consume four hours of world time whether the player watches it at normal speed, fast-forwards, advances directly to completion, or advances until a meaningful interrupt occurs.
+
+The player pays with character time, resources, risk, preparation, and opportunity cost. They should not be forced to pay with avoidable real-world waiting.
+
+### Time controls
+
+The intended simulation eventually supports:
+
+- normal-speed ticking;
+- pause;
+- configurable fast-forward;
+- advance-to-task-completion;
+- advance-to-next-event;
+- end-of-day auto-pause;
+- meaningful interrupts such as combat, exhaustion, tool failure, project completion, major NPC events, dangerous weather, or important unlocks.
+
+Hardcore modes may restrict pauses, saving, injury tolerance, or event handling, but should not simply force slower real-world waiting.
+
+## End-of-day review
+
+Standard play should default to an end-of-day decision pause.
+
+The day summary should make progress legible without forcing the player to watch every low-value tick. Useful summary categories include:
+
+- work completed;
+- resources gained or spent;
+- skill/proficiency changes;
+- project progress;
+- notable encounters;
+- relationship/reputation changes;
+- injuries, fatigue, equipment wear, or shortages;
+- newly available opportunities;
+- reminders for tomorrow.
+
+The player should be able to inspect state, plan, save/quit, or immediately continue.
+
+## Construction and resource economy
+
+Construction costs should follow physical and economic logic, not arbitrary exponential repetition penalties.
+
+If one standard barn requires a particular amount of lumber, stone, fittings, and labor, a second identical barn under comparable conditions should cost approximately the same amount.
+
+Costs may legitimately change because of:
+
+- different size;
+- different materials;
+- difficult terrain;
+- transport distance;
+- labor availability;
+- regional scarcity;
+- specialized machinery or magic;
+- structural upgrades;
+- capacity expansion;
+- renovation complexity;
+- prestige or regional scale.
+
+The game should create long-term resource demand through expansion and sophistication rather than unexplained multipliers based only on how many copies the player has already built.
+
+High-value resource sinks include:
+
+- larger structures;
+- renovations;
+- specialized facilities;
+- automation and labor-saving infrastructure;
+- storage and transport capacity;
+- roads, carts, warehouses, irrigation, and workshops;
+- equipment maintenance and replacement;
+- prestige projects;
+- civic or regional projects.
+
+## Jobs are disciplines, not magical transformations
+
+The project should retain recognizable jobs such as Warrior, White Mage, Black Mage, Red Mage, Thief, Ranger, Paladin, Dark Knight, Bard, and other fantasy disciplines, but a job is not a magical character state.
+
+A job is a recognized archetype, curriculum, training tradition, or classification of competencies.
+
+The character remains one continuous person. Equipping an axe does not transform the character into a Warrior. Equipping a staff does not transform the character into a Mage. Removing equipment does not cause learned knowledge to disappear.
+
+### Design vocabulary
+
+Use these concepts distinctly:
+
+| Term | Meaning |
+| --- | --- |
+| Discipline / Job | A recognized school, profession, archetype, or training tradition. |
+| Capability | A learned spell, technique, skill, trait, or other action the character knows. |
+| Proficiency | How practiced or competent the character is with a capability or skill domain. |
+| Loadout | The equipment and immediately prepared state that determines what the character can effectively do now. |
+| Preparation | Ammunition, reagents, focus items, stance, memorization/prepared actions, tools, mounts, supplies, or other contextual readiness. |
+
+A useful rule is:
+
+```text
+Jobs describe.
+Capabilities enable.
+Loadouts constrain and enhance.
+```
+
+### Ability eligibility
+
+Ability use should eventually resolve from actual prerequisites rather than primarily from `currentJob`.
+
+A capability check may consider:
+
+- whether the character has learned the ability;
+- relevant proficiency or mastery;
+- required or preferred equipment;
+- required free hands, weapon family, shield, focus, ammunition, or tool;
+- MP, TP, stamina, charges, reagents, or other resources;
+- silence, injury, encumbrance, status effects, or environmental restrictions;
+- mounted, workshop, travel, terrain, or other context;
+- discipline-specific advanced training where instruction is genuinely required.
+
+### Hard requirements, soft requirements, and enhancers
+
+Abilities should support three broad equipment/preparation relationships.
+
+**Hard requirement:** the action does not make sense without the prerequisite. Shield Bash requires a shield. Archery techniques require a bow and usable ammunition. Some rituals may require a focus.
+
+**Soft requirement:** the action is still possible, but the character is poorly prepared. A learned healing spell may be cast without a preferred wand or staff at increased resource cost, longer cast time, lower potency, or higher interruption risk.
+
+**Enhancer:** the item is not required but improves the action. A healing focus may improve potency or efficiency; specialist armor may improve interruption resistance.
+
+The exact penalties and bonuses should be data-driven, confidence-labeled, and balance-tested rather than hard-coded into command handlers.
+
+### Cross-discipline use
+
+The design intentionally does not use FFXI's single support-job limitation as the primary capability gate.
+
+A character may use capabilities associated with several disciplines at the same time if they genuinely know those capabilities and satisfy their prerequisites.
+
+The balancing constraint is that the character cannot optimally deploy everything simultaneously. Equipment, preparation, resources, encumbrance, action economy, proficiency, and context create the build boundaries.
+
+A heavily armored sword-and-shield character who studied restoration magic may still cast a basic heal, but may do so less efficiently than a character equipped and prepared as a dedicated healer.
+
+### Discipline progression still matters
+
+Jobs remain meaningful because advanced techniques may require formal instruction, certification, guild standing, milestones, quests, mentors, or minimum proficiencies.
+
+A discipline can provide:
+
+- training paths;
+- advanced techniques;
+- specialist traits;
+- trainers and guilds;
+- titles and recognition;
+- access to equipment or facilities;
+- reputation and narrative identity;
+- shorthand for describing a loadout or play style.
+
+The important rule is that discipline identity should represent earned training, not a toggle that rewrites the character.
+
+## Origins and starting conditions
+
+Character creation should eventually move from a simple starting-job choice toward origin-based starting circumstances.
+
+Origins may provide different:
+
+- starting tools;
+- equipment;
+- seeds or materials;
+- learned beginner capabilities;
+- local relationships;
+- debts, obligations, or reputation;
+- starting property or lodging;
+- starting proficiencies;
+- introductory objectives.
+
+Origins should not permanently lock later play. They change the opening and early constraints while allowing a character to learn other disciplines and livelihoods over time.
+
+Examples include Homesteader, Guard, Apprentice, Hunter, Drifter, Craftsperson, or similar setting-appropriate backgrounds.
+
+## Preparation should be gameplay
+
+Before an expedition, the player should think about what they are trying to accomplish rather than selecting a magical class transformation.
+
+A hunting trip, dungeon expedition, gathering run, escort mission, or construction supply trip should naturally favor different equipment and supplies.
+
+This gives long-term value to:
+
+- storage;
+- equipment collections;
+- tools;
+- crafting;
+- mounts and pack animals;
+- carts;
+- homes and workshops;
+- consumables;
+- scouting and known routes;
+- relationships and local services.
+
+Preparation should create meaningful tradeoffs without becoming inventory busywork.
+
+## Visual presentation policy
+
+The game remains text-first and imagination-led.
+
+Limited visual polish is encouraged when it improves comprehension or identity without creating a full graphical-world burden.
+
+Appropriate visual elements include:
+
+- icons;
+- tokens;
+- status meters;
+- equipment silhouettes;
+- cards;
+- simple node diagrams;
+- maps represented as schematic/coordinate information;
+- project progress indicators;
+- day/time indicators;
+- relationship or reputation markers.
+
+The project should not pivot into sprite animation, full graphical terrain, cinematic rendering, or a large asset-production pipeline unless explicitly reconsidered later.
+
+## First lovable vertical slice
+
+The first substantial playable target should prove the life/adventure intersection rather than only combat or only farming.
+
+Working concept: **A Week Beyond the West Gate**.
+
+The slice should include:
+
+1. a small set of origins with different starting circumstances;
+2. a modest home base, room, plot, workshop access, or equivalent foothold;
+3. one simple livelihood/gathering loop;
+4. a local shop/economy loop;
+5. a persistent project that accumulates materials and labor;
+6. simulated days with end-of-day review;
+7. one meaningful expedition outside the city/gate;
+8. travel risk and at least one dangerous combat encounter;
+9. measurable proficiency or capability growth;
+10. return-home recovery and preparation;
+11. completion of something permanent that did not exist when the character began;
+12. a resulting unlock that opens the next layer of play.
+
+The first slice should make the player feel that a week of fictional life produced a materially different character and world state.
+
+## Architecture direction
+
+The current separation of data, state, systems, and UI remains appropriate. Do not rewrite the project simply to pursue the new direction.
+
+Evolutionary priorities:
+
+- add explicit ordered save migrations before persistent systems proliferate;
+- separate deterministic simulation time from wall-clock timer delivery;
+- define a canonical time-consuming action/task model used by travel, work, crafting, construction, farming, and other systems;
+- move toward structured action results instead of prose-only return values;
+- add lightweight semantic game events so quests, summaries, tests, achievements, and UI can react to meaning rather than parsing strings;
+- keep command input and UI controls as adapters into the same gameplay actions;
+- keep content data-driven and stable-ID based;
+- author dense regional content packs rather than broad shallow map coverage;
+- preserve formula confidence labels: exact/sourced, researched approximation, intentional simplification, placeholder;
+- avoid full event sourcing unless a later requirement justifies its complexity.
+
+## Current transitional systems
+
+Several current systems are useful foundations but should not be mistaken for final design commitments.
+
+In particular:
+
+- `mainJobId`, support-job assumptions, job-specific current-state checks, and current job switching are transitional;
+- job level data may later become discipline training/mastery data;
+- capability eligibility should gradually migrate away from a single current-job gate;
+- the existing wall-clock tick engine is a scaffold, not the final world-time model;
+- current formulas are executable scaffolds, not a requirement to reproduce retail FFXI exactly;
+- current San d'Oria content is a foundation for a dense region, not a mandate to reproduce every FFXI zone before the core game loop is fun.
+
+Do not rip these systems out in one broad rewrite. Replace assumptions incrementally behind tested interfaces.
+
+## Priority order
+
+The broad priority order from the present repo is:
+
+1. lock development direction and version protocol;
+2. persistence/migration foundation;
+3. deterministic world time, pause, advance, and day boundaries;
+4. canonical tasks/projects and semantic action/event contracts;
+5. capability/discipline/loadout model and origins;
+6. first livelihood plus first-week vertical slice;
+7. infrastructure, construction, tools, farming/gathering depth, crafting, relationships, taming, and logistics;
+8. deeper adventure systems, magic, combat, objectives, and regional expansion;
+9. formula refinement where it materially improves an already-compelling game loop;
+10. release hardening and 1.0 content completeness.
+
+The detailed release sequence and version-number protocol live in `docs/VERSIONING_AND_RELEASE_ROADMAP.md`.
+
+## Non-goals for the near term
+
+Do not let the following become the roadmap spine before the first complete loop is proven:
+
+- exact retail FFXI formula reconstruction;
+- complete FFXI job/ability/spell coverage;
+- complete FFXI item database migration;
+- full auction-house/economy simulation;
+- broad map reproduction with low interaction density;
+- full graphical world rendering;
+- massive creature or recipe catalogs before one representative instance is fun;
+- arbitrary exponential construction costs;
+- real-world idle timers as a substitute for simulation depth.
+
+## Decision test for new features
+
+Before adding a substantial feature, ask:
+
+1. Does this help the player build a persistent life or capability?
+2. Does it create a meaningful decision, risk, preparation need, or long-term ambition?
+3. Does repeated use become more efficient or more expressive through mastery?
+4. Does it integrate with at least one other system rather than exist as an isolated checklist item?
+5. Can it be represented clearly in the text-first UI without demanding a graphical-engine pivot?
+6. Can its state and behavior be tested deterministically?
+7. Is the implementation appropriately scoped for the current release milestone?
+
+If the answer to most of these is no, the feature probably belongs later or should be redesigned.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,227 +1,222 @@
 # Roadmap
 
-This roadmap turns the text-only reset into a stable expandable RPG foundation. Backwards compatibility is intentionally out of scope until explicitly restored.
+This roadmap is the current implementation summary and release-phase index for the text-first fantasy life RPG.
 
-## Version tracks
+Authoritative companion documents:
 
-| Version | Theme | Gate |
+- `docs/DEVELOPMENT_DIRECTION.md` — design north star and non-negotiable product direction.
+- `docs/VERSIONING_AND_RELEASE_ROADMAP.md` — detailed four-part version protocol, sub-milestones, exit gates, and path to 1.0.
+- `docs/ARCHITECTURE.md` — current runtime/module boundaries.
+- `docs/THREAD_HANDOFF.md` — current implementation state for a new development thread.
+
+The older `docs/planning/DEVELOPMENT_PIPELINE_AND_MILESTONES.md` remains useful as historical planning context for the formula/item-behavior era, but its recommended milestone order is superseded by this roadmap and the two authoritative direction documents above.
+
+## Current baseline
+
+Historical product version:
+
+```text
+0.4.4
+```
+
+Current baseline remains a rough pre-alpha foundation rather than a nearly half-complete product.
+
+Implemented foundations include:
+
+- canvas-first text UI and command compatibility;
+- local account/character saves;
+- character creation;
+- structured player/NPC/enemy entities;
+- San d'Oria coordinate navigation and atlas discovery;
+- world places, travel, aggro, POIs, shops, guild hooks, and starter quest hooks;
+- inventory/storage/wardrobes;
+- item schema, inspection, equipment, buying, and selling;
+- character-owned skills and deterministic skill-gain hooks;
+- combat/reward/EXP/loot scaffolds;
+- status and live-tick scaffolds;
+- validation, tests, benchmarks, version/system manifests, and documentation.
+
+Important transitional assumptions:
+
+- the current wall-clock tick engine is not the final world-time model;
+- `mainJob`/support-job/current-job behavior is not the final capability model;
+- current formulas are conservative scaffolds, not the main product roadmap;
+- current broad FFXI data/system coverage is less important than proving a cohesive life/adventure loop.
+
+## Product direction summary
+
+The intended game is a long-form, text-first fantasy life RPG built around:
+
+```text
+effort -> mastery -> efficiency -> capability -> larger ambition
+```
+
+The character should remain one continuous person. Jobs become recognizable disciplines/classifications rather than magical transformations. Learned capabilities may cross discipline boundaries when the character satisfies their proficiency, equipment, preparation, resource, and context requirements.
+
+Simulation time and wall-clock time must be separable so fictional grind can retain weight without forcing unnecessary real-world waiting.
+
+Construction/resource progression should be driven by physical scale, upgrades, specialization, logistics, and infrastructure rather than arbitrary exponential costs for repeated identical work.
+
+The game remains text-first; limited icons, tokens, meters, cards, and diagrams are encouraged where they improve comprehension without creating a full graphical-world production burden.
+
+See `docs/DEVELOPMENT_DIRECTION.md` for the full policy.
+
+## Release phases
+
+| Product phase | Theme | Player-facing gate |
 | --- | --- | --- |
-| 0.2.x | Foundation pipeline, version tracking, benchmarks, registries | Tests, benchmark harness, docs |
-| 0.3.x | Places, zone connections, travel restrictions, tick-based travel, POIs, starter services | Zone graph tests, POI tests, travel benchmark |
-| 0.4.x | Slash UI, account saves, character creation, inventory, equipment, starter item modifiers | Save/schema tests, UI command tests, equipment stat tests |
-| 0.6.0 | Canvas-first text UI shell | Canvas action/layout/input tests |
-| 0.5.x | Combat rewards, leveling, enemies, loot, item schema, magic basics, enemy AI | Battle/progression benchmarks and deterministic combat tests |
-| 0.6.x | Quests, trusts, enmity, party AI, progression flags | Quest and trust AI tests |
-| 0.7.x | Achievements, missions, skillchains, magic bursts, reputation | Formula confidence documentation |
-| 0.8.x | Crafting, mounts, advanced travel/economy | Crafting and travel benchmark coverage |
+| `0.4` | Foundation closeout and direction lock | Architecture is ready for simulation/capability work without another rewrite. |
+| `0.5` | World time, tasks, projects | Multi-hour/day fictional work can be advanced, interrupted, summarized, and completed without real-time waiting. |
+| `0.6` | Capabilities, disciplines, origins, livelihood | One continuous character can mix learned disciplines logically through loadout/preparation and participate in a livelihood. |
+| `0.7` | First complete game loop | A new player can live through a representative first week combining work, preparation, travel, danger, recovery, and permanent progress. |
+| `0.8` | Life/infrastructure expansion | Buildings, tools, farming/gathering, crafting, taming, relationships, and logistics materially transform earlier work. |
+| `0.9` | Adventure depth and release hardening | Combat/magic/content/balance/UI/persistence are content-complete and release-candidate quality. |
+| `1.0` | Live Foundation | Core product promise is coherent, stable, migratable, and playable as a persistent long-form RPG. |
 
-## Phase 0: Reset shell
+Detailed sub-milestones (`0.x.100`, `0.x.200`, etc.) are defined in `docs/VERSIONING_AND_RELEASE_ROADMAP.md`.
 
-Status: complete enough for current development.
+## Version protocol summary
 
-- [x] Strip active graphical UI entry path.
-- [x] Add text command shell.
-- [x] Add slash-command UI wrapper.
-- [x] Add canvas-first UI host with command-backed buttons and canvas command input.
-- [x] Add local account/character save adapter.
-- [x] Add encoded localStorage payloads.
-- [x] Add README and changelog.
-- [x] Add basic dev package metadata and tests.
+Future product versions use:
 
-## Phase 1: Entity foundation
+```text
+MAJOR.PHASE.TRACK.REVISION
+```
 
-Status: mostly complete.
+Example:
 
-- [x] Define player, NPC, and enemy entities.
-- [x] Define identity, job, equipment, wallet, progression, status, and combat containers.
-- [x] Add seed NPCs and enemies.
-- [x] Add conservative stat engine.
-- [x] Add status engine.
-- [x] Add simple battle-state engine.
-- [x] Add schema validation helpers.
-- [x] Add command parser with arguments instead of whole-command matching.
-- [x] Add version manifest and system version map.
-- [x] Add database registry for all major planned systems.
-- [x] Add live tick engine scaffold.
-- [x] Add baseline benchmark harness.
-- [x] Add baseline pipeline, system catalog, and research reference docs.
-- [ ] Add explicit save migration/reset tooling beyond the current legacy raw-save migration.
+```text
+0.5.300.4
+```
 
-## Phase 2: Character creation and inspection
+- `MAJOR`: product stability generation (`0` pre-live, `1` live).
+- `PHASE`: major release milestone.
+- `TRACK`: three-digit scoped sub-milestone, normally in increments of 100.
+- `REVISION`: simple integration counter within the track.
 
-Status: mostly complete for a starter shell.
+The historical `0.4.4` release is not retroactively renumbered.
 
-- [x] Character creation flow: name, nation, race, sex, starting job, confirmation.
-- [x] New Character entry from main menu via `/newcharacter`.
-- [x] Job list and race list commands.
-- [x] Full character sheet output.
-- [x] Equipment sheet output.
-- [x] Account character listing and load commands.
-- [x] UI character-slot cards/buttons.
-- [ ] Support job unlock placeholder.
+Because npm package versions are three-part SemVer, the product version must be decoupled from `package.json.version` when the new protocol is implemented. Do not write a four-numeric-segment product version directly into `package.json.version`.
 
-## Phase 3: World graph, zones, and travel
+## 0.4 current work
 
-Status: starter implementation complete.
+### Complete enough
 
-- [x] Places database: starter cities, starter wilderness, starter dungeon hooks.
-- [x] Zone schema with region, type, danger level, restrictions, services, map unlocks.
-- [x] Zone connection schema with directionality, travel time, mode, and restrictions.
-- [x] Travel restrictions scaffold: level, key item, quest flag, nation/rank, mount permission, combat state, content lock.
-- [x] Travel command.
-- [x] Tick-based travel progress via manual wait/tick scaffold.
-- [x] Zone inspection command.
-- [x] Travel benchmark for zone graph lookup.
-- [x] Coordinate-grid atlas discovery where unvisited grids stay unknown.
-- [x] San d’Oria city alphanumeric coordinate topology with explicit navigable coordinates and exits.
-- [x] Direction-aware coordinate navigation engine with movement timing metadata.
-- [x] Canvas 3x3 compass rose with direct movement intents and Auto Run state.
-- [x] Foot-travel aggro scaffold by grid spawn rule, spawn count, and aggro type.
-- [ ] Expand non-San d’Oria city POIs and exits with higher-fidelity coordinates.
-- [ ] Add interior/Mog House places instead of temporary Mog House access flag.
+- [x] Text/canvas shell.
+- [x] Command adapters.
+- [x] Current account/save foundation.
+- [x] Core entity/state/data separation.
+- [x] World/travel/atlas scaffolds.
+- [x] Inventory/equipment/item/shop foundations.
+- [x] Combat/reward/progression scaffolds.
+- [x] Validation/test/benchmark infrastructure.
+- [x] Development direction documented on planning branch.
+- [x] Four-part version protocol and 1.0 milestone plan documented on planning branch.
 
-## Phase 4: Inventory, items, key items, and equipment
+### Remaining 0.4 closeout
 
-Status: starter framework implemented.
+- [ ] Implement product/package version separation.
+- [ ] Add ordered persistence migrations.
+- [ ] Introduce a small structured action-result contract.
+- [ ] Add lightweight semantic events without full event sourcing.
+- [ ] Stabilize existing systems against the new contracts.
 
-- [x] Inventory container schema.
-- [x] Main Inventory container.
-- [x] Mog Safe, Mog Safe 2, Storage, Mog Locker, Satchel, Sack, Case, Wardrobes 1-8.
-- [x] Storage capacity tied to Mog House furniture.
-- [x] Mog House-only access rules for Storage/Mog Safe.
-- [x] Anywhere/locked rules for portable containers.
-- [x] Equipment-only Wardrobe rules.
-- [x] Container transfer command.
-- [x] Starter equipment catalog.
-- [x] Stat aggregation from equipped gear.
-- [x] Equip/unequip commands.
-- [x] Shop buying into Inventory.
-- [x] New full item schema foundation.
-- [x] Inventory stack handling.
-- [ ] Key item schema for unlocks and permissions.
-- [x] Equipment validation by job/race/level.
-- [x] Item flag/effect schema foundation: rare, exclusive, key item, no sell, latent, enchantment, charges.
-- [x] Item command inspection.
-- [x] Runtime behavior metadata inspection for latent effects, enchantments, charges, ranged/ammo, and restricted selling.
-- [x] Conservative selling and vendor restrictions.
+## 0.5 focus — simulation substrate
 
-## Phase 5: Leveling, skills, and progression
+- [ ] Deterministic world clock independent of `Date.now()`.
+- [ ] Pause and speed/fast-forward semantics.
+- [ ] Canonical timed task model.
+- [ ] Meaningful interrupt model.
+- [ ] Day boundary and end-of-day auto-pause/review.
+- [ ] Persistent material/labor project model.
+- [ ] Integrate travel plus one work activity with world time.
 
-Target: 0.5.x.
+## 0.6 focus — continuous character capability
 
-- [x] EXP tables and level-up rules.
-- [x] Reward EXP routed through progression engine.
-- [x] HP/MP/resource refresh after level-up.
-- [x] EXP-to-next tracking.
-- [x] Level-cap behavior.
-- [x] Job-level state for all unlocked jobs with per-job EXP.
-- [ ] Level cap / limit break placeholders beyond simple cap enforcement.
-- [x] Combat and magic skill cap data-helper foundation.
-- [x] Character-owned current skill state and inspection commands.
-- [x] Validation for flat `player.progression.skills[skillId]` values.
-- [x] Isolated deterministic skill-gain hooks for basic attacks, placeholder weapon skills, and placeholder spell casts.
-- [ ] Wire combat and magic skill caps into formulas.
-- [ ] Progression flags for maps, teleport points, mounts, trusts, quests, missions, achievements.
+- [ ] Learned capability/proficiency model.
+- [ ] Jobs represented as disciplines/classifications rather than magical active states.
+- [ ] Hard/soft/enhancing equipment and preparation prerequisites.
+- [ ] Cross-discipline capability use where prerequisites are met.
+- [ ] Origin-based starting circumstances.
+- [ ] First complete livelihood loop.
+- [ ] Loadout UX showing enabled/penalized/blocked capabilities.
 
-## Phase 6: Combat, enemies, loot, and drops
+## 0.7 focus — first complete representative game
 
-Target: 0.5.x.
+Working slice: **A Week Beyond the West Gate**.
 
-- [x] Encounter command.
-- [x] Basic target attack flow.
-- [x] Placeholder weapon skill and cast commands.
-- [x] Deterministic combat RNG injection.
-- [x] EXP rewards.
-- [x] Gil rewards.
-- [x] Loot table schema.
-- [x] Drop roll engine.
-- [x] Inventory insertion through existing container rules.
-- [x] Duplicate reward payout guard.
-- [ ] Target selection improvements.
-- [ ] Enemy AI turn.
-- [ ] Battle tick integration.
-- [ ] Death/KO flow.
-- [ ] Simple rest/recovery flow.
+- [ ] Lightweight objective/quest state foundation.
+- [ ] Real starting foothold/home-base context.
+- [ ] One permanent project.
+- [ ] One livelihood/economy loop.
+- [ ] One meaningful West Gate expedition route.
+- [ ] Combat/KO/recovery adequate for the slice.
+- [ ] Multiple simulated days and end-of-day summaries.
+- [ ] Permanent end-of-week accomplishment/unlock.
+- [ ] At least two meaningfully different origin openings.
+- [ ] UI/action discoverability without command memorization.
 
-## Phase 7: Magic, abilities, and status systems
+## 0.8 focus — systemic life expansion
 
-Target: 0.5.x to 0.7.x.
+- [ ] Construction instances, renovations, capacity, and efficiency upgrades.
+- [ ] Gathering/farming depth.
+- [ ] Crafting/tools/facilities.
+- [ ] Taming/husbandry with practical value.
+- [ ] Persistent relationships and local/guild reputation.
+- [ ] Logistics and labor-saving infrastructure.
+- [ ] Additional disciplines/livelihood interactions.
+- [ ] Economy/resource sink balancing.
 
-- [x] Status effect lifecycle scaffold.
-- [x] Placeholder cast command.
-- [x] Recovered job ability and weapon skill display hooks.
-- [ ] Magic database.
-- [ ] Spell schema: skill, element, MP cost, cast time, recast, target, effect.
-- [ ] Cast-time tick integration.
-- [ ] Recast timers.
-- [ ] Interruption rules.
-- [ ] Job traits schema.
-- [ ] Job abilities schema.
-- [ ] Weapon skills as real combat actions.
-- [ ] TP return model.
-- [ ] Skillchains.
-- [ ] Magic bursts.
-- [ ] Food/song/roll/samba stacking rules.
+## 0.9 focus — content, adventure, and release candidate
 
-## Phase 8: Quests, achievements, missions, and reputation
+- [ ] Deeper enemy/combat behavior.
+- [ ] Structured magic and advanced capabilities consistent with the loadout model.
+- [ ] Second dense region proving content scalability.
+- [ ] Long-form progression/economy balance.
+- [ ] UI/accessibility/readability hardening.
+- [ ] Save migration/compatibility hardening.
+- [ ] Deterministic simulation/content validation/performance gates.
+- [ ] Content-complete beta.
+- [ ] Release-candidate feature freeze.
 
-Target: 0.6.x to 0.7.x.
+## 1.0 minimum promise
 
-- [x] Starter quest/mission POI hooks.
-- [ ] Quest database.
-- [ ] Quest state machine: unavailable, available, active, readyToTurnIn, completed, repeatableCooldown.
-- [ ] Quest objectives: talk, kill, collect, travel, craft, unlock, inspect.
-- [ ] Quest rewards: EXP, gil, items, key items, titles, fame, unlocks.
-- [ ] Achievements database.
-- [ ] Achievement triggers.
-- [ ] Nation mission/rank progression.
-- [ ] Fame/reputation containers.
+1.0 should not be declared merely because a checklist is large. It requires a coherent persistent game.
 
-## Phase 9: Trusts and AI companions
+At minimum, a player must be able to:
 
-Target: 0.6.x.
+- begin from meaningful starting circumstances;
+- develop one persistent character across disciplines;
+- alter practical capability through logical equipment/preparation rather than magical job changes;
+- work, learn, build, travel, prepare, fight, recover, and improve;
+- use pause/fast-forward while preserving fictional time costs and meaningful interrupts;
+- pursue long-duration projects with logical material/labor costs;
+- improve infrastructure so mastered chores consume less attention;
+- build relationships/reputation that affect available opportunities;
+- experience representative taming/creature systems if retained in the 1.0 scope;
+- play through at least two dense regional content spaces;
+- save/load under an explicit supported migration contract;
+- play normal flows without command-line expertise;
+- understand game state through text-first presentation with limited visual polish.
 
-- [x] Trust POI action placeholder.
-- [ ] Trust database.
-- [ ] Trust unlock key items/flags.
-- [ ] Party slot rules.
-- [ ] Trust summon/dismiss commands.
-- [ ] Trust role profiles: tank, healer, melee, ranged, caster, support.
-- [ ] Trust AI tick integration.
-- [ ] Enmity model.
-- [ ] Trust spell/ability access.
+## Formula policy
 
-## Phase 10: Crafting, mounts, and advanced travel
+Formula work remains important but no longer leads the product roadmap.
 
-Target: 0.8.x.
+Use formula confidence categories:
 
-- [x] Starter guild service hooks and recipe previews.
-- [ ] Crafting recipe database.
-- [ ] Crystals and ingredient rules.
-- [ ] Crafting skill checks.
-- [ ] HQ/failure model.
-- [ ] Crafting guild/support hooks.
-- [ ] Mount database.
-- [ ] Mount unlock key items.
-- [ ] Mount zone restrictions.
-- [ ] Mount travel speed modifiers.
-- [ ] Mount interaction with encounters.
+- exact / sourced;
+- researched approximation;
+- intentional simplification;
+- placeholder.
 
-## Phase 11: Formula refinement
-
-Target: ongoing.
-
-- [ ] Replace placeholder stat formulas with sourced formulas where useful.
-- [ ] Separate exact, approximate, and intentionally simplified mechanics.
-- [ ] Add formula confidence annotations.
-- [ ] Add balancing tests and golden-character snapshots.
-- [ ] Expand benchmarks as systems become runtime-heavy.
+Refine formulas when they improve a player-facing loop that already has a reason to exist. Do not delay world time, capabilities, livelihoods, objectives, projects, or the first complete slice merely to chase retail-exact combat math.
 
 ## Current recommended next pass
 
-The next best implementation pass is conservative formula and item behavior application planning:
+After this planning branch is reviewed/merged, the next runtime pass should target `0.4.200`:
 
-1. Keep latent effects, enchantments, charges, and ranged/ammo records metadata-only until action/combat semantics are explicit.
-2. Wire skill caps into combat and magic formulas only after current skill state, skill-gain flow, and confidence labels are explicit.
-3. Keep skill-gain pacing deterministic until a tested RNG policy is introduced.
-4. Add validation/tests before expanding loot tables or applying item behavior in combat.
+1. introduce an authoritative four-part product version;
+2. decouple it from the private npm package SemVer;
+3. update version display/tests/docs;
+4. then proceed to ordered persistence migrations before adding new persistent simulation state.

--- a/docs/THREAD_HANDOFF.md
+++ b/docs/THREAD_HANDOFF.md
@@ -2,37 +2,78 @@
 
 This file is the first document a new ChatGPT/Codex thread should read before continuing work on this repo.
 
+## Read order
+
+Before planning implementation, read:
+
+1. `docs/DEVELOPMENT_DIRECTION.md` — authoritative design north star.
+2. `docs/VERSIONING_AND_RELEASE_ROADMAP.md` — authoritative product-version protocol and path to 1.0.
+3. `docs/ROADMAP.md` — current implementation summary and release-phase index.
+4. `docs/ARCHITECTURE.md` — runtime/module boundaries.
+5. `js/text/version.js` — current runtime/system version state.
+
+`docs/planning/DEVELOPMENT_PIPELINE_AND_MILESTONES.md` is historical planning from the earlier formula/item-behavior direction. Its recommended milestone order is superseded.
+
 ## Project intent
 
-The repo is being reset into a text-first, expandable FFXI-inspired RPG foundation. The active runtime should stay text based. Graphical/non-text systems should not be rebuilt unless explicitly requested.
+The project is a text-first fantasy life RPG with FFXI-inspired weight, preparation, danger, jobs/disciplines, equipment, travel, and earned accomplishment.
 
-Core design goals:
+It is **not** intended to become a text transcription of retail FFXI.
 
-- Stable and expandable frame first.
-- Canvas-first text UI with intent-backed global UI and compass controls plus command-backed gameplay buttons.
-- Local account and character save slots.
-- San d’Oria city zones use alphanumeric coordinate topology with explicit navigable coordinates and exits.
-- Zone atlas reveals visited coordinates/grids only.
-- Resource bars, visual tick timer metadata, and 8-way compass/keypad metadata.
-- Travel by foot can trigger grid-based aggro based on spawn rules, count, and aggro type.
-- Action controls should separate auto attack, weapon skills, magic, items, travel, interaction, etc.
-- Backwards compatibility should not be considered until explicitly requested.
+The long-term product combines:
 
-Suggested local repo path for Codex desktop work:
+- persistent character/life progression;
+- simulated days and long fictional timescales;
+- measurable mastery and efficiency gains;
+- livelihoods, projects, construction, infrastructure, relationships, and taming;
+- dangerous expeditions, combat, travel, equipment, and magic;
+- text/tabletop-style presentation with limited icons/tokens/meters/diagrams;
+- deterministic/testable simulation systems.
+
+Core progression law:
 
 ```text
-C:\Codex\ffxi-text-rpg
+effort -> mastery -> efficiency -> capability -> larger ambition
 ```
+
+Avoid arbitrary exponential costs for repeated identical work. Increase resource demand through physical scale, upgrades, specialization, logistics, infrastructure, and more ambitious projects.
+
+Simulation time and wall-clock time are separate concepts. Fictional grind may be substantial; avoid unnecessary real-world waiting by supporting pause/fast-forward/advance semantics and end-of-day review.
+
+## Jobs/disciplines direction
+
+The current `mainJob`/support-job/current-job architecture is transitional.
+
+Long-term rule:
+
+```text
+Jobs describe.
+Capabilities enable.
+Loadouts constrain and enhance.
+```
+
+Jobs remain recognizable disciplines/training traditions, but equipment does not magically transform the character into another job.
+
+Ability eligibility should gradually depend on:
+
+- learned capability;
+- proficiency/mastery;
+- equipment;
+- hard/soft requirements;
+- focus/ammunition/reagents/tools;
+- resources;
+- status/condition;
+- preparation;
+- context;
+- formal advanced training where logically required.
+
+Characters may use capabilities associated with several disciplines at once when prerequisites are satisfied. Balance comes from loadout, resource, preparation, proficiency, encumbrance, and action-economy tradeoffs rather than one universal support-job slot.
+
+Do not rip the existing job code out in a broad rewrite. Migrate behind tested interfaces during the 0.6 capability phase.
 
 ## Current version state
 
-Authoritative file:
-
-```text
-js/text/version.js
-```
-
-Current state at handoff:
+Historical runtime baseline:
 
 ```text
 App/package: 0.4.4
@@ -42,40 +83,41 @@ Data: 13
 Codename: Conservative Skill Gains
 ```
 
-Major active system versions:
+The historical `0.4.4` build remains on the old three-part application/package scheme.
+
+The new product protocol is:
 
 ```text
-slashCommands: 0.4.1
-canvasUi: 0.7.0
-accountSaves: 0.5.2
-saveEncoding: 0.4.1
-validation: 0.6.0
-playerEntity: 0.5.4
-statEngine: 0.4.0
-equipmentCommands: 0.5.0
-equipmentEligibility: 0.5.0
-itemInspection: 0.5.1
-itemBehavior: 0.1.0
-equipmentCatalog: 0.6.0
-inventoryContainers: 0.5.1
-inventoryTransfers: 0.5.1
-itemSchema: 0.6.0
-itemStacking: 0.5.1
-skillCaps: 0.5.1
-skillProgression: 0.5.2
-battleEngine: 0.5.0
-combatActions: 0.5.1
-battleRewards: 0.5.2
-progression: 0.5.3
-expTables: 0.5.2
-jobSwitching: 0.5.3
-leveling: 0.5.3
-loot: 0.5.0
-shops/shopTransactions: 0.3.8
-coordinates/navigation: 0.1.0
-pois/poiDiscovery/poiFastTravel: 0.3.5
-travel/gridMovement/zoneAtlas: 0.4.0
+MAJOR.PHASE.TRACK.REVISION
 ```
+
+Example:
+
+```text
+0.5.300.4
+```
+
+Do not place a four-numeric-segment version directly into `package.json.version`; npm uses three-part SemVer. Product/package version separation is the next versioning implementation target.
+
+See `docs/VERSIONING_AND_RELEASE_ROADMAP.md` for the complete protocol.
+
+## Current recommended runtime sequence
+
+From the current foundation:
+
+1. `0.4.200` — product/package version-manifest separation;
+2. `0.4.300` — ordered persistence migrations;
+3. `0.4.400` — structured action-result contract;
+4. `0.4.500` — lightweight semantic events;
+5. close 0.4 without rewriting current systems;
+6. 0.5 — deterministic world time, pause/fast-forward, tasks, interrupts, end-of-day, projects;
+7. 0.6 — continuous-character capabilities, jobs as disciplines, origins, first livelihood;
+8. 0.7 — first complete life/adventure vertical slice, **A Week Beyond the West Gate**;
+9. 0.8 — construction/life/infrastructure/taming/relationships/crafting/logistics depth;
+10. 0.9 — adventure/magic/content expansion, balance, persistence, UI, release hardening;
+11. 1.0 — Live Foundation.
+
+Formula refinement is still important, but it no longer leads the roadmap. Refine formulas when they materially improve an already-meaningful player-facing loop.
 
 ## Development commands
 
@@ -87,11 +129,27 @@ npm run check
 
 Use Node 20+.
 
+## Current browser entry path
+
+```text
+index.html
+  -> js/main.js
+      -> createCanvasApp(canvas)
+          -> loadActiveCharacter() or createInitialState()
+          -> createCommandRouter(state)
+          -> createSlashCommandRouter(state)
+          -> canvas layout/input/render loop
+```
+
+The active UI is canvas-first. Game logic should remain independent of canvas/DOM rendering.
+
 ## UI command model
 
-The browser UI is canvas-first. HTML provides one canvas host; all visible game UI is canvas-rendered.
+The left canvas sidebar uses direct navigation intents and command-backed gameplay/global actions.
 
-The left canvas sidebar has direct compass/navigation intent actions and clickable global actions backed by existing `commandRouter.js` commands:
+The bottom canvas input accepts bare command-router commands and leading-slash commands where `slashCommandRouter.js` owns account/menu behavior.
+
+Representative commands:
 
 ```text
 character
@@ -107,11 +165,18 @@ battle
 help
 validate
 save
+move n
+travel West Ronfaure
+wait 60
+item Bronze Sword
+inspect item Bronze Sword
+equip Bronze Sword
+shop Ashene
+buy Bronze Sword
+sell Bronze Sword
 ```
 
-The bottom canvas input accepts bare command-router commands and still accepts slash commands where `slashCommandRouter.js` owns account/menu behavior.
-
-Main commands:
+Account/menu commands include:
 
 ```text
 /menu
@@ -125,49 +190,14 @@ Main commands:
 /reset
 ```
 
-Gameplay examples:
+FFXI macro-style commands such as `/ma`, `/ja`, `/ws`, `/item`, `/equipset`, `/recast`, and `/echo` remain compatible adapters where supported.
 
-```text
-look
-stats
-skills
-skill axe
-inspect skills
-inspect skill axe
-inventory
-item Bronze Sword
-inspect item Bronze Sword
-equipment
-containers
-container inventory
-transfer Bronze Sword from inventory to wardrobe1
-equip Bronze Sword
-unequip mainHand to wardrobe1
-here
-talk Ashene
-shop Ashene
-buy Bronze Sword
-sell Bronze Sword
-zonefast
-move n
-travel West Ronfaure
-wait 60
-validate
-```
+## Current character creation
 
-FFXI macro-style commands such as `/macrohelp`, `/ma`, `/ja`, `/ws`, `/item`, `/equipset`, `/recast`, and `/echo` are preserved with their leading slash and routed through the FFXI command adapter.
-
-## Character creation flow
-
-Start with:
+Current flow is still transitional:
 
 ```text
 /newcharacter
-```
-
-While prompts are active, answers do not use `/`. Current prompt order is name, nation, race, sex, starting job, then confirmation:
-
-```text
 CharacterName
 sandoria
 hume
@@ -176,232 +206,112 @@ warrior
 yes
 ```
 
-When confirmed, the character is saved automatically.
+The future 0.6 direction replaces a simple starting-job emphasis with origins/starting circumstances while preserving logical discipline training.
 
 ## Save/account model
 
-File:
+Current files/state:
 
 ```text
 js/text/save.js
-```
-
-LocalStorage keys:
-
-```text
 ffxiTextRpgAccounts
 ffxiTextRpgAccountSession
-```
-
-Encoding:
-
-```text
 base64-json-v1
 ```
 
-Important caveat: this is encoded, not strong encryption. It avoids plain JSON in localStorage but is not secure against browser/devtools access. Real encryption should use a password-derived key or platform key later.
+The payload is encoded, not cryptographically protected.
 
-Save structure includes:
+Important current compatibility rule:
 
-- account profile
-- last active character ID
-- character summary records
-- encoded full character game states
-
-Legacy migration:
-
-- Old raw `ffxiTextRpgSave` and legacy single-account `ffxiTextRpgAccount` are read only for migration when no current account save exists.
-- Valid legacy saves are migrated into the encoded account model.
-- Save load must call `reviveGameState()` to relink `player.inventory` to `player.inventoryState.containers.inventory.items`.
-
-## Current browser entry path
+`reviveGameState()` relinks:
 
 ```text
-index.html
-  -> js/main.js
-      -> createCanvasApp(canvas)
-          -> loadActiveCharacter() or createInitialState()
-          -> createCommandRouter(state)
-          -> createSlashCommandRouter(state)
-          -> canvas layout/input/render loop
+player.inventory
 ```
 
-Relevant UI files:
+to:
 
 ```text
-js/main.js
-js/text/ui/canvasApp.js
-js/text/ui/canvasRenderer.js
-js/text/ui/canvasLayout.js
-js/text/ui/canvasInput.js
-js/text/ui/uiActions.js
-js/text/ui/uiTheme.js
-js/text/slashCommandRouter.js
-css/style.css
+player.inventoryState.containers.inventory.items
 ```
+
+after JSON load.
+
+Do not add large amounts of new persistent simulation state before the ordered migration mechanism planned for `0.4.300`.
 
 ## Core systems already implemented
 
-### World and travel
+### World/travel
 
-Files:
+Implemented foundations include:
 
-```text
-js/text/data/maps.js
-js/text/data/places.js
-js/text/systems/atlasEngine.js
-js/text/systems/travelEngine.js
-js/text/systems/aggroEngine.js
-```
+- starter cities and wilderness/dungeon hooks;
+- San d'Oria alphanumeric topology;
+- coordinate navigation and atlas discovery;
+- zone graph and travel restrictions scaffold;
+- grid movement;
+- foot-travel aggro scaffold;
+- POI discovery and same-zone fast travel.
 
-Implemented:
+### Inventory/items/equipment/economy
 
-- starter cities and starter outdoor/dungeon hooks
-- San d'Oria city topology coordinates with explicit alphanumeric nodes and exits
-- legacy numeric grids for non-San d'Oria wilderness/city areas until those zones are expanded
-- connection grids / departure and arrival coordinates
-- zone graph
-- direct travel command
-- travel restrictions scaffold
-- atlas discovery with unknown unvisited coordinates/grids
-- 8-way coordinate movement where topology exists, with legacy numeric movement elsewhere
-- foot-travel aggro scaffold
+Implemented foundations include:
 
-### POIs, shops, guilds, quests
+- Inventory, Mog Safe/Safe 2, Storage, Locker, Satchel, Sack, Case, Wardrobes 1-8;
+- container access/capacity/stacking rules;
+- item normalization/schema;
+- equipment eligibility and stat modifiers;
+- item inspection;
+- shop buying/selling;
+- metadata-only latent/enchantment/charge/ranged-ammo behavior.
 
-Files:
+### Skills/progression
 
-```text
-js/text/data/pointsOfInterest.js
-js/text/data/shopCatalogs.js
-js/text/data/guildServices.js
-js/text/data/questHooks.js
-js/text/systems/poiEngine.js
-js/text/systems/shopEngine.js
-js/text/systems/itemBehaviorEngine.js
-```
+Implemented foundations include:
 
-Implemented:
+- character-owned current skills in `player.progression.skills`;
+- sparse skill cap scaffolds;
+- deterministic +1 gain hooks for representative combat/cast actions;
+- EXP/leveling/reward/loot scaffolds.
 
-- starter-city POIs
-- current-grid POI actions
-- POI discovery
-- same-zone POI fast travel
-- starter shop catalogs
-- starter guild service/recipe previews
-- starter quest/mission hooks
-- buying from shops into Inventory
-- conservative selling from Inventory at current shop POIs
-- item behavior metadata helpers for sell restrictions, latent effects, enchantments, charges, and ranged/ammo records
+Current skill caps and formulas are not authoritative retail FFXI data.
 
-Selling intentionally stays conservative: key items, `noSell`, and zero-value items are rejected by default; `noTrade`, `noDrop`, and `noAuction` are described as metadata but are not enforced as shop-sale restrictions yet.
+### Combat/status/ticks
 
-### Inventory, items, storage, wardrobes
+Implemented foundations include:
 
-Files:
+- battle state;
+- deterministic RNG injection;
+- basic attacks;
+- placeholder weapon skill/cast actions;
+- rewards;
+- status lifecycle;
+- wall-clock tick scaffold.
 
-```text
-js/text/data/itemSchema.js
-js/text/data/inventoryContainers.js
-js/text/data/skillCaps.js
-js/text/data/mogHouseFurniture.js
-js/text/systems/inventoryEngine.js
-js/text/systems/itemBehaviorEngine.js
-```
+The current tick engine is not the final world-time engine. 0.5 should separate deterministic simulation time from wall-clock scheduling.
 
-Implemented containers:
+## Important architectural rules
 
-```text
-Inventory
-Mog Safe
-Mog Safe 2
-Storage
-Mog Locker
-Mog Satchel
-Mog Sack
-Mog Case
-Mog Wardrobe 1-8
-```
-
-Rules:
-
-- Inventory accessible anywhere.
-- Mog Safe and Storage require Mog House context.
-- Storage capacity is derived from placed furniture.
-- Satchel/Sack/Case exist but are locked by default.
-- Wardrobe 1 is unlocked by default, equipment-only, accessible anywhere.
-- Wardrobes 2-8 exist but are locked by default.
-- Item normalization adds kind, quantity, stackable, maxStack, tags, source, template metadata, family/archetype/subtype, requirements, flags, effects, latent/enchantment/augment scaffolds, charges, modifiers, and equipmentSlot/allowedSlots fields.
-- Stackable consumables/materials/misc items merge into existing stacks when possible.
-- Container transfers are atomic and enforce source access, destination access, capacity, item-kind, and stack rules.
-- Inventory quantity removal is used by shop selling so gil is credited only after item removal succeeds.
-- Latent effects, enchantments, charges, and ranged/ammo behavior are inspectable metadata only; they are not wired into combat formulas yet.
-- Sparse skill rank/cap helpers exist for current skill-gain clamping and later combat/magic formula integration.
-- Character-owned current skills live in `player.progression.skills[skillId]`. Do not reintroduce per-job skill storage maps.
-- `skills`, `skill <id>`, `inspect skills`, and `inspect skill <id>` describe current character-owned skill values against the active main-job cap scaffold.
-- Basic attacks, placeholder weapon skills, and placeholder spell casts can add deterministic +1 learned skill when the active main job has room under its current cap.
-
-Temporary limitation: Mog House is currently a boolean access context, not a real zone/interior yet.
-
-### Equipment and stats
-
-Files:
-
-```text
-js/text/data/equipmentCatalog.js
-js/text/systems/equipmentEngine.js
-js/text/systems/statEngine.js
-```
-
-Implemented:
-
-- equip from Inventory or accessible Wardrobe
-- unequip to valid destination container
-- replacement gear returns safely
-- slot inference from `equipmentSlot` or tags
-- eligibility validation by job, race, level, allowed slot, two-handed/offhand conflicts, and ranged/ammo slot constraints
-- `item <query>` and `inspect item <query>` for text-first item template/runtime/behavior inspection
-- starter equipment modifiers affect combat profile
-
-Starter gear bonuses, eligibility, and delay values are conservative placeholders or intentional simplifications, not exact FFXI formulas.
-
-### Combat, rewards, and actions
-
-Files:
-
-```text
-js/text/data/lootTables.js
-js/text/systems/battleEngine.js
-js/text/systems/combatActionEngine.js
-js/text/systems/rewardEngine.js
-js/text/systems/rng.js
-js/text/systems/statusEngine.js
-js/text/systems/tickEngine.js
-```
-
-Implemented:
-
-- basic encounter/battle state
-- deterministic RNG injection for battle attacks and tests
-- basic attack flow
-- placeholder weapon skill/cast commands
-- deterministic skill-gain hooks for basic attacks, placeholder weapon skills, and placeholder spell casts
-- starter loot tables
-- victory reward resolution for EXP, gil, loot rolls, Inventory insertion, and duplicate payout prevention
-- status lifecycle scaffold
-- tick engine scaffold
-
-Not implemented yet:
-
-- enemy AI turn depth
-- death/KO flow
-- real magic/recast/cast-time integration
-- random/retail-like skill-up pacing and skill-cap use in damage or magic formulas
+- Keep active runtime text-first.
+- Limited icons/tokens/meters/diagrams are acceptable; do not rebuild a full graphical world unless explicitly requested.
+- Keep logic independent of rendering.
+- Keep command input/UI buttons as adapters into the same gameplay actions.
+- Prefer small modules and data-driven stable IDs.
+- Do not implement full event sourcing merely because semantic events are added.
+- Add explicit migrations when persistent schema changes.
+- Do not store new saves as raw plain JSON.
+- Preserve `player.inventory` compatibility until deliberately migrated with tests.
+- Use formula confidence labels: exact/sourced, researched approximation, intentional simplification, placeholder.
+- Add tests/version/docs for major runtime changes.
+- Do not treat backwards compatibility as guaranteed pre-1.0; migration/reset decisions must still be explicit.
 
 ## Important tests
 
+Representative current tests include:
+
 ```text
 tests/saveAccount.test.js
+tests/pipeline.test.js
 tests/slashCommandRouter.test.js
 tests/canvasUi.test.js
 tests/equipmentEngine.test.js
@@ -423,45 +333,25 @@ tests/characterCreation.test.js
 tests/uiPanels.test.js
 ```
 
-New work should add tests in the same style using Node's built-in `node:test`.
+Use Node's built-in `node:test` style for new tests.
 
-## Documentation status
+## First representative gameplay target
 
-Updated for this handoff:
+Working 0.7 vertical slice: **A Week Beyond the West Gate**.
 
-```text
-README.md
-docs/ARCHITECTURE.md
-docs/ROADMAP.md
-docs/THREAD_HANDOFF.md
-CHANGELOG.md
-```
+It should combine:
 
-Still useful but may need future refresh as systems deepen:
+- multiple origins;
+- a modest starting foothold;
+- one livelihood/gathering loop;
+- local economy;
+- one persistent material/labor project;
+- simulated days and end-of-day review;
+- preparation;
+- one meaningful expedition;
+- travel danger and combat;
+- recovery/return-home loop;
+- measurable capability growth;
+- one permanent end-of-week accomplishment/unlock.
 
-```text
-docs/BASELINE_PIPELINE.md
-docs/SYSTEM_CATALOG.md
-docs/RESEARCH_REFERENCES.md
-```
-
-## Current recommended next pass
-
-The next best implementation pass is conservative formula and item behavior application planning:
-
-1. Keep latent effects, enchantments, charges, and ranged/ammo records metadata-only until their action/combat semantics are explicit.
-2. Decide how skill caps feed combat and magic formulas before using learned/effective skill values in formulas.
-3. Keep skill-gain pacing deterministic unless a tested RNG policy is added.
-4. Keep formula-sensitive values labeled as exact, approximate, simplified, or placeholder.
-
-Important: `skillCaps.js` still should not be treated as exact retail formula data. Current skills now live on the character and can increase through isolated hooks, but do not wire those caps into combat or magic calculations until the formula semantics are explicitly designed and tested.
-
-## Rules for future agents
-
-- Do not reintroduce graphical map/image systems unless explicitly requested.
-- Do not remove the command router or slash-command compatibility; canvas buttons should dispatch existing commands.
-- Do not store new saves as raw plain JSON.
-- Do not break `player.inventory` compatibility without updating save revive logic and tests.
-- Do not add exact FFXI formulas unless sourced and documented.
-- Do not skip tests/version/docs for major runtime changes.
-- Backwards compatibility is out of scope unless the user says otherwise.
+The goal is to prove that life-building and adventure are one connected game rather than separate minigames.

--- a/docs/VERSIONING_AND_RELEASE_ROADMAP.md
+++ b/docs/VERSIONING_AND_RELEASE_ROADMAP.md
@@ -1,0 +1,865 @@
+# Versioning and Release Roadmap
+
+This document defines the product-version protocol and the planned release path from the current rough foundation to a coherent 1.0 release.
+
+The roadmap is intentionally milestone-driven rather than calendar-driven. A version changes because its exit criteria are met, not because a date arrived or a large number of commits accumulated.
+
+`docs/DEVELOPMENT_DIRECTION.md` is the design north star. This document translates that direction into version gates.
+
+## Current baseline and transition
+
+The current repository uses a legacy three-part application/package version:
+
+```text
+0.4.4
+```
+
+That number describes a very early foundation build. It should not be read as “44% complete” or as a promise that 0.5 is nearly production-ready.
+
+The existing project is architecturally useful but still pre-alpha in product terms: it has many system scaffolds and relatively little complete game experience.
+
+The new protocol should not retroactively renumber historical releases. `0.4.4` remains the historical baseline. The four-part product-version format begins when the version manifest is deliberately migrated in a runtime PR.
+
+## Product version format
+
+Use:
+
+```text
+MAJOR.PHASE.TRACK.REVISION
+```
+
+Example:
+
+```text
+0.5.300.4
+```
+
+Meaning:
+
+| Segment | Meaning |
+| --- | --- |
+| `MAJOR` | Product stability/compatibility generation. `0` means pre-1.0 development; `1` begins the live compatibility contract. |
+| `PHASE` | Major pre-release milestone or, after 1.0, the live feature line. Examples: `0.5`, `0.7`, `0.9`. |
+| `TRACK` | Three-digit scoped sub-milestone within the phase. Planned tracks normally advance by 100: `100`, `200`, `300`, etc. |
+| `REVISION` | Incremental integration counter inside the active track. It starts at `0` and increments for merged runtime changes that advance or repair that track. |
+
+### Why the track is three digits
+
+Using `100`, `200`, `300` leaves room to insert unforeseen work without renumbering the entire roadmap.
+
+For example:
+
+```text
+0.6.200.x  discipline classification
+0.6.250.x  inserted prerequisite refactor
+0.6.300.x  equipment/preparation eligibility
+```
+
+The roadmap numbers are therefore stable labels, not estimates of effort.
+
+## Revision handling
+
+The fourth segment is deliberately simple.
+
+Within one track:
+
+```text
+0.5.200.0
+0.5.200.1
+0.5.200.2
+0.5.200.3
+```
+
+A revision increment means a merged runtime-affecting change has advanced, fixed, or hardened the current track.
+
+When the track exit gate is met, move to the next track and reset the revision:
+
+```text
+0.5.200.7 -> 0.5.300.0
+```
+
+When the phase exit gate is met, move to the next phase:
+
+```text
+0.5.900.x -> 0.6.100.0
+```
+
+Do not bump the fourth segment for README wording, comments, planning notes, or other docs-only edits unless a release artifact itself is being corrected and the project explicitly chooses to version documentation releases.
+
+## Product version versus package version
+
+The project currently treats `VERSION.app` and `package.json.version` as the same value. That cannot continue unchanged because npm package versions use standard three-part SemVer while the product protocol uses four numeric segments.
+
+At protocol adoption, separate these concepts.
+
+Recommended model:
+
+```text
+Product/game version: 0.5.300.4
+Package/tooling version: 0.5.300
+```
+
+The four-part product version is authoritative for game-development milestones.
+
+`package.json.version` remains valid SemVer and normally mirrors `MAJOR.PHASE.TRACK`, omitting the fourth revision. Because the package is private, it does not need to change for every product revision unless tooling or package identity actually requires it.
+
+If an exact build identity is later needed in package metadata, use valid SemVer prerelease/build metadata rather than a fourth numeric segment.
+
+Example:
+
+```text
+0.5.300+rev.4
+```
+
+Do not place `0.5.300.4` directly into `package.json.version`.
+
+## Other version counters
+
+The existing independent counters remain useful and should not be collapsed into the product version.
+
+Examples:
+
+- Account Save
+- Game State
+- Data
+- Benchmark
+- individual system versions
+
+These answer different questions.
+
+### Product version
+
+Answers:
+
+> What coherent development milestone does this build represent?
+
+### Game State / Account Save
+
+Answers:
+
+> Can persisted player data be safely read, migrated, or rejected?
+
+Increment these only when the persisted schema/contract changes.
+
+### Data version
+
+Answers:
+
+> Has the authoritative data schema/content contract changed in a way that consumers or migrations need to distinguish?
+
+Do not bump it for every content entry.
+
+### System versions
+
+Answers:
+
+> What revision of an individual subsystem's behavior or public contract is present?
+
+System versions may continue to use ordinary three-part SemVer-like values. They do not have to match the product milestone.
+
+## Version bump protocol
+
+Every runtime PR should declare:
+
+1. target product phase/track;
+2. whether it increments product revision or completes a track;
+3. affected system versions;
+4. whether Game State, Account Save, or Data versions change;
+5. migration/reset implications;
+6. tests and benchmark results;
+7. known limitations.
+
+### Normal runtime change inside a track
+
+Example:
+
+```text
+Before: 0.5.200.3
+After:  0.5.200.4
+```
+
+Use when the change advances or fixes the same scoped goal.
+
+### Track completion
+
+Example:
+
+```text
+Before: 0.5.200.7
+After:  0.5.300.0
+```
+
+Use only when the prior track's exit gate is satisfied and the codebase is ready to begin the next scoped objective.
+
+### Phase completion
+
+Example:
+
+```text
+Before: 0.6.900.5
+After:  0.7.100.0
+```
+
+Do not enter the next phase just because planned features exist on branches. The merged `main` branch must satisfy the phase exit gate.
+
+### Bug fixes
+
+A bug fix that belongs to the active track increments the revision.
+
+A critical bug discovered after the team has begun a later track should normally be fixed on the current line and documented as a regression fix. Avoid reopening historical numbering unless an actual release branch/hotfix policy exists.
+
+### Docs-only planning
+
+No product-version bump.
+
+### Save-shape change
+
+A product-version bump does not substitute for a Game State/Account Save migration decision. If persistence shape changes, bump the relevant schema counter and provide an explicit migration or deliberate reset policy.
+
+## Milestone philosophy
+
+Pre-1.0 versions are product-completeness gates, not marketing labels.
+
+Each phase should leave the game materially more playable than the prior phase.
+
+A phase is not complete because its modules exist. It is complete when the player-facing loop associated with that phase works end-to-end and is covered by tests/validation appropriate to the system.
+
+---
+
+# 0.4 — Foundation Closeout and Direction Lock
+
+## Purpose
+
+Convert the existing broad scaffold into a stable launch point for the new game direction without attempting another rewrite.
+
+The historical baseline is `0.4.4`. The first four-part release should be made deliberately during this phase when the version manifest/protocol is implemented.
+
+## 0.4.100 — Direction and version protocol
+
+Planning/design deliverables:
+
+- development north star;
+- version protocol;
+- updated authoritative roadmap/handoff references;
+- explicit declaration that formula reconstruction is no longer the primary roadmap spine;
+- jobs/discipline/capability/loadout design recorded.
+
+This track may be documentation-only and therefore does not itself require changing the historical `0.4.4` runtime string.
+
+## 0.4.200 — Version manifest separation
+
+Runtime/tooling deliverables:
+
+- introduce authoritative four-part product version field;
+- decouple product version from `package.json.version`;
+- update version-display tests;
+- document package/product version behavior;
+- retain compatibility aliases only where genuinely useful.
+
+Suggested first four-part product version:
+
+```text
+0.4.200.0
+```
+
+## 0.4.300 — Ordered persistence migrations
+
+Deliverables:
+
+- explicit ordered Game State migration mechanism;
+- explicit Account Save migration path where needed;
+- deterministic handling of unsupported old state;
+- tests for migration order and failure behavior;
+- remove reliance on ad-hoc revive logic as the only compatibility strategy.
+
+## 0.4.400 — Structured action contract
+
+Deliverables:
+
+- define a small `ActionResult`-style contract for engine-facing actions;
+- separate semantic outcome data from display prose;
+- migrate one representative action path first;
+- preserve command compatibility as an adapter.
+
+## 0.4.500 — Lightweight semantic event foundation
+
+Deliverables:
+
+- structured events for important game outcomes;
+- stable event IDs/types;
+- tests proving consumers do not parse log prose to understand game state;
+- no full event-sourcing architecture.
+
+## 0.4.600 — Current-system stabilization
+
+Deliverables:
+
+- preserve current inventory/equipment/travel/combat foundations;
+- fix blocking regressions exposed by the new contracts;
+- document transitional job/main-job assumptions;
+- validate that the architecture can accept world-time and capability work without a rewrite.
+
+## 0.4.900 — 0.4 exit gate
+
+0.4 is complete when:
+
+- the new direction and version protocol are authoritative;
+- product/package version concepts are separated;
+- ordered persistence migration exists;
+- a structured action/event seam exists;
+- current systems remain functional and tested;
+- the next phase can build deterministic world time without depending on wall-clock behavior.
+
+---
+
+# 0.5 — World Time, Tasks, and Projects
+
+## Purpose
+
+Establish the simulation substrate for long-duration play without real-world waiting.
+
+## 0.5.100 — Deterministic world clock
+
+Deliverables:
+
+- canonical world date/time state;
+- deterministic time advancement independent of `Date.now()`;
+- world-time formatting and inspection;
+- tests for exact advancement.
+
+## 0.5.200 — Pause and speed control
+
+Deliverables:
+
+- pause/resume semantics;
+- simulation speed control;
+- fast-forward that advances simulation rather than merely changing renderer timing;
+- clean boundary between wall-clock scheduling and world-time calculation.
+
+## 0.5.300 — Canonical timed task model
+
+Deliverables:
+
+- common task/action duration representation;
+- start/progress/complete/cancel semantics where appropriate;
+- deterministic task completion;
+- travel adapted as one consumer without forcing every system into travel-specific logic.
+
+## 0.5.400 — Interrupt model
+
+Deliverables:
+
+- advance-until-event;
+- meaningful interrupt priority;
+- combat/exhaustion/tool failure/project completion hooks or placeholders;
+- tests for deterministic interrupt ordering.
+
+## 0.5.500 — Day boundary and end-of-day review
+
+Deliverables:
+
+- day transition;
+- configurable end-of-day auto-pause;
+- structured daily summary data;
+- review UI/text output;
+- continue/save/inspect flow.
+
+## 0.5.600 — Persistent project model
+
+Deliverables:
+
+- projects with material requirements;
+- accumulated labor/time;
+- progress visibility;
+- completion events;
+- no arbitrary exponential duplicate-building multiplier.
+
+## 0.5.700 — Time-cost integration pilot
+
+Deliverables:
+
+- integrate at least travel plus one non-travel work activity with the canonical time model;
+- resource/energy or fatigue hooks where appropriate;
+- fast-forward through low-information periods without skipping meaningful events.
+
+## 0.5.900 — 0.5 exit gate
+
+0.5 is complete when the player can perform multi-hour/multi-day fictional activities, fast-forward safely, reach a day boundary, review meaningful progress, and advance a persistent project without the design depending on real-world waiting.
+
+---
+
+# 0.6 — Character Capability, Disciplines, Origins, and Livelihood
+
+## Purpose
+
+Replace magical job-switch assumptions with a continuous-character capability model and give the character a meaningful starting life.
+
+## 0.6.100 — Capability and proficiency model
+
+Deliverables:
+
+- learned capabilities stored independently from current equipment;
+- proficiency/mastery representation;
+- capability inspection;
+- migration strategy from existing character-owned skills.
+
+## 0.6.200 — Jobs as disciplines/classifications
+
+Deliverables:
+
+- jobs represented as training traditions/archetypes rather than magical active states;
+- discipline metadata for training, recognition, and advanced instruction;
+- clear distinction between discipline identity and immediate ability eligibility;
+- transitional compatibility for current job data.
+
+## 0.6.300 — Equipment/preparation prerequisites
+
+Deliverables:
+
+- hard requirements;
+- soft requirements with data-driven penalties;
+- enhancers;
+- equipment, focus, ammunition, tool, reagent, stance, and context checks where relevant.
+
+## 0.6.400 — Cross-discipline ability access
+
+Deliverables:
+
+- capabilities from multiple disciplines can coexist;
+- no single support-job slot as the universal gate;
+- loadout/resource/preparation tradeoffs prevent unrestricted optimal use of everything at once;
+- tests for valid hybrid behavior.
+
+## 0.6.500 — Origin system
+
+Deliverables:
+
+- multiple starting backgrounds;
+- different starting loadouts/resources/relationships/proficiencies;
+- origins do not permanently lock later disciplines;
+- character creation revised around starting circumstances rather than only a starting job toggle.
+
+## 0.6.600 — First livelihood loop
+
+Deliverables:
+
+- one complete gathering/farming/crafting-oriented work loop;
+- time, energy/resource cost, yield, proficiency growth, and sale/use of output;
+- measurable improvement with mastery.
+
+## 0.6.700 — Preparation/loadout UX
+
+Deliverables:
+
+- clear presentation of what the current loadout enables, weakens, or blocks;
+- recognizable archetype classification may be shown as descriptive shorthand;
+- the UI must not imply that equipment literally transforms the character into another person/job.
+
+## 0.6.900 — 0.6 exit gate
+
+0.6 is complete when one character can learn capabilities across disciplines, change effective play style through logical equipment/preparation, begin from different origins, and participate in at least one livelihood loop without magical job transformation.
+
+---
+
+# 0.7 — First Complete Game Loop
+
+## Purpose
+
+Deliver the first genuinely representative game experience: life building plus preparation plus adventure plus permanent progress.
+
+Working slice: **A Week Beyond the West Gate**.
+
+## 0.7.100 — Objective/quest state foundation
+
+Deliverables:
+
+- lightweight objective state machine;
+- semantic event-driven progress;
+- talk/collect/travel/kill/work/project objective types as needed by the slice;
+- rewards and unlocks.
+
+## 0.7.200 — Home-base foothold
+
+Deliverables:
+
+- a real starting foothold appropriate to origin;
+- storage/recovery/preparation context;
+- one permanent project tied to establishing or improving the foothold.
+
+## 0.7.300 — West Gate expedition loop
+
+Deliverables:
+
+- prepare;
+- leave the safe area;
+- travel through a meaningful route;
+- encounter risk;
+- complete an objective;
+- return with materials/rewards/state changes.
+
+## 0.7.400 — Combat/recovery hardening for the slice
+
+Deliverables:
+
+- reliable target handling;
+- enemy turn/AI adequate for the slice;
+- KO/injury/recovery behavior;
+- clear battle end cleanup;
+- combat advancement compatible with world time.
+
+## 0.7.500 — First-week progression integration
+
+Deliverables:
+
+- multiple simulated days;
+- end-of-day summaries;
+- livelihood and expedition interdependence;
+- proficiency/capability gains;
+- project progression;
+- a permanent end-of-week accomplishment.
+
+## 0.7.600 — Slice UX and onboarding
+
+Deliverables:
+
+- player can discover actions without knowing command internals;
+- origin-specific opening guidance;
+- icons/tokens/meters used where helpful;
+- no full graphical-world requirement.
+
+## 0.7.700 — Replay and alternate-origin pass
+
+Deliverables:
+
+- at least two meaningfully different openings into the same systemic slice;
+- common systems remain reusable rather than scripting separate games per origin.
+
+## 0.7.900 — 0.7 exit gate
+
+0.7 is complete when a new player can start a character, live through a meaningful first week, work, prepare, travel, fight, return, build something permanent, and end the slice with materially expanded capability and future options.
+
+This is the first milestone that should be judged primarily by “is this fun enough to keep playing?” rather than “does the architecture exist?”
+
+---
+
+# 0.8 — Life, Infrastructure, and Systemic Expansion
+
+## Purpose
+
+Turn the first slice into a durable long-form life RPG by expanding the systems that make accumulated resources and mastery change how the player lives.
+
+## 0.8.100 — Construction and renovation depth
+
+Deliverables:
+
+- reusable building instances;
+- upgrades/renovations;
+- capacity/efficiency improvements;
+- physically/economically justified costs;
+- project labor and logistics.
+
+## 0.8.200 — Gathering and farming depth
+
+Deliverables:
+
+- multiple materials/crops or equivalent production lines;
+- quality/yield/season/environment hooks where useful;
+- better tools and infrastructure reduce labor or increase output;
+- avoid repetitive click expansion.
+
+## 0.8.300 — Crafting and tools
+
+Deliverables:
+
+- structured recipe catalog;
+- tool requirements;
+- facilities;
+- skill/proficiency checks;
+- quality/failure rules appropriate to the game;
+- crafted goods feed other loops.
+
+## 0.8.400 — Taming and husbandry
+
+Deliverables:
+
+- at least one tamable creature family;
+- relationship/care requirements;
+- housing/facility needs;
+- product, transport, labor, or companion value;
+- creature ownership should change capability, not just create another timer.
+
+## 0.8.500 — Relationships and local reputation
+
+Deliverables:
+
+- persistent NPC relationships;
+- local/guild reputation or standing;
+- relationships unlock information, training, services, opportunities, or assistance;
+- avoid affection bars with no systemic consequence.
+
+## 0.8.600 — Logistics and labor-saving infrastructure
+
+Deliverables:
+
+- carts/pack capacity/storage networks/roads/irrigation/helpers or equivalent;
+- mature characters spend less attention on mastered low-level chores;
+- long-term resource sinks come from capability expansion rather than arbitrary multipliers.
+
+## 0.8.700 — Discipline and livelihood expansion
+
+Deliverables:
+
+- additional disciplines/capabilities chosen for systemic value;
+- additional livelihood interactions;
+- hybrid play tested beyond the first slice.
+
+## 0.8.800 — Economy and project balancing
+
+Deliverables:
+
+- resource faucets/sinks reviewed across systems;
+- repeated identical construction remains logically priced;
+- upgrades/logistics/prestige create meaningful advanced demand;
+- no single livelihood trivially dominates all others.
+
+## 0.8.900 — 0.8 exit gate
+
+0.8 is complete when the player can pursue a sustained multi-week or multi-season life in which buildings, tools, creatures, relationships, and infrastructure measurably change how earlier work is performed.
+
+---
+
+# 0.9 — Adventure Depth, Content Expansion, and Release Hardening
+
+## Purpose
+
+Bring adventure, magic, region content, balance, persistence, and UX to a release-candidate standard without losing the life-simulation identity proven in earlier phases.
+
+## 0.9.100 — Adventure/combat depth
+
+Deliverables:
+
+- stronger enemy behavior;
+- encounter variety;
+- tactical action choices;
+- status/recovery/death consequences;
+- preparation matters materially.
+
+## 0.9.200 — Magic and advanced capabilities
+
+Deliverables:
+
+- structured spell/capability catalog;
+- cast/recast/resource behavior;
+- equipment/focus/preparation relationships;
+- hybrid access consistent with the discipline model;
+- formula confidence documented.
+
+## 0.9.300 — Second dense region
+
+Deliverables:
+
+- prove the content architecture scales beyond the initial San d'Oria/Ronfaure-centered slice;
+- new local economy/resources/NPCs/objectives;
+- travel and discovery remain meaningful;
+- do not expand map count merely for breadth.
+
+## 0.9.400 — Long-form progression and economy balance
+
+Deliverables:
+
+- progression pacing across days/weeks/seasons reviewed;
+- grind produces measurable gains;
+- fast-forward does not trivialize decisions;
+- resource economy remains stable enough for extended play;
+- advanced sinks are logical and useful.
+
+## 0.9.500 — UI, accessibility, and readability
+
+Deliverables:
+
+- keyboard/mouse interaction stable;
+- action discovery and context panels clear;
+- text scaling/readability/accessibility improvements;
+- icons/tokens/meters used consistently;
+- no required command memorization for normal play.
+
+## 0.9.600 — Save compatibility and migration hardening
+
+Deliverables:
+
+- supported migration policy for late-beta saves;
+- corruption/failure handling;
+- backup/export/import strategy if appropriate;
+- 1.0 compatibility expectations documented.
+
+## 0.9.700 — Validation, performance, and deterministic test hardening
+
+Deliverables:
+
+- full standard test/check gate;
+- deterministic simulation tests;
+- benchmark targets;
+- content/schema validation;
+- no known blocker-class save, progression, or simulation defects.
+
+## 0.9.800 — Content complete beta
+
+Deliverables:
+
+- 1.0-critical content present;
+- no major 1.0 system still represented only by a placeholder;
+- tuning, writing, bug fixing, and polish may continue.
+
+## 0.9.900 — Release candidate freeze
+
+Deliverables:
+
+- feature freeze for 1.0-critical systems;
+- only release-blocking fixes, balancing, content corrections, migration work, and polish;
+- version/migration documentation finalized;
+- release checklist passes.
+
+## 0.9 exit gate
+
+0.9 is complete when `main` is suitable to promote to 1.0 without adding another foundational subsystem.
+
+---
+
+# 1.0 — Live Foundation
+
+Suggested initial product version:
+
+```text
+1.0.000.0
+```
+
+`1.0` does not mean the game is finished forever. It means the core product promise is coherent, playable, stable enough to support persistent players, and governed by an explicit compatibility policy.
+
+## 1.0 minimum product promise
+
+A 1.0 player should be able to:
+
+- create a character from meaningful starting circumstances;
+- develop one persistent character across multiple disciplines without magical job transformations;
+- use equipment/preparation to shape available and effective capabilities;
+- live through a deterministic day/time simulation with pause and fast-forward;
+- work at livelihoods and improve through measurable mastery;
+- own/use a persistent foothold and improve infrastructure;
+- undertake material projects with logical resource/labor costs;
+- travel into dangerous areas and prepare for expeditions;
+- fight, recover, and gain useful capability from adventure;
+- participate in an economy where work, crafting, gathering, and adventure interconnect;
+- build relationships/reputation that affect available opportunities;
+- tame/use at least representative creature systems if retained in the 1.0 scope;
+- progress through at least two dense regional content spaces;
+- experience end-of-day review and long-duration fictional progression without mandatory real-world waiting;
+- save/load through an explicit supported compatibility/migration contract;
+- play normal game flows without command-line expertise;
+- understand important state through text-first presentation plus limited visual polish.
+
+## 1.0 quality gate
+
+Before promotion to 1.0:
+
+- no known data-loss blocker;
+- supported 0.9 save migration path is tested;
+- normal new-game-to-established-character loop is tested end-to-end;
+- first-region critical path and second-region access are complete;
+- economy has no obvious infinite or catastrophic early-game exploit in normal play;
+- fast-forward cannot silently skip blocker-class interrupts;
+- game logic remains renderer-independent;
+- validation/check/benchmark suite passes;
+- release notes and known limitations are explicit;
+- version manifest and all schema counters are correct;
+- project documentation points to current, non-superseded direction documents.
+
+## After 1.0
+
+Post-1.0 versions can continue using the same four-part product scheme:
+
+```text
+1.MINOR.TRACK.REVISION
+```
+
+Example:
+
+```text
+1.1.200.3
+```
+
+At that point `MINOR` represents a live feature line rather than a pre-release completeness phase.
+
+Breaking save or gameplay-contract changes after 1.0 require explicit migration/deprecation policy and should not be hidden inside an ordinary revision bump.
+
+A future `2.x` line should be reserved for a genuinely incompatible product-generation change, not ordinary content expansion.
+
+---
+
+# Release management rules
+
+## Branch/PR targeting
+
+Every implementation branch should identify its intended target in the PR body, for example:
+
+```text
+Target: 0.5.300.x — Canonical timed task model
+```
+
+Do not mix unrelated tracks merely to increase version numbers faster.
+
+## Milestone completion evidence
+
+A track or phase exit should be based on merged evidence:
+
+- implemented behavior;
+- tests;
+- validation;
+- relevant benchmark/check results;
+- docs updated to the new state;
+- known limitations recorded.
+
+## Codenames
+
+Codenames are optional human-readable labels for meaningful product points. They must never replace numeric versions and should not be changed for every revision.
+
+Good use:
+
+```text
+0.7.900.x — First Week
+0.9.800.x — Content Complete Beta
+1.0.000.0 — Live Foundation
+```
+
+## Changelog policy
+
+`CHANGELOG.md` should record player-visible/runtime-significant changes grouped by product track or release.
+
+Do not flood the changelog with every internal refactor unless it affects behavior, compatibility, migration, testing guarantees, or developer-operational requirements.
+
+## Roadmap maintenance
+
+When reality changes, insert or revise future tracks rather than pretending the original plan was exact.
+
+Rules:
+
+- completed version labels are immutable history;
+- active track scope may be clarified but should not be silently broadened into a new phase;
+- new necessary work can use inserted track numbers such as `250` or `350`;
+- moving a feature later is preferable to declaring a milestone complete with placeholder behavior;
+- version numbers represent achieved gates, not aspirational branch names.
+
+## Current recommended sequence
+
+From the present `0.4.4` baseline:
+
+1. merge the direction/version planning docs without pretending they are runtime progress;
+2. implement `0.4.200` version-manifest separation;
+3. implement ordered persistence migrations;
+4. add structured action/event seams;
+5. close 0.4;
+6. build deterministic world time and task/project simulation in 0.5;
+7. build continuous-character capability/disciplines/origins in 0.6;
+8. prove the complete life/adventure loop in 0.7;
+9. deepen life/infrastructure systems in 0.8;
+10. deepen adventure, add a second region, balance, and harden in 0.9;
+11. promote the tested release candidate to `1.0.000.0`.

--- a/docs/planning/DEVELOPMENT_PIPELINE_AND_MILESTONES.md
+++ b/docs/planning/DEVELOPMENT_PIPELINE_AND_MILESTONES.md
@@ -1,413 +1,57 @@
-# Development Pipeline and Milestone Roadmap
-
-This document captures the connector-safe planning pass for the text RPG rebuild after the San d'Oria coordinate/navigation work, item behavior/selling foundation, and conservative skill-gain hook merge.
-
-It is intentionally planning-only. It does not change runtime code, tests, data, versions, or save shape.
-
-## Current baseline
-
-At the time this plan was updated, `main` is expected to be at the post-PR-293 baseline:
-
-- App/package: `0.4.4`
-- Codename: `Conservative Skill Gains`
-- Game State: `3`
-- Data: `13`
-- `itemBehavior: 0.1.0`
-- `itemInspection: 0.5.1`
-- `shops` / `shopTransactions: 0.3.8`
-- `skillProgression: 0.5.2`
-- `combatActions: 0.5.1`
-
-Completed foundation:
-
-- PR #293, `codex/conservative-skill-gain-hooks`, merged deterministic skill-gain hooks into `main`.
-- Basic attacks, placeholder weapon skills, and placeholder spell casts can now gain conservative learned skill while keeping damage, accuracy, magic potency, enemy AI, and item behavior formulas unchanged.
-
-Next active planning target:
-
-- Formula confidence planning should define how learned/effective skill, skill caps, stats, and item behavior metadata may safely enter formulas without claiming exact retail behavior.
-
-## Delivery pipeline
-
-Every implementation PR should follow this sequence:
-
-1. Start from current `main` unless explicitly creating a stacked planning branch.
-2. Keep one primary gameplay/system goal per PR.
-3. Inspect the current repo state before editing.
-4. Avoid broad rewrites when a small module or helper can isolate the change.
-5. Keep formulas conservative and confidence-labeled.
-6. Add or update tests in the same PR as runtime behavior changes.
-7. Update docs and version metadata when behavior changes.
-8. Run the standard gate locally or through Codex:
-   - `npm.cmd test`
-   - `npm.cmd run benchmark`
-   - `npm.cmd run check`
-   - `git diff --check`
-9. Report:
-   - branch name
-   - PR number/link
-   - final commit SHA
-   - changed files
-   - version bump
-   - test count and check results
-   - known limitations
-   - working-tree status
-
-Connector-only passes should remain docs, planning, metadata, issue/PR triage, or review-only unless the user explicitly approves a write such as closing stale PRs or opening a planning PR.
-
-## Merge gates
-
-A PR should not be merged until all relevant gates are satisfied.
-
-### Runtime PR gate
-
-- Local/Codex tests pass.
-- Benchmark passes.
-- Static check passes.
-- Whitespace check passes.
-- Version metadata matches the PR body.
-- ROADMAP and THREAD_HANDOFF reflect the new repo state.
-- Known limitations are stated in the PR body.
-
-### Docs-only PR gate
-
-- No runtime files changed.
-- No version bump unless the docs change is part of a release/documentation sync policy.
-- No test run required, but the PR body should state that it is docs-only.
-- The doc must not claim runtime behavior that has not merged.
-
-### Connector-only gate
-
-- Prefer read-only inspection first.
-- Mutating actions must be low-risk and explicit: create a planning branch, add a planning doc, comment on a PR, close a superseded PR, or open a draft/planning PR.
-- Do not merge implementation PRs through connector-only review if local/Codex verification has not been reported.
-
-## Milestone 0: conservative skill-gain hooks (completed)
-
-Status: completed by PR #293.
-
-Goal: merge deterministic skill-gain hooks after local/Codex verification.
-
-Delivered foundation:
-
-- Basic attacks infer and gain main-hand weapon skill.
-- Weapon skills gain the main-hand weapon skill once.
-- Cure-like placeholder casts gain `healingMagic`.
-- Offensive placeholder casts gain `elementalMagic`.
-- Skill gain clamps to the current job cap.
-- Capped skills do not spam battle-log gain messages.
-- Damage, accuracy, magic potency, enemy AI, and item behavior formulas remain unchanged.
-
-Merged version target:
-
-- App/package: `0.4.4`
-- Codename: `Conservative Skill Gains`
-- `skillProgression: 0.5.2`
-- `combatActions: 0.5.1`
-
-Completion gate:
-
-- PR #293 merged into `main`.
-- `main` version metadata matches the PR body.
-- Learned/effective skill values remain intentionally unused by damage, accuracy, magic potency, enemy AI, and item behavior formulas until a later formula-confidence pass.
-
-## Milestone 1: formula confidence planning
-
-Suggested branch: `planning/formula-confidence-and-skill-application`
-
-Goal: define how skill caps, learned/effective skill, stats, and item behavior metadata can safely enter formulas without pretending placeholder math is exact retail behavior.
-
-Deliverables:
-
-- Add a planning document for formula confidence and skill application.
-- Define confidence tiers:
-  - exact / sourced
-  - researched approximation
-  - intentional simplification
-  - placeholder
-- Define the first safe formula integration points:
-  - main-hand skill contribution to physical accuracy or attack
-  - magic skill contribution to magic accuracy or potency
-  - defensive skill hooks later
-- Define boundaries:
-  - no retail-exact formula claim without source notes
-  - no random skill-up pacing until RNG policy is explicit
-  - no latent/enchantment/charge behavior application until semantics are explicit
-
-Exit gate:
-
-- Planning doc merged.
-- ROADMAP points to a small next implementation pass, not a broad combat rewrite.
-
-## Milestone 2: conservative skill formula hooks
-
-Suggested branch: `codex/skill-caps-combat-formula-hooks`
-
-Goal: allow effective learned skill to influence one or two conservative formula outputs in a small, testable way.
-
-Deliverables:
-
-- Add or extend a formula helper module rather than scattering math through command handlers.
-- Use effective skill, not raw over-cap learned skill.
-- Keep current job cap clamping explicit.
-- Add confidence/source notes in formula descriptions.
-- Keep formula changes deliberately small.
-
-Candidate first hooks:
-
-- main-hand effective skill contributes to physical accuracy scaffold
-- magic effective skill contributes to magic accuracy/potency scaffold
-
-Non-goals:
-
-- no weapon-skill unlock tables
-- no full magic database
-- no enemy AI expansion
-- no exact FFXI formula claim
-- no item behavior application yet
-
-Exit gate:
-
-- Tests prove capped effective skill is used.
-- Tests prove over-cap learned skill does not overboost formulas.
-- Existing combat and reward tests remain stable.
-
-## Milestone 3: combat UX hardening
-
-Suggested branch: `codex/combat-targeting-and-recovery`
-
-Goal: improve the moment-to-moment battle loop before deeper AI, magic, or formula work.
-
-Deliverables:
-
-- Target selection improvements.
-- Clear invalid-target messages.
-- Multi-enemy target list display.
-- Simple rest/recovery flow outside battle.
-- Death/KO placeholder flow.
-- Battle-end cleanup and inspectability.
-
-Non-goals:
-
-- no full enemy AI system
-- no trust AI
-- no spell database
-- no formula overhaul
-
-Exit gate:
-
-- Tests cover invalid target, valid target selection, KO state, rest blocked in battle, and rest allowed outside battle.
-
-## Milestone 4: spell catalog scaffold
-
-Suggested branch: `codex/spell-catalog-scaffold`
-
-Goal: replace placeholder spell-name inference with structured spell records.
-
-Deliverables:
-
-- Add a minimal spell catalog.
-- Define spell fields:
-  - id
-  - name
-  - skill
-  - element
-  - mp cost
-  - target type
-  - effect type
-  - cast time placeholder
-  - recast placeholder
-  - confidence/source metadata
-- Route `cast Cure` and `cast Fire` through catalog entries.
-- Keep effects conservative and close to current behavior.
-
-Non-goals:
-
-- no full magic database
-- no cast-time tick integration yet
-- no recast timers yet
-- no interruption rules yet
-
-Exit gate:
-
-- Existing cast behavior remains stable.
-- Skill gain uses catalog spell skill where present.
-- Placeholder fallback is still safe or explicitly removed with tests.
-
-## Milestone 5: item behavior application planning
-
-Suggested branch: `planning/item-behavior-application`
-
-Goal: define how latent effects, enchantments, charges, ranged/ammo, and item flags will move from metadata-only inspection into runtime.
-
-Deliverables:
-
-- Categorize item behavior types:
-  - passive always-on modifiers
-  - conditional latent modifiers
-  - activated enchantments
-  - charge and cooldown state
-  - ranged/ammo consumption
-  - restricted trade/sell/drop behavior
-- Define runtime state shape before implementation.
-- Define validation requirements.
-- Define formula and action touchpoints.
-
-Non-goals:
-
-- no runtime item behavior application in the planning PR
-- no combat formula rewrites
-- no economy expansion
-
-Exit gate:
-
-- Clear next implementation PR is scoped to one item behavior category only.
-
-## Milestone 6: key items and unlock flags
-
-Suggested branch: `codex/key-items-and-progression-flags`
-
-Goal: add the missing unlock substrate for maps, travel restrictions, trusts, missions, quests, and permissions.
-
-Deliverables:
-
-- Key item schema.
-- Player key item storage.
-- Key item inspection output.
-- Validation for key item records.
-- Unlock/permission helpers.
-- Tests for adding, checking, and validating key items.
-
-Non-goals:
-
-- no full quest database
-- no mission progression
-- no trust implementation
-
-Exit gate:
-
-- Travel/zone/item restriction scaffolds can reference key item helpers safely.
-
-## Milestone 7: San d'Oria interaction nodes
-
-Suggested branch: `codex/sandoria-interaction-nodes`
-
-Goal: make San d'Oria feel interactive through compact nodes instead of unnecessary full interiors.
-
-Deliverables:
-
-- Improve `here`, `look`, `talk`, `shop`, `guild`, and `quest` affordances at important San d'Oria coordinates.
-- Add compact interaction nodes for shops, guilds, inns, gates, Mog House access, and civic points.
-- Improve exit prompts.
-- Keep full interiors for locations that have meaningful gameplay use.
-
-Non-goals:
-
-- no full city expansion outside San d'Oria
-- no unnecessary building interiors
-- no broad POI rewrite
-
-Exit gate:
-
-- San d'Oria movement remains stable.
-- POI discovery and shop/guild hooks remain stable.
-
-## Milestone 8: Mog House as a real place
-
-Suggested branch: `codex/mog-house-place`
-
-Goal: replace temporary boolean Mog House access with a real place/interior.
-
-Deliverables:
-
-- Mog House place definition.
-- Entry and exit flow from city coordinate.
-- Storage access tied to being inside Mog House.
-- Tests for storage access transitions.
-- Documentation update for the new place model.
-
-Non-goals:
-
-- no furniture placement system
-- no full housing customization
-- no auction house/economy work
-
-Exit gate:
-
-- Storage access is location-driven instead of boolean-only.
-
-## Milestone 9: quest state foundation
-
-Suggested branch: `codex/quest-state-foundation`
-
-Goal: add a minimal quest state machine after key item and POI foundations are ready.
-
-Deliverables:
-
-- Quest database scaffold.
-- Quest state machine:
-  - unavailable
-  - available
-  - active
-  - readyToTurnIn
-  - completed
-  - repeatableCooldown
-- Objective types:
-  - talk
-  - kill
-  - collect
-  - travel
-  - inspect
-- Reward types:
-  - EXP
-  - gil
-  - items
-  - key items
-  - titles/flags placeholders
-
-Non-goals:
-
-- no complete nation mission chain
-- no reputation/fame economy
-- no large quest content dump
-
-Exit gate:
-
-- One tiny sample quest works end-to-end with tests.
-
-## Near-term recommended order
-
-1. Add formula confidence planning.
-2. Implement conservative skill formula hooks.
-3. Harden combat UX.
-4. Add spell catalog scaffold.
-5. Plan item behavior application.
-6. Add key item/unlock substrate.
-7. Improve San d'Oria interaction nodes.
-8. Replace Mog House access flag with a real place.
-9. Start quest state foundation.
-
-## Branch naming conventions
-
-Use one of these prefixes:
-
-- `codex/` for runtime implementation
-- `planning/` for connector-safe planning docs
-- `docs/` for documentation syncs without new planning scope
-- `fix/` for narrow bug fixes
-- `test/` for test-only hardening
-
-## Versioning guidance
-
-- Patch bump for small runtime behavior changes.
-- No app version bump for planning-only docs unless a release/documentation policy requires it.
-- Bump specific system versions only when that system's runtime behavior or public output changes.
-- Keep `gameState` and `data` stable unless save shape or data schema changes.
-
-## Current risks
-
-- Multiple open branches touching docs can conflict. Keep planning docs in standalone files when another implementation PR is open.
-- Formula work can become too broad; keep the first formula PR intentionally small.
-- Skill cap data remains placeholder; any formula use must be described as scaffold behavior.
-- Item behavior metadata should not enter combat until activation, state, and validation rules are explicit.
-- Connector-only PRs cannot prove runtime tests pass; report that limitation plainly.
+# Historical Development Pipeline and Milestones
+
+> **Status: superseded.**
+>
+> This document previously described a formula/item-behavior-first milestone sequence after the conservative skill-gain work. That ordering is no longer authoritative.
+
+Use these documents instead:
+
+1. `docs/DEVELOPMENT_DIRECTION.md` — current design north star.
+2. `docs/VERSIONING_AND_RELEASE_ROADMAP.md` — current product-version protocol and detailed milestones through 1.0.
+3. `docs/ROADMAP.md` — current implementation summary and phase index.
+4. `docs/THREAD_HANDOFF.md` — current repo handoff and next implementation sequence.
+
+The original content remains available in git history if the formula-confidence, skill-hook, combat UX, spell-catalog, item-behavior, key-item, San d'Oria interaction, Mog House, or quest-state planning notes need to be recovered.
+
+## What remains valid from the old plan
+
+The following engineering policies still apply:
+
+- start implementation work from current `main` unless deliberately stacking a planning branch;
+- keep one primary gameplay/system goal per PR;
+- inspect current repo state before editing;
+- prefer small modules/helpers over broad rewrites;
+- keep formulas confidence-labeled;
+- add/update tests in the same PR as runtime behavior changes;
+- update docs and version metadata when behavior changes;
+- run the standard gate when runtime code changes:
+
+```text
+npm.cmd test
+npm.cmd run benchmark
+npm.cmd run check
+git diff --check
+```
+
+- report branch, PR, commit, changed files, version impact, checks, known limitations, and working-tree status;
+- connector-only work should remain planning/docs/metadata/review unless explicit runtime writes are requested.
+
+## What changed
+
+The project direction now prioritizes a cohesive long-form life/adventure game over formula reconstruction as the roadmap spine.
+
+Major new priorities include:
+
+- ordered persistence migrations;
+- deterministic simulation time separate from wall-clock time;
+- pause/fast-forward/end-of-day review;
+- canonical timed tasks and persistent projects;
+- jobs as disciplines/classifications rather than magical active states;
+- learned capabilities with logical equipment/preparation prerequisites;
+- origins and starting circumstances;
+- a first livelihood loop;
+- the **A Week Beyond the West Gate** representative vertical slice;
+- construction/infrastructure, relationships, taming, crafting, and logistics;
+- later combat/magic/content hardening toward 1.0.
+
+Formula confidence, skill application, item behavior, key items, quests, Mog House, combat UX, and magic remain relevant systems; they are now scheduled where they best support the player-facing release milestones instead of leading the release sequence by themselves.


### PR DESCRIPTION
## Summary

Documents the revised long-term product direction and introduces a milestone-driven versioning plan from the current rough 0.4.4 foundation through 1.0.

### New authoritative docs

- `docs/DEVELOPMENT_DIRECTION.md`
  - long-form text-first fantasy life RPG north star
  - effort -> mastery -> efficiency -> capability -> larger ambition
  - simulation time separated from wall-clock waiting
  - logical construction/resource scaling
  - jobs as disciplines/classifications rather than magical transformations
  - cross-discipline capabilities gated by proficiency, equipment, preparation, resources, condition, and context
  - origins, preparation, limited visual polish, and the `A Week Beyond the West Gate` vertical-slice target

- `docs/VERSIONING_AND_RELEASE_ROADMAP.md`
  - four-part product format: `MAJOR.PHASE.TRACK.REVISION`
  - three-digit subtracks (`100`, `200`, etc.) with inserted-track room
  - simple fourth-segment integration counter
  - product/package version separation because npm requires three-part SemVer
  - explicit tracks and exit gates for 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, and 1.0
  - version bump, save/schema, changelog, branch/PR, and milestone-completion protocol

### Updated authoritative pointers

- realigns `docs/ROADMAP.md`
- refreshes `docs/THREAD_HANDOFF.md`
- updates `README.md`
- archives the old formula-first `docs/planning/DEVELOPMENT_PIPELINE_AND_MILESTONES.md` as superseded historical planning while preserving it in git history

## Version impact

Docs/planning only. The runtime remains the historical `0.4.4` baseline.

The planned first runtime version-protocol implementation is `0.4.200`, which will separate the four-part product version from `package.json` SemVer.

## Runtime/test impact

- No runtime files changed.
- No save/data/schema changes.
- No test or benchmark run required for this docs-only planning PR.

## Recommended next runtime pass

`0.4.200` — product/package version-manifest separation, followed by ordered persistence migrations in `0.4.300`.