### PR TITLE
Implement 0.4.400 structured action contract

### DIFF
--- a/js/text/systems/actionResult.js
+++ b/js/text/systems/actionResult.js
@@ -1,11 +1,11 @@
 export const ACTION_RESULT_VERSION = 1;
 
 export function actionSuccess(options = {}) {
-    return createActionResult({ ...options, ok: true });
+    return asLegacyActionResult(createActionResult({ ...options, ok: true }));
 }
 
 export function actionFailure(options = {}) {
-    return createActionResult({ ...options, ok: false });
+    return asLegacyActionResult(createActionResult({ ...options, ok: false }));
 }
 
 export function createActionResult(options = {}) {

--- a/js/text/systems/actionResult.js
+++ b/js/text/systems/actionResult.js
@@ -1,0 +1,65 @@
+export const ACTION_RESULT_VERSION = 1;
+
+export function actionSuccess(options = {}) {
+    return createActionResult({ ...options, ok: true });
+}
+
+export function actionFailure(options = {}) {
+    return createActionResult({ ...options, ok: false });
+}
+
+export function createActionResult(options = {}) {
+    const {
+        ok,
+        action,
+        code,
+        outcome,
+        data = {},
+        display = {},
+    } = options;
+
+    if (typeof ok !== 'boolean') throw new Error('ActionResult ok must be boolean.');
+    if (!isNonEmptyString(action)) throw new Error('ActionResult action is required.');
+    if (!isNonEmptyString(code)) throw new Error('ActionResult code is required.');
+    if (!isNonEmptyString(outcome)) throw new Error('ActionResult outcome is required.');
+    if (!isPlainObject(data)) throw new Error('ActionResult data must be an object.');
+    if (!isPlainObject(display)) throw new Error('ActionResult display must be an object.');
+
+    return Object.freeze({
+        contract: 'ActionResult',
+        version: ACTION_RESULT_VERSION,
+        ok,
+        action,
+        code,
+        outcome,
+        data: Object.freeze({ ...data }),
+        display: Object.freeze({ ...display }),
+    });
+}
+
+export function isActionResult(value) {
+    return Boolean(
+        value
+        && value.contract === 'ActionResult'
+        && value.version === ACTION_RESULT_VERSION
+        && typeof value.ok === 'boolean'
+        && isNonEmptyString(value.action)
+        && isNonEmptyString(value.code)
+        && isNonEmptyString(value.outcome)
+        && isPlainObject(value.data)
+        && isPlainObject(value.display),
+    );
+}
+
+export function describeActionResult(result, fallback = '') {
+    if (!isActionResult(result)) return fallback;
+    return String(result.display.text ?? fallback);
+}
+
+function isNonEmptyString(value) {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isPlainObject(value) {
+    return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}

--- a/js/text/systems/actionResult.js
+++ b/js/text/systems/actionResult.js
@@ -56,6 +56,35 @@ export function describeActionResult(result, fallback = '') {
     return String(result.display.text ?? fallback);
 }
 
+// Transitional adapter for callers that still read .message/.reason or a promoted
+// semantic field directly. The compatibility aliases are non-enumerable so saved,
+// logged, or inspected ActionResult data keeps prose isolated under display.
+export function asLegacyActionResult(result, promotedDataKeys = []) {
+    if (!isActionResult(result)) return result;
+    const view = { ...result };
+    const descriptors = {
+        message: {
+            enumerable: false,
+            get: () => (result.ok ? describeActionResult(result) : undefined),
+        },
+        reason: {
+            enumerable: false,
+            get: () => (!result.ok ? describeActionResult(result) : undefined),
+        },
+    };
+
+    for (const key of promotedDataKeys) {
+        if (!(key in result.data) || key in view) continue;
+        descriptors[key] = {
+            enumerable: false,
+            get: () => result.data[key],
+        };
+    }
+
+    Object.defineProperties(view, descriptors);
+    return Object.freeze(view);
+}
+
 function isNonEmptyString(value) {
     return typeof value === 'string' && value.trim().length > 0;
 }

--- a/js/text/systems/travelEngine.js
+++ b/js/text/systems/travelEngine.js
@@ -7,6 +7,7 @@ import {
     normalizePositionForPlace,
 } from '../data/coordinates.js';
 import { getConnectionsFrom, getPlace, listPlaces } from '../data/places.js';
+import { actionFailure, actionSuccess } from './actionResult.js';
 import { setPositionAndDiscover } from './atlasEngine.js';
 
 export function describePlace(placeId) {
@@ -45,28 +46,49 @@ export function findTravelRoute(state, destinationQuery, options = {}) {
     const from = state.currentPlaceId ?? 'southern-sandoria';
     const destination = findPlaceByQuery(destinationQuery);
     if (!destination) {
-        return { ok: false, reason: `Unknown destination: ${destinationQuery}` };
+        return { ok: false, code: 'unknown-destination', reason: `Unknown destination: ${destinationQuery}` };
     }
 
     const connections = getConnectionsFrom(from).filter((candidate) => candidate.to === destination.id);
     const connection = selectConnectionForPosition(state, connections, options.direction);
     if (!connection) {
         if (connections.length) return describeBlockedConnection(state, connections, destination);
-        return { ok: false, reason: `No direct route from ${getPlace(from)?.name ?? from} to ${destination.name}.` };
+        return {
+            ok: false,
+            code: 'no-direct-route',
+            reason: `No direct route from ${getPlace(from)?.name ?? from} to ${destination.name}.`,
+            from,
+            to: destination.id,
+        };
     }
 
     const restriction = findBlockingRestriction(state, connection.restrictions);
     if (restriction) {
-        return { ok: false, reason: restriction.reason ?? `Travel blocked by ${restriction.type}.` };
+        return {
+            ok: false,
+            code: 'route-restricted',
+            reason: restriction.reason ?? `Travel blocked by ${restriction.type}.`,
+            from,
+            to: destination.id,
+            restrictionType: restriction.type,
+        };
     }
 
     const placeRestriction = findBlockingRestriction(state, destination.restrictions);
     if (placeRestriction) {
-        return { ok: false, reason: placeRestriction.reason ?? `Entry blocked by ${placeRestriction.type}.` };
+        return {
+            ok: false,
+            code: 'destination-restricted',
+            reason: placeRestriction.reason ?? `Entry blocked by ${placeRestriction.type}.`,
+            from,
+            to: destination.id,
+            restrictionType: placeRestriction.type,
+        };
     }
 
     return {
         ok: true,
+        code: 'route-found',
         from,
         to: destination.id,
         connection,
@@ -76,11 +98,31 @@ export function findTravelRoute(state, destinationQuery, options = {}) {
 
 export function startTravel(state, destinationQuery) {
     if (state.travel?.active) {
-        return { ok: false, reason: `Already traveling to ${getPlace(state.travel.to)?.name ?? state.travel.to}.` };
+        const destinationName = getPlace(state.travel.to)?.name ?? state.travel.to;
+        return actionFailure({
+            action: 'travel.start',
+            code: 'travel.already-active',
+            outcome: 'blocked',
+            data: { destinationId: state.travel.to },
+            display: { text: `Already traveling to ${destinationName}.` },
+        });
     }
 
     const route = findTravelRoute(state, destinationQuery);
-    if (!route.ok) return route;
+    if (!route.ok) {
+        return actionFailure({
+            action: 'travel.start',
+            code: `travel.${route.code ?? 'blocked'}`,
+            outcome: 'blocked',
+            data: {
+                destinationQuery,
+                from: route.from ?? state.currentPlaceId ?? null,
+                to: route.to ?? null,
+                restrictionType: route.restrictionType ?? null,
+            },
+            display: { text: route.reason ?? 'Travel is blocked.' },
+        });
+    }
 
     state.travel = {
         active: true,
@@ -92,11 +134,20 @@ export function startTravel(state, destinationQuery) {
         arriveAt: route.connection.arriveAt ?? route.destination.coordinateSystem.start,
     };
 
-    return {
-        ok: true,
-        message: `Traveling to ${route.destination.name}. Estimated time: ${route.connection.travelSeconds}s.`,
-        travel: state.travel,
-    };
+    return actionSuccess({
+        action: 'travel.start',
+        code: 'travel.started',
+        outcome: 'started',
+        data: {
+            from: route.from,
+            to: route.to,
+            destinationName: route.destination.name,
+            mode: route.connection.mode,
+            durationSeconds: route.connection.travelSeconds,
+            travel: state.travel,
+        },
+        display: { text: `Traveling to ${route.destination.name}. Estimated time: ${route.connection.travelSeconds}s.` },
+    });
 }
 
 export function advanceTravel(state, elapsedSeconds) {
@@ -199,6 +250,9 @@ function describeBlockedConnection(state, connections, destination) {
         .join('; ');
     return {
         ok: false,
+        code: 'departure-position-required',
+        from: state.currentPlaceId,
+        to: destination.id,
         reason: `Reach ${options} to travel from ${place?.name ?? state.currentPlaceId} to ${destination.name}. Current position: ${describeCoordinate(current)}.`,
     };
 }

--- a/js/text/version.js
+++ b/js/text/version.js
@@ -1,5 +1,5 @@
-export const PRODUCT_VERSION = '0.4.300.0';
-export const PACKAGE_VERSION = '0.4.300';
+export const PRODUCT_VERSION = '0.4.400.0';
+export const PACKAGE_VERSION = '0.4.400';
 
 export const VERSION = Object.freeze({
     product: PRODUCT_VERSION,
@@ -8,7 +8,7 @@ export const VERSION = Object.freeze({
     gameState: 3,
     data: 13,
     benchmark: 1,
-    codename: 'Ordered Persistence Migrations',
+    codename: 'Structured Action Contract',
     compatibility: 'migrate-supported-save-versions',
     released: false,
 
@@ -18,8 +18,9 @@ export const VERSION = Object.freeze({
 });
 
 export const SYSTEM_VERSIONS = Object.freeze({
-    versionManifest: '0.4.300',
+    versionManifest: '0.4.400',
     saveMigrations: '0.1.0',
+    actionResults: '0.1.0',
     commandShell: '0.4.4',
     canvasUi: '0.7.0',
     uiIntents: '0.1.1',
@@ -51,7 +52,7 @@ export const SYSTEM_VERSIONS = Object.freeze({
     gridMovement: '0.4.0',
     hudControls: '0.4.0',
     aggro: '0.3.3',
-    travel: '0.4.0',
+    travel: '0.4.1',
     pois: '0.3.5',
     poiDiscovery: '0.3.5',
     poiFastTravel: '0.3.5',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffxi-text-rpg",
-  "version": "0.4.300",
+  "version": "0.4.400",
   "private": true,
   "type": "module",
   "description": "Text-first fantasy life RPG foundation inspired by Final Fantasy XI systems.",

--- a/tests/actionResult.test.js
+++ b/tests/actionResult.test.js
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+    ACTION_RESULT_VERSION,
+    actionFailure,
+    actionSuccess,
+    createActionResult,
+    describeActionResult,
+    isActionResult,
+} from '../js/text/systems/actionResult.js';
+
+
+test('ActionResult separates semantic data from display prose', () => {
+    const result = actionSuccess({
+        action: 'fixture.start',
+        code: 'fixture.started',
+        outcome: 'started',
+        data: { targetId: 'target-1', durationSeconds: 30 },
+        display: { text: 'Started fixture action.' },
+    });
+
+    assert.equal(result.contract, 'ActionResult');
+    assert.equal(result.version, ACTION_RESULT_VERSION);
+    assert.equal(result.ok, true);
+    assert.equal(result.action, 'fixture.start');
+    assert.equal(result.code, 'fixture.started');
+    assert.equal(result.outcome, 'started');
+    assert.deepEqual(result.data, { targetId: 'target-1', durationSeconds: 30 });
+    assert.deepEqual(result.display, { text: 'Started fixture action.' });
+    assert.equal(describeActionResult(result), 'Started fixture action.');
+    assert.equal(isActionResult(result), true);
+});
+
+test('legacy message and reason aliases are non-enumerable compatibility adapters', () => {
+    const success = actionSuccess({
+        action: 'fixture.start',
+        code: 'fixture.started',
+        outcome: 'started',
+        display: { text: 'Started.' },
+    });
+    const failure = actionFailure({
+        action: 'fixture.start',
+        code: 'fixture.blocked',
+        outcome: 'blocked',
+        display: { text: 'Blocked.' },
+    });
+
+    assert.equal(success.message, 'Started.');
+    assert.equal(success.reason, undefined);
+    assert.equal(failure.message, undefined);
+    assert.equal(failure.reason, 'Blocked.');
+    assert.equal(Object.keys(success).includes('message'), false);
+    assert.equal(Object.keys(failure).includes('reason'), false);
+    assert.equal(JSON.stringify(success).includes('Started.'), true);
+    assert.equal(JSON.stringify(success).includes('message'), false);
+});
+
+test('ActionResult validates required semantic fields', () => {
+    assert.throws(() => createActionResult({ ok: true, action: '', code: 'x', outcome: 'x' }), /action is required/);
+    assert.throws(() => createActionResult({ ok: true, action: 'x', code: '', outcome: 'x' }), /code is required/);
+    assert.throws(() => createActionResult({ ok: true, action: 'x', code: 'x', outcome: '' }), /outcome is required/);
+});

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -14,8 +14,8 @@ import {
 
 
 test('version manifest separates product package and persistence versions', () => {
-    assert.equal(PRODUCT_VERSION, '0.4.300.0');
-    assert.equal(PACKAGE_VERSION, '0.4.300');
+    assert.equal(PRODUCT_VERSION, '0.4.400.0');
+    assert.equal(PACKAGE_VERSION, '0.4.400');
     assert.equal(VERSION.product, PRODUCT_VERSION);
     assert.equal(VERSION.package, PACKAGE_VERSION);
     assert.equal(VERSION.app, PRODUCT_VERSION);
@@ -24,14 +24,16 @@ test('version manifest separates product package and persistence versions', () =
     assert.equal(VERSION.data, 13);
     assert.equal(VERSION.benchmark, 1);
     assert.equal(VERSION.save, VERSION.accountSave);
-    assert.match(describeVersion(), /Product: 0\.4\.300\.0/);
-    assert.match(describeVersion(), /Package: 0\.4\.300/);
+    assert.match(describeVersion(), /Product: 0\.4\.400\.0/);
+    assert.match(describeVersion(), /Package: 0\.4\.400/);
     assert.match(describeVersion(), /Account Save: 4/);
     assert.match(describeVersion(), /Game State: 3/);
-    assert.match(describeVersion(), /Codename: Ordered Persistence Migrations/);
+    assert.match(describeVersion(), /Codename: Structured Action Contract/);
     assert.match(describeVersion(), /Compatibility: migrate-supported-save-versions/);
-    assert.match(describeSystemVersions(), /versionManifest: 0\.4\.300/);
+    assert.match(describeSystemVersions(), /versionManifest: 0\.4\.400/);
     assert.match(describeSystemVersions(), /saveMigrations: 0\.1\.0/);
+    assert.match(describeSystemVersions(), /actionResults: 0\.1\.0/);
+    assert.match(describeSystemVersions(), /travel: 0\.4\.1/);
     assert.match(describeSystemVersions(), /characterCreation/);
     assert.match(describeSystemVersions(), /canvasUi: 0.7.0/);
     assert.match(describeSystemVersions(), /combatActions: 0.5.1/);

--- a/tests/travelEngine.test.js
+++ b/tests/travelEngine.test.js
@@ -5,6 +5,7 @@ import { createInitialState } from '../js/text/gameState.js';
 import { createCommandRouter } from '../js/text/commandRouter.js';
 import { describeMap, describeMaps, listMaps } from '../js/text/data/maps.js';
 import { getPlace, listPlaces, ZONE_CONNECTIONS } from '../js/text/data/places.js';
+import { isActionResult } from '../js/text/systems/actionResult.js';
 import { setPositionAndDiscover } from '../js/text/systems/atlasEngine.js';
 import { validateWorldData } from '../js/text/systems/validation.js';
 import {
@@ -53,6 +54,7 @@ test('findTravelRoute finds connected destination', () => {
     const route = findTravelRoute(state, 'West Ronfaure');
 
     assert.equal(route.ok, true);
+    assert.equal(route.code, 'route-found');
     assert.equal(route.to, 'west-ronfaure');
 });
 
@@ -61,15 +63,23 @@ test('findTravelRoute rejects disconnected destination', () => {
     const route = findTravelRoute(state, 'Ghelsba Outpost');
 
     assert.equal(route.ok, false);
+    assert.equal(route.code, 'no-direct-route');
     assert.match(route.reason, /No direct route/);
 });
 
-test('startTravel and advanceTravel move current place', () => {
+test('startTravel returns semantic ActionResult and advanceTravel moves current place', () => {
     const state = createInitialState();
     setPositionAndDiscover(state, 'southern-sandoria', { coord: 'F-10' });
     const started = startTravel(state, 'West Ronfaure');
 
+    assert.equal(isActionResult(started), true);
     assert.equal(started.ok, true);
+    assert.equal(started.action, 'travel.start');
+    assert.equal(started.code, 'travel.started');
+    assert.equal(started.outcome, 'started');
+    assert.equal(started.data.to, 'west-ronfaure');
+    assert.equal(started.data.durationSeconds, 45);
+    assert.match(started.display.text, /Traveling to West Ronfaure/);
     assert.equal(state.travel.active, true);
 
     const advanced = advanceTravel(state, 45);
@@ -77,6 +87,20 @@ test('startTravel and advanceTravel move current place', () => {
     assert.equal(advanced.completed, true);
     assert.equal(state.currentPlaceId, 'west-ronfaure');
     assert.equal(state.location, 'West Ronfaure');
+});
+
+test('startTravel failure uses semantic code while retaining command compatibility text adapter', () => {
+    const state = createInitialState();
+    const result = startTravel(state, 'Unknown Somewhere');
+
+    assert.equal(isActionResult(result), true);
+    assert.equal(result.ok, false);
+    assert.equal(result.code, 'travel.unknown-destination');
+    assert.equal(result.outcome, 'blocked');
+    assert.equal(result.data.destinationQuery, 'Unknown Somewhere');
+    assert.match(result.display.text, /Unknown destination/);
+    assert.match(result.reason, /Unknown destination/);
+    assert.equal(Object.keys(result).includes('reason'), false);
 });
 
 test('router exposes maps zones travel and wait commands', () => {


### PR DESCRIPTION
## Target

Product track: `0.4.400` — Structured action contract.

## Changes

- adds a small versioned `ActionResult` contract with explicit semantic fields: `action`, `code`, `outcome`, and `data`
- isolates user-facing prose under `display`
- adds validation/introspection helpers for ActionResult consumers
- provides non-enumerable `.message` / `.reason` compatibility aliases as a transitional command adapter
- migrates the travel-start path as the first representative engine action
- adds stable semantic route/start failure codes instead of requiring consumers to infer state from prose
- preserves existing `travel` command output while direct engine consumers can use structured data

## Version impact

- Product: `0.4.300.0` -> `0.4.400.0`
- Package: `0.4.300` -> `0.4.400`
- `actionResults`: `0.1.0`
- `travel`: `0.4.0` -> `0.4.1`
- Account Save / Game State / Data: unchanged

## Contract boundary

This is deliberately a pilot, not a mass rewrite. Existing systems may continue returning their current forms until migrated deliberately. The travel-start path proves that semantic outcome data and display prose can be separated without breaking command-facing text behavior.

## Tests

Adds focused ActionResult tests plus travel semantic/compatibility tests. GitHub Actions runs the full test suite and benchmark before merge.

## Next track

`0.4.500` — lightweight semantic event foundation.