### PR TITLE
Implement 0.4.200 version manifest separation

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,25 @@
+name: Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Test
+        run: npm test
+      - name: Benchmark
+        run: npm run benchmark

--- a/js/text/version.js
+++ b/js/text/version.js
@@ -1,18 +1,24 @@
+export const PRODUCT_VERSION = '0.4.200.0';
+export const PACKAGE_VERSION = '0.4.200';
+
 export const VERSION = Object.freeze({
-    app: '0.4.4',
+    product: PRODUCT_VERSION,
+    package: PACKAGE_VERSION,
     accountSave: 4,
     gameState: 3,
     data: 13,
     benchmark: 1,
-    codename: 'Conservative Skill Gains',
+    codename: 'Version Manifest Separation',
     compatibility: 'no-backwards-compatibility',
     released: false,
 
-    // Backward-compatible alias for older callers while they migrate.
+    // Transitional aliases for callers that still use the historical names.
+    app: PRODUCT_VERSION,
     save: 4,
 });
 
 export const SYSTEM_VERSIONS = Object.freeze({
+    versionManifest: '0.4.200',
     commandShell: '0.4.4',
     canvasUi: '0.7.0',
     uiIntents: '0.1.1',
@@ -78,7 +84,8 @@ export const SYSTEM_VERSIONS = Object.freeze({
 
 export function describeVersion() {
     return [
-        `App: ${VERSION.app}`,
+        `Product: ${VERSION.product}`,
+        `Package: ${VERSION.package}`,
         `Account Save: ${VERSION.accountSave}`,
         `Game State: ${VERSION.gameState}`,
         `Data: ${VERSION.data}`,

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "ffxi-text-rpg",
-  "version": "0.4.4",
+  "version": "0.4.200",
   "private": true,
   "type": "module",
-  "description": "Text-only RPG foundation inspired by Final Fantasy XI systems.",
+  "description": "Text-first fantasy life RPG foundation inspired by Final Fantasy XI systems.",
   "scripts": {
     "serve": "node scripts/serve.js",
     "start": "npm run serve",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "serve": "node scripts/serve.js",
     "start": "npm run serve",
-    "test": "node --test \"tests/**/*.test.js\"",
+    "test": "node --test",
     "benchmark": "node scripts/benchmark.js",
     "bench": "npm run benchmark",
     "check": "npm test && npm run benchmark"

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -4,20 +4,32 @@ import assert from 'node:assert/strict';
 import { describeDatabases, listDatabases } from '../js/text/data/databaseRegistry.js';
 import { describeLegacyRecoveredData } from '../js/text/data/legacyRecoveredData.js';
 import { createTickEngine } from '../js/text/systems/tickEngine.js';
-import { describeSystemVersions, describeVersion, VERSION } from '../js/text/version.js';
+import {
+    describeSystemVersions,
+    describeVersion,
+    PACKAGE_VERSION,
+    PRODUCT_VERSION,
+    VERSION,
+} from '../js/text/version.js';
 
 
-test('version manifest exposes explicit app account save game state data and benchmark versions', () => {
-    assert.equal(VERSION.app, '0.4.4');
+test('version manifest separates product package and persistence versions', () => {
+    assert.equal(PRODUCT_VERSION, '0.4.200.0');
+    assert.equal(PACKAGE_VERSION, '0.4.200');
+    assert.equal(VERSION.product, PRODUCT_VERSION);
+    assert.equal(VERSION.package, PACKAGE_VERSION);
+    assert.equal(VERSION.app, PRODUCT_VERSION);
     assert.equal(VERSION.accountSave, 4);
     assert.equal(VERSION.gameState, 3);
     assert.equal(VERSION.data, 13);
     assert.equal(VERSION.benchmark, 1);
     assert.equal(VERSION.save, VERSION.accountSave);
-    assert.match(describeVersion(), /App: 0.4.4/);
+    assert.match(describeVersion(), /Product: 0\.4\.200\.0/);
+    assert.match(describeVersion(), /Package: 0\.4\.200/);
     assert.match(describeVersion(), /Account Save: 4/);
     assert.match(describeVersion(), /Game State: 3/);
-    assert.match(describeVersion(), /Codename: Conservative Skill Gains/);
+    assert.match(describeVersion(), /Codename: Version Manifest Separation/);
+    assert.match(describeSystemVersions(), /versionManifest: 0\.4\.200/);
     assert.match(describeSystemVersions(), /characterCreation/);
     assert.match(describeSystemVersions(), /canvasUi: 0.7.0/);
     assert.match(describeSystemVersions(), /combatActions: 0.5.1/);


### PR DESCRIPTION
## Target

Product track: `0.4.200` — Version manifest separation.

## Changes

- introduces authoritative `PRODUCT_VERSION = 0.4.200.0`
- introduces separate `PACKAGE_VERSION = 0.4.200`
- keeps `VERSION.app` as a transitional alias to the product version
- keeps Account Save/Game State/Data/Benchmark counters independent
- adds `versionManifest` system version tracking
- updates version display/tests for Product vs Package semantics
- updates `package.json` to valid three-part SemVer `0.4.200`
- adds a GitHub Actions check workflow for Node 20 tests and benchmarks

## Version impact

- Product: `0.4.4` historical baseline -> `0.4.200.0`
- Package: `0.4.4` -> `0.4.200`
- Account Save: unchanged (`4`)
- Game State: unchanged (`3`)
- Data: unchanged (`13`)
- No migration/reset implications

## Tests

The PR workflow runs `npm test` and `npm run benchmark` on Node 20. Merge only after the check passes.

## Known limitations

This track intentionally does not implement ordered persistence migrations; that is `0.4.300`.