### PR TITLE
Implement 0.4.300 ordered persistence migrations

### DIFF
--- a/js/text/save.js
+++ b/js/text/save.js
@@ -1,11 +1,13 @@
 import { createInventoryState } from './systems/inventoryEngine.js';
+import { migrateAccountRegistryPayload, migrateGameStatePayload } from './systems/saveMigrations.js';
 import { isValidGameState, validateGameState } from './systems/validation.js';
+import { VERSION } from './version.js';
 
 const ACCOUNTS_KEY = 'ffxiTextRpgAccounts';
 const ACCOUNT_SESSION_KEY = 'ffxiTextRpgAccountSession';
 const LEGACY_SINGLE_ACCOUNT_KEY = 'ffxiTextRpgAccount';
 const LEGACY_SAVE_KEY = 'ffxiTextRpgSave';
-const ACCOUNT_VERSION = 2;
+const ACCOUNT_VERSION = VERSION.accountSave;
 const ENCODING = 'base64-json-v1';
 const RESERVED_ACCOUNT_NAMES = new Set(['local-adventurer', 'account', 'placeholder']);
 
@@ -40,12 +42,22 @@ export function loadCharacter(characterSelector) {
 
     const state = decodeState(record.encodedState);
     if (!state) return null;
-    const revived = reviveGameState(state, record.id);
+    const migration = migrateGameStatePayload(state);
+    if (!migration.ok) {
+        console.warn('Ignoring incompatible character save.', migration.message);
+        return null;
+    }
+
+    const revived = reviveGameState(migration.value, record.id);
     if (!isValidGameState(revived)) {
         console.warn('Ignoring incompatible character save.', validateGameState(revived));
         return null;
     }
 
+    if (migration.migrated) {
+        record.encodedState = encodeState(revived);
+        record.updatedAt = new Date().toISOString();
+    }
     account.profile.lastCharacterId = record.id;
     saveAccount(account);
     return revived;
@@ -251,8 +263,22 @@ function loadAccountRegistry() {
         const raw = getStorage()?.getItem(ACCOUNTS_KEY);
         if (!raw) return createAccountRegistry();
         const parsed = decodePayload(raw);
-        if (!parsed || parsed.version !== ACCOUNT_VERSION || !Array.isArray(parsed.accounts)) return createAccountRegistry();
-        return { version: ACCOUNT_VERSION, encoding: ENCODING, accounts: parsed.accounts.map(normalizeAccount).filter((account) => isRealAccount(account)) };
+        const migration = migrateAccountRegistryPayload(parsed);
+        if (!migration.ok) {
+            console.warn('Ignoring incompatible account registry.', migration.message);
+            return createAccountRegistry();
+        }
+        if (!Array.isArray(migration.value.accounts)) return createAccountRegistry();
+
+        const nextRegistry = {
+            version: ACCOUNT_VERSION,
+            encoding: ENCODING,
+            accounts: migration.value.accounts.map(normalizeAccount).filter((account) => isRealAccount(account)),
+        };
+        if (migration.migrated) {
+            getStorage()?.setItem(ACCOUNTS_KEY, encodePayload(nextRegistry));
+        }
+        return nextRegistry;
     } catch (error) {
         console.warn('Unable to load account registry.', error);
         return createAccountRegistry();

--- a/js/text/systems/migrationEngine.js
+++ b/js/text/systems/migrationEngine.js
@@ -1,0 +1,101 @@
+function cloneValue(value) {
+    if (typeof structuredClone === 'function') return structuredClone(value);
+    return JSON.parse(JSON.stringify(value));
+}
+
+function failure(code, message, details = {}) {
+    return { ok: false, code, message, ...details };
+}
+
+export function migrateVersionedValue(value, options = {}) {
+    const {
+        currentVersion,
+        migrations = [],
+        label = 'payload',
+        versionKey = 'version',
+    } = options;
+
+    if (!Number.isInteger(currentVersion) || currentVersion < 0) {
+        throw new Error('Migration currentVersion must be a non-negative integer.');
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return failure('invalid-payload', `${label} must be an object.`);
+    }
+
+    const startVersion = value[versionKey];
+    if (!Number.isInteger(startVersion) || startVersion < 0) {
+        return failure('missing-version', `${label} has no supported integer ${versionKey}.`);
+    }
+    if (startVersion > currentVersion) {
+        return failure(
+            'future-version',
+            `${label} version ${startVersion} is newer than supported version ${currentVersion}.`,
+            { fromVersion: startVersion, toVersion: currentVersion },
+        );
+    }
+
+    const migrationsByFrom = new Map();
+    for (const migration of migrations) {
+        if (!migration || !Number.isInteger(migration.from) || !Number.isInteger(migration.to) || typeof migration.migrate !== 'function') {
+            throw new Error(`Invalid migration definition for ${label}.`);
+        }
+        if (migration.to !== migration.from + 1) {
+            throw new Error(`Migration ${migration.id ?? `${migration.from}->${migration.to}`} must advance exactly one version.`);
+        }
+        if (migrationsByFrom.has(migration.from)) {
+            throw new Error(`Duplicate migration from version ${migration.from} for ${label}.`);
+        }
+        migrationsByFrom.set(migration.from, migration);
+    }
+
+    let working = cloneValue(value);
+    let version = startVersion;
+    const applied = [];
+
+    while (version < currentVersion) {
+        const migration = migrationsByFrom.get(version);
+        if (!migration) {
+            return failure(
+                'missing-migration',
+                `${label} cannot migrate from version ${version} to ${version + 1}.`,
+                { fromVersion: startVersion, stoppedAtVersion: version, toVersion: currentVersion, applied },
+            );
+        }
+
+        try {
+            const migrated = migration.migrate(working);
+            if (!migrated || typeof migrated !== 'object' || Array.isArray(migrated)) {
+                return failure(
+                    'invalid-migration-result',
+                    `${label} migration ${migration.id ?? `${migration.from}->${migration.to}`} did not return an object.`,
+                    { fromVersion: startVersion, stoppedAtVersion: version, toVersion: currentVersion, applied },
+                );
+            }
+            if (migrated[versionKey] !== migration.to) {
+                return failure(
+                    'invalid-migration-version',
+                    `${label} migration ${migration.id ?? `${migration.from}->${migration.to}`} did not set ${versionKey} to ${migration.to}.`,
+                    { fromVersion: startVersion, stoppedAtVersion: version, toVersion: currentVersion, applied },
+                );
+            }
+            working = migrated;
+            version = migration.to;
+            applied.push(migration.id ?? `${migration.from}->${migration.to}`);
+        } catch (error) {
+            return failure(
+                'migration-error',
+                `${label} migration ${migration.id ?? `${migration.from}->${migration.to}`} failed: ${error.message}`,
+                { fromVersion: startVersion, stoppedAtVersion: version, toVersion: currentVersion, applied, error },
+            );
+        }
+    }
+
+    return {
+        ok: true,
+        value: working,
+        fromVersion: startVersion,
+        toVersion: currentVersion,
+        applied,
+        migrated: applied.length > 0,
+    };
+}

--- a/js/text/systems/saveMigrations.js
+++ b/js/text/systems/saveMigrations.js
@@ -1,0 +1,125 @@
+import { VERSION } from '../version.js';
+import { createInventoryState } from './inventoryEngine.js';
+import { migrateVersionedValue } from './migrationEngine.js';
+import { CURRENT_SAVE_VERSION } from './validation.js';
+
+function migrateGameState2To3(state) {
+    const next = { ...state, version: 3 };
+    next.meta = { ...(state.meta ?? {}) };
+    next.atlas = state.atlas && typeof state.atlas === 'object' ? state.atlas : {};
+    next.discoveredPois = state.discoveredPois && typeof state.discoveredPois === 'object' ? state.discoveredPois : {};
+    next.travel = state.travel ?? null;
+    next.flags = state.flags && typeof state.flags === 'object' ? state.flags : {};
+    next.log = Array.isArray(state.log) ? state.log : [];
+
+    if (state.player && typeof state.player === 'object') {
+        const player = { ...state.player };
+        const defaults = createInventoryState();
+        const existingInventory = Array.isArray(state.player.inventory) ? state.player.inventory : [];
+        const inventoryState = state.player.inventoryState && typeof state.player.inventoryState === 'object'
+            ? { ...state.player.inventoryState }
+            : defaults;
+
+        inventoryState.containers = inventoryState.containers && typeof inventoryState.containers === 'object'
+            ? { ...inventoryState.containers }
+            : defaults.containers;
+        inventoryState.mogHouse = inventoryState.mogHouse && typeof inventoryState.mogHouse === 'object'
+            ? { ...inventoryState.mogHouse }
+            : defaults.mogHouse;
+
+        const inventoryContainer = inventoryState.containers.inventory && typeof inventoryState.containers.inventory === 'object'
+            ? { ...inventoryState.containers.inventory }
+            : { ...defaults.containers.inventory };
+        inventoryContainer.items = Array.isArray(inventoryContainer.items)
+            ? inventoryContainer.items
+            : existingInventory;
+        inventoryState.containers.inventory = inventoryContainer;
+        player.inventoryState = inventoryState;
+        player.progression = player.progression && typeof player.progression === 'object'
+            ? { ...player.progression }
+            : {};
+        player.progression.skills = player.progression.skills && typeof player.progression.skills === 'object'
+            ? { ...player.progression.skills }
+            : {};
+        next.player = player;
+    }
+
+    return next;
+}
+
+const GAME_STATE_MIGRATIONS = Object.freeze([
+    Object.freeze({
+        id: 'game-state-2-to-3-inventory-and-progression',
+        from: 2,
+        to: 3,
+        migrate: migrateGameState2To3,
+    }),
+]);
+
+function migrateAccountRegistry2To3(registry) {
+    return {
+        ...registry,
+        version: 3,
+        encoding: registry.encoding ?? 'base64-json-v1',
+        accounts: Array.isArray(registry.accounts)
+            ? registry.accounts.map((account) => ({ ...account, version: 3, encoding: account.encoding ?? registry.encoding ?? 'base64-json-v1' }))
+            : [],
+    };
+}
+
+function migrateAccountRegistry3To4(registry) {
+    return {
+        ...registry,
+        version: 4,
+        encoding: registry.encoding ?? 'base64-json-v1',
+        accounts: Array.isArray(registry.accounts)
+            ? registry.accounts.map((account) => ({ ...account, version: 4, encoding: account.encoding ?? registry.encoding ?? 'base64-json-v1' }))
+            : [],
+    };
+}
+
+const ACCOUNT_REGISTRY_MIGRATIONS = Object.freeze([
+    Object.freeze({
+        id: 'account-registry-2-to-3-version-contract',
+        from: 2,
+        to: 3,
+        migrate: migrateAccountRegistry2To3,
+    }),
+    Object.freeze({
+        id: 'account-registry-3-to-4-version-contract',
+        from: 3,
+        to: 4,
+        migrate: migrateAccountRegistry3To4,
+    }),
+]);
+
+export function migrateGameStatePayload(state) {
+    return migrateVersionedValue(state, {
+        currentVersion: CURRENT_SAVE_VERSION,
+        migrations: GAME_STATE_MIGRATIONS,
+        label: 'game state',
+    });
+}
+
+export function migrateAccountRegistryPayload(registry) {
+    return migrateVersionedValue(registry, {
+        currentVersion: VERSION.accountSave,
+        migrations: ACCOUNT_REGISTRY_MIGRATIONS,
+        label: 'account registry',
+    });
+}
+
+export function describeSaveMigrationSupport() {
+    return {
+        gameState: {
+            currentVersion: CURRENT_SAVE_VERSION,
+            supportedFrom: GAME_STATE_MIGRATIONS.length ? Math.min(...GAME_STATE_MIGRATIONS.map((migration) => migration.from)) : CURRENT_SAVE_VERSION,
+            migrations: GAME_STATE_MIGRATIONS.map(({ id, from, to }) => ({ id, from, to })),
+        },
+        accountSave: {
+            currentVersion: VERSION.accountSave,
+            supportedFrom: ACCOUNT_REGISTRY_MIGRATIONS.length ? Math.min(...ACCOUNT_REGISTRY_MIGRATIONS.map((migration) => migration.from)) : VERSION.accountSave,
+            migrations: ACCOUNT_REGISTRY_MIGRATIONS.map(({ id, from, to }) => ({ id, from, to })),
+        },
+    };
+}

--- a/js/text/systems/saveMigrations.js
+++ b/js/text/systems/saveMigrations.js
@@ -16,6 +16,7 @@ function migrateGameState2To3(state) {
         const player = { ...state.player };
         const defaults = createInventoryState();
         const existingInventory = Array.isArray(state.player.inventory) ? state.player.inventory : [];
+        const existingStructuredItems = state.player.inventoryState?.containers?.inventory?.items;
         const inventoryState = state.player.inventoryState && typeof state.player.inventoryState === 'object'
             ? { ...state.player.inventoryState }
             : defaults;
@@ -30,8 +31,8 @@ function migrateGameState2To3(state) {
         const inventoryContainer = inventoryState.containers.inventory && typeof inventoryState.containers.inventory === 'object'
             ? { ...inventoryState.containers.inventory }
             : { ...defaults.containers.inventory };
-        inventoryContainer.items = Array.isArray(inventoryContainer.items)
-            ? inventoryContainer.items
+        inventoryContainer.items = Array.isArray(existingStructuredItems)
+            ? existingStructuredItems
             : existingInventory;
         inventoryState.containers.inventory = inventoryContainer;
         player.inventoryState = inventoryState;

--- a/js/text/version.js
+++ b/js/text/version.js
@@ -1,5 +1,5 @@
-export const PRODUCT_VERSION = '0.4.200.0';
-export const PACKAGE_VERSION = '0.4.200';
+export const PRODUCT_VERSION = '0.4.300.0';
+export const PACKAGE_VERSION = '0.4.300';
 
 export const VERSION = Object.freeze({
     product: PRODUCT_VERSION,
@@ -8,8 +8,8 @@ export const VERSION = Object.freeze({
     gameState: 3,
     data: 13,
     benchmark: 1,
-    codename: 'Version Manifest Separation',
-    compatibility: 'no-backwards-compatibility',
+    codename: 'Ordered Persistence Migrations',
+    compatibility: 'migrate-supported-save-versions',
     released: false,
 
     // Transitional aliases for callers that still use the historical names.
@@ -18,12 +18,13 @@ export const VERSION = Object.freeze({
 });
 
 export const SYSTEM_VERSIONS = Object.freeze({
-    versionManifest: '0.4.200',
+    versionManifest: '0.4.300',
+    saveMigrations: '0.1.0',
     commandShell: '0.4.4',
     canvasUi: '0.7.0',
     uiIntents: '0.1.1',
     slashCommands: '0.4.1',
-    accountSaves: '0.5.2',
+    accountSaves: '0.6.0',
     saveEncoding: '0.4.1',
     parser: '0.2.0',
     validation: '0.6.0',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffxi-text-rpg",
-  "version": "0.4.200",
+  "version": "0.4.300",
   "private": true,
   "type": "module",
   "description": "Text-first fantasy life RPG foundation inspired by Final Fantasy XI systems.",

--- a/tests/migrationEngine.test.js
+++ b/tests/migrationEngine.test.js
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createInitialState } from '../js/text/gameState.js';
+import { reviveGameState } from '../js/text/save.js';
+import { migrateVersionedValue } from '../js/text/systems/migrationEngine.js';
+import {
+    describeSaveMigrationSupport,
+    migrateAccountRegistryPayload,
+    migrateGameStatePayload,
+} from '../js/text/systems/saveMigrations.js';
+import { isValidGameState } from '../js/text/systems/validation.js';
+
+
+test('ordered migration engine applies every required step in sequence', () => {
+    const source = { version: 1, values: [] };
+    const result = migrateVersionedValue(source, {
+        currentVersion: 3,
+        label: 'fixture',
+        migrations: [
+            { id: 'one-to-two', from: 1, to: 2, migrate: (value) => ({ ...value, version: 2, values: [...value.values, 2] }) },
+            { id: 'two-to-three', from: 2, to: 3, migrate: (value) => ({ ...value, version: 3, values: [...value.values, 3] }) },
+        ],
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.migrated, true);
+    assert.deepEqual(result.applied, ['one-to-two', 'two-to-three']);
+    assert.deepEqual(result.value.values, [2, 3]);
+    assert.equal(source.version, 1);
+    assert.deepEqual(source.values, []);
+});
+
+test('ordered migration engine fails deterministically on missing or future versions', () => {
+    const missing = migrateVersionedValue({ version: 1 }, {
+        currentVersion: 3,
+        label: 'fixture',
+        migrations: [{ id: 'two-to-three', from: 2, to: 3, migrate: (value) => ({ ...value, version: 3 }) }],
+    });
+    assert.equal(missing.ok, false);
+    assert.equal(missing.code, 'missing-migration');
+    assert.equal(missing.stoppedAtVersion, 1);
+
+    const future = migrateVersionedValue({ version: 4 }, { currentVersion: 3, label: 'fixture' });
+    assert.equal(future.ok, false);
+    assert.equal(future.code, 'future-version');
+});
+
+test('game-state migration upgrades version 2 inventory/progression shape to version 3', () => {
+    const state = createInitialState();
+    const flatInventory = [{ id: 'old-item', name: 'Old Item', kind: 'misc', quantity: 1 }];
+    state.version = 2;
+    delete state.meta;
+    delete state.player.inventoryState;
+    state.player.inventory = flatInventory;
+    state.player.progression = { ...state.player.progression };
+    delete state.player.progression.skills;
+
+    const result = migrateGameStatePayload(state);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.applied, ['game-state-2-to-3-inventory-and-progression']);
+    assert.equal(result.value.version, 3);
+    assert.equal(result.value.player.inventoryState.containers.inventory.items[0].name, 'Old Item');
+    assert.deepEqual(result.value.player.progression.skills, {});
+
+    const revived = reviveGameState(result.value, 'migrated-character');
+    assert.equal(revived.player.inventory, revived.player.inventoryState.containers.inventory.items);
+    assert.equal(isValidGameState(revived), true);
+});
+
+test('account registry migrations advance stored version 2 records through version 4', () => {
+    const result = migrateAccountRegistryPayload({
+        version: 2,
+        encoding: 'base64-json-v1',
+        accounts: [{ version: 2, encoding: 'base64-json-v1', profile: { accountId: 'account-1' }, characters: [] }],
+    });
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.applied, [
+        'account-registry-2-to-3-version-contract',
+        'account-registry-3-to-4-version-contract',
+    ]);
+    assert.equal(result.value.version, 4);
+    assert.equal(result.value.accounts[0].version, 4);
+});
+
+test('save migration support describes current and oldest supported versions', () => {
+    const support = describeSaveMigrationSupport();
+
+    assert.equal(support.gameState.currentVersion, 3);
+    assert.equal(support.gameState.supportedFrom, 2);
+    assert.equal(support.accountSave.currentVersion, 4);
+    assert.equal(support.accountSave.supportedFrom, 2);
+});

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -14,8 +14,8 @@ import {
 
 
 test('version manifest separates product package and persistence versions', () => {
-    assert.equal(PRODUCT_VERSION, '0.4.200.0');
-    assert.equal(PACKAGE_VERSION, '0.4.200');
+    assert.equal(PRODUCT_VERSION, '0.4.300.0');
+    assert.equal(PACKAGE_VERSION, '0.4.300');
     assert.equal(VERSION.product, PRODUCT_VERSION);
     assert.equal(VERSION.package, PACKAGE_VERSION);
     assert.equal(VERSION.app, PRODUCT_VERSION);
@@ -24,12 +24,14 @@ test('version manifest separates product package and persistence versions', () =
     assert.equal(VERSION.data, 13);
     assert.equal(VERSION.benchmark, 1);
     assert.equal(VERSION.save, VERSION.accountSave);
-    assert.match(describeVersion(), /Product: 0\.4\.200\.0/);
-    assert.match(describeVersion(), /Package: 0\.4\.200/);
+    assert.match(describeVersion(), /Product: 0\.4\.300\.0/);
+    assert.match(describeVersion(), /Package: 0\.4\.300/);
     assert.match(describeVersion(), /Account Save: 4/);
     assert.match(describeVersion(), /Game State: 3/);
-    assert.match(describeVersion(), /Codename: Version Manifest Separation/);
-    assert.match(describeSystemVersions(), /versionManifest: 0\.4\.200/);
+    assert.match(describeVersion(), /Codename: Ordered Persistence Migrations/);
+    assert.match(describeVersion(), /Compatibility: migrate-supported-save-versions/);
+    assert.match(describeSystemVersions(), /versionManifest: 0\.4\.300/);
+    assert.match(describeSystemVersions(), /saveMigrations: 0\.1\.0/);
     assert.match(describeSystemVersions(), /characterCreation/);
     assert.match(describeSystemVersions(), /canvasUi: 0.7.0/);
     assert.match(describeSystemVersions(), /combatActions: 0.5.1/);

--- a/tests/saveMigrationIntegration.test.js
+++ b/tests/saveMigrationIntegration.test.js
@@ -1,0 +1,81 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createInitialState } from '../js/text/gameState.js';
+import {
+    createAccountWithPassword,
+    decodePayload,
+    encodePayload,
+    loadAccount,
+    loadCharacter,
+    saveGame,
+} from '../js/text/save.js';
+
+class MemoryStorage {
+    constructor() {
+        this.values = new Map();
+    }
+
+    getItem(key) {
+        return this.values.has(key) ? this.values.get(key) : null;
+    }
+
+    setItem(key, value) {
+        this.values.set(key, String(value));
+    }
+
+    removeItem(key) {
+        this.values.delete(key);
+    }
+}
+
+function installStorage() {
+    globalThis.localStorage = new MemoryStorage();
+}
+
+test('loading a version 2 account registry migrates and persists it as account save version 4', () => {
+    installStorage();
+    const created = createAccountWithPassword('Legacy Account', 'pwd', { persistentLogin: true });
+    assert.equal(created.ok, true);
+
+    const key = 'ffxiTextRpgAccounts';
+    const registry = decodePayload(globalThis.localStorage.getItem(key));
+    registry.version = 2;
+    registry.accounts = registry.accounts.map((account) => ({ ...account, version: 2 }));
+    globalThis.localStorage.setItem(key, encodePayload(registry));
+
+    const loaded = loadAccount();
+    const migratedRegistry = decodePayload(globalThis.localStorage.getItem(key));
+
+    assert.equal(loaded.profile.displayName, 'Legacy Account');
+    assert.equal(migratedRegistry.version, 4);
+    assert.equal(migratedRegistry.accounts[0].version, 4);
+});
+
+test('loading a version 2 character migrates and persists game state version 3', () => {
+    installStorage();
+    const created = createAccountWithPassword('Legacy Character Account', 'pwd', { persistentLogin: true });
+    assert.equal(created.ok, true);
+
+    const state = createInitialState();
+    state.player.identity.name = 'Legacyhero';
+    assert.equal(saveGame(state), true);
+
+    const key = 'ffxiTextRpgAccounts';
+    const registry = decodePayload(globalThis.localStorage.getItem(key));
+    const record = registry.accounts[0].characters[0];
+    const oldState = decodePayload(record.encodedState);
+    oldState.version = 2;
+    delete oldState.meta;
+    record.encodedState = encodePayload(oldState);
+    globalThis.localStorage.setItem(key, encodePayload(registry));
+
+    const loaded = loadCharacter('Legacyhero');
+    const migratedRegistry = decodePayload(globalThis.localStorage.getItem(key));
+    const migratedState = decodePayload(migratedRegistry.accounts[0].characters[0].encodedState);
+
+    assert.equal(loaded.version, 3);
+    assert.equal(loaded.meta.characterId, record.id);
+    assert.equal(migratedState.version, 3);
+    assert.equal(migratedState.meta.characterId, record.id);
+});


### PR DESCRIPTION
## Target

Product track: `0.4.300` — Ordered persistence migrations.

## Changes

- adds a generic ordered version-migration engine with deterministic failure codes
- adds explicit Game State migration support from v2 -> v3
- adds explicit Account Save registry migration support from v2 -> v3 -> v4
- reconciles the persisted account registry version with authoritative `VERSION.accountSave`
- migrates supported character saves before revive/validation and persists the migrated state on successful load
- migrates supported account registries on load and persists the current shape
- rejects unsupported missing/future migration paths deterministically instead of silently treating them as current
- adds migration support introspection and focused unit/integration tests

## Version impact

- Product: `0.4.200.0` -> `0.4.300.0`
- Package: `0.4.200` -> `0.4.300`
- Account Save: remains `4`; stored registry now actually uses that authoritative counter
- Game State: remains `3`
- Data: unchanged (`13`)
- `saveMigrations`: `0.1.0`
- `accountSaves`: `0.6.0`

## Migration policy

- Account registry v2 and v3 are supported and migrate to v4 in order.
- Game State v2 is supported and migrates to v3.
- Older unregistered versions and future versions are rejected with explicit migration failures.
- Existing revive logic remains a post-migration object-reference repair step; it is no longer the sole compatibility strategy.

## Tests

GitHub Actions runs `npm test` and `npm run benchmark` on Node 20. Merge only after the check passes.

## Known limitations

This pass does not add the structured engine action contract; that is the next `0.4.400` track.