### PR TITLE
Implement 0.4.500 semantic event foundation

### DIFF
--- a/js/text/gameState.js
+++ b/js/text/gameState.js
@@ -5,6 +5,7 @@ import { describeCoordinate, normalizePositionForPlace } from './data/coordinate
 import { getPlace } from './data/places.js';
 import { createAtlasState, describeCurrentGrid, setPositionAndDiscover } from './systems/atlasEngine.js';
 import { describeCurrentPois, createPoiDiscoveryState } from './systems/poiEngine.js';
+import { createSemanticEventState } from './systems/semanticEventEngine.js';
 import { describePlace } from './systems/travelEngine.js';
 import { moveInDirection } from './systems/navigationEngine.js';
 import { calculateCombatProfile } from './systems/statEngine.js';
@@ -33,7 +34,7 @@ export function createNewGameState(options = {}) {
     });
 
     return {
-        version: 3,
+        version: 4,
         currentPlaceId: startPlace.id,
         location: startPlace.name,
         position: startCoordinate,
@@ -46,6 +47,7 @@ export function createNewGameState(options = {}) {
         inventory: player.inventory,
         flags: {},
         log: [],
+        events: createSemanticEventState(),
         activeBattle: null,
     };
 }

--- a/js/text/gameState.js
+++ b/js/text/gameState.js
@@ -34,7 +34,7 @@ export function createNewGameState(options = {}) {
     });
 
     return {
-        version: 4,
+        version: 3,
         currentPlaceId: startPlace.id,
         location: startPlace.name,
         position: startCoordinate,

--- a/js/text/systems/semanticEventEngine.js
+++ b/js/text/systems/semanticEventEngine.js
@@ -1,0 +1,121 @@
+export const SEMANTIC_EVENT_VERSION = 1;
+export const DEFAULT_EVENT_HISTORY_LIMIT = 200;
+
+export function createSemanticEventState(options = {}) {
+    const nextSequence = Number.isInteger(options.nextSequence) && options.nextSequence > 0
+        ? options.nextSequence
+        : 1;
+    const records = Array.isArray(options.records) ? [...options.records] : [];
+    return { nextSequence, records };
+}
+
+export function ensureSemanticEventState(state) {
+    if (!state || typeof state !== 'object') throw new Error('Semantic events require game state.');
+    if (!state.events || typeof state.events !== 'object' || Array.isArray(state.events)) {
+        state.events = createSemanticEventState();
+    }
+    if (!Number.isInteger(state.events.nextSequence) || state.events.nextSequence < 1) {
+        const maxSequence = Array.isArray(state.events.records)
+            ? state.events.records.reduce((max, event) => Math.max(max, Number(event?.sequence) || 0), 0)
+            : 0;
+        state.events.nextSequence = maxSequence + 1;
+    }
+    if (!Array.isArray(state.events.records)) state.events.records = [];
+    return state.events;
+}
+
+export function emitSemanticEvent(state, type, data = {}, options = {}) {
+    if (!isEventType(type)) throw new Error(`Invalid semantic event type: ${type}`);
+    if (!isPlainObject(data)) throw new Error('Semantic event data must be an object.');
+
+    const eventState = ensureSemanticEventState(state);
+    const sequence = eventState.nextSequence;
+    eventState.nextSequence += 1;
+
+    const event = Object.freeze({
+        id: `evt-${String(sequence).padStart(6, '0')}`,
+        version: SEMANTIC_EVENT_VERSION,
+        sequence,
+        type,
+        source: normalizeSource(options.source),
+        worldTimeSeconds: Number.isFinite(state.worldTime?.totalSeconds) ? state.worldTime.totalSeconds : null,
+        data: Object.freeze({ ...data }),
+    });
+
+    eventState.records.push(event);
+    const limit = normalizeLimit(options.historyLimit ?? DEFAULT_EVENT_HISTORY_LIMIT);
+    if (eventState.records.length > limit) {
+        eventState.records.splice(0, eventState.records.length - limit);
+    }
+    return event;
+}
+
+export function listSemanticEvents(state, options = {}) {
+    const eventState = ensureSemanticEventState(state);
+    const type = options.type ? String(options.type) : null;
+    const afterSequence = Number.isInteger(options.afterSequence) ? options.afterSequence : 0;
+    const limit = normalizeLimit(options.limit ?? DEFAULT_EVENT_HISTORY_LIMIT);
+    return eventState.records
+        .filter((event) => (!type || event.type === type) && event.sequence > afterSequence)
+        .slice(-limit);
+}
+
+export function hasSemanticEvent(state, type, predicate = null) {
+    return listSemanticEvents(state, { type }).some((event) => (
+        typeof predicate === 'function' ? predicate(event) : true
+    ));
+}
+
+export function isSemanticEvent(value) {
+    return Boolean(
+        value
+        && typeof value.id === 'string'
+        && value.version === SEMANTIC_EVENT_VERSION
+        && Number.isInteger(value.sequence)
+        && value.sequence > 0
+        && isEventType(value.type)
+        && typeof value.source === 'string'
+        && isPlainObject(value.data),
+    );
+}
+
+export function validateSemanticEventState(eventState) {
+    const issues = [];
+    if (!eventState || typeof eventState !== 'object' || Array.isArray(eventState)) return ['events must be an object.'];
+    if (!Number.isInteger(eventState.nextSequence) || eventState.nextSequence < 1) issues.push('events.nextSequence must be a positive integer.');
+    if (!Array.isArray(eventState.records)) return [...issues, 'events.records must be an array.'];
+
+    let previousSequence = 0;
+    const ids = new Set();
+    for (const [index, event] of eventState.records.entries()) {
+        if (!isSemanticEvent(event)) {
+            issues.push(`events.records[${index}] is not a valid semantic event.`);
+            continue;
+        }
+        if (ids.has(event.id)) issues.push(`events.records[${index}] duplicates event id ${event.id}.`);
+        ids.add(event.id);
+        if (event.sequence <= previousSequence) issues.push('events.records must be ordered by increasing sequence.');
+        previousSequence = event.sequence;
+    }
+    if (previousSequence >= eventState.nextSequence) issues.push('events.nextSequence must be greater than all stored event sequences.');
+    return issues;
+}
+
+function normalizeLimit(value) {
+    const parsed = Number.parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed < 1) return DEFAULT_EVENT_HISTORY_LIMIT;
+    return parsed;
+}
+
+function normalizeSource(value) {
+    const source = String(value ?? 'system').trim();
+    return source || 'system';
+}
+
+function isEventType(value) {
+    return typeof value === 'string' && /^[a-z][a-z0-9]*(?:\.[a-z0-9-]+)+$/.test(value);
+}
+
+function isPlainObject(value) {
+    return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}

--- a/js/text/systems/travelEngine.js
+++ b/js/text/systems/travelEngine.js
@@ -9,6 +9,7 @@ import {
 import { getConnectionsFrom, getPlace, listPlaces } from '../data/places.js';
 import { actionFailure, actionSuccess } from './actionResult.js';
 import { setPositionAndDiscover } from './atlasEngine.js';
+import { emitSemanticEvent } from './semanticEventEngine.js';
 
 export function describePlace(placeId) {
     const place = getPlace(placeId);
@@ -134,6 +135,14 @@ export function startTravel(state, destinationQuery) {
         arriveAt: route.connection.arriveAt ?? route.destination.coordinateSystem.start,
     };
 
+    const event = emitSemanticEvent(state, 'travel.started', {
+        from: route.from,
+        to: route.to,
+        destinationName: route.destination.name,
+        mode: route.connection.mode,
+        durationSeconds: route.connection.travelSeconds,
+    }, { source: 'travelEngine' });
+
     return actionSuccess({
         action: 'travel.start',
         code: 'travel.started',
@@ -145,6 +154,7 @@ export function startTravel(state, destinationQuery) {
             mode: route.connection.mode,
             durationSeconds: route.connection.travelSeconds,
             travel: state.travel,
+            eventId: event.id,
         },
         display: { text: `Traveling to ${route.destination.name}. Estimated time: ${route.connection.travelSeconds}s.` },
     });
@@ -170,10 +180,19 @@ export function advanceTravel(state, elapsedSeconds) {
     }
     state.travel = null;
 
+    const event = emitSemanticEvent(state, 'travel.arrived', {
+        from: completed.from,
+        to: completed.to,
+        destinationName: destination?.name ?? completed.to,
+        mode: completed.mode,
+        arrival,
+    }, { source: 'travelEngine' });
+
     return {
         completed: true,
         travel: completed,
         destination,
+        eventId: event.id,
         message: `Arrived at ${destination?.name ?? completed.to} ${describeCoordinate(arrival)}.`,
     };
 }

--- a/js/text/version.js
+++ b/js/text/version.js
@@ -1,5 +1,5 @@
-export const PRODUCT_VERSION = '0.4.400.0';
-export const PACKAGE_VERSION = '0.4.400';
+export const PRODUCT_VERSION = '0.4.500.0';
+export const PACKAGE_VERSION = '0.4.500';
 
 export const VERSION = Object.freeze({
     product: PRODUCT_VERSION,
@@ -8,7 +8,7 @@ export const VERSION = Object.freeze({
     gameState: 3,
     data: 13,
     benchmark: 1,
-    codename: 'Structured Action Contract',
+    codename: 'Semantic Event Foundation',
     compatibility: 'migrate-supported-save-versions',
     released: false,
 
@@ -18,9 +18,10 @@ export const VERSION = Object.freeze({
 });
 
 export const SYSTEM_VERSIONS = Object.freeze({
-    versionManifest: '0.4.400',
+    versionManifest: '0.4.500',
     saveMigrations: '0.1.0',
     actionResults: '0.1.0',
+    semanticEvents: '0.1.0',
     commandShell: '0.4.4',
     canvasUi: '0.7.0',
     uiIntents: '0.1.1',
@@ -52,7 +53,7 @@ export const SYSTEM_VERSIONS = Object.freeze({
     gridMovement: '0.4.0',
     hudControls: '0.4.0',
     aggro: '0.3.3',
-    travel: '0.4.1',
+    travel: '0.4.2',
     pois: '0.3.5',
     poiDiscovery: '0.3.5',
     poiFastTravel: '0.3.5',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffxi-text-rpg",
-  "version": "0.4.400",
+  "version": "0.4.500",
   "private": true,
   "type": "module",
   "description": "Text-first fantasy life RPG foundation inspired by Final Fantasy XI systems.",

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -14,8 +14,8 @@ import {
 
 
 test('version manifest separates product package and persistence versions', () => {
-    assert.equal(PRODUCT_VERSION, '0.4.400.0');
-    assert.equal(PACKAGE_VERSION, '0.4.400');
+    assert.equal(PRODUCT_VERSION, '0.4.500.0');
+    assert.equal(PACKAGE_VERSION, '0.4.500');
     assert.equal(VERSION.product, PRODUCT_VERSION);
     assert.equal(VERSION.package, PACKAGE_VERSION);
     assert.equal(VERSION.app, PRODUCT_VERSION);
@@ -24,16 +24,17 @@ test('version manifest separates product package and persistence versions', () =
     assert.equal(VERSION.data, 13);
     assert.equal(VERSION.benchmark, 1);
     assert.equal(VERSION.save, VERSION.accountSave);
-    assert.match(describeVersion(), /Product: 0\.4\.400\.0/);
-    assert.match(describeVersion(), /Package: 0\.4\.400/);
+    assert.match(describeVersion(), /Product: 0\.4\.500\.0/);
+    assert.match(describeVersion(), /Package: 0\.4\.500/);
     assert.match(describeVersion(), /Account Save: 4/);
     assert.match(describeVersion(), /Game State: 3/);
-    assert.match(describeVersion(), /Codename: Structured Action Contract/);
+    assert.match(describeVersion(), /Codename: Semantic Event Foundation/);
     assert.match(describeVersion(), /Compatibility: migrate-supported-save-versions/);
-    assert.match(describeSystemVersions(), /versionManifest: 0\.4\.400/);
+    assert.match(describeSystemVersions(), /versionManifest: 0\.4\.500/);
     assert.match(describeSystemVersions(), /saveMigrations: 0\.1\.0/);
     assert.match(describeSystemVersions(), /actionResults: 0\.1\.0/);
-    assert.match(describeSystemVersions(), /travel: 0\.4\.1/);
+    assert.match(describeSystemVersions(), /semanticEvents: 0\.1\.0/);
+    assert.match(describeSystemVersions(), /travel: 0\.4\.2/);
     assert.match(describeSystemVersions(), /characterCreation/);
     assert.match(describeSystemVersions(), /canvasUi: 0.7.0/);
     assert.match(describeSystemVersions(), /combatActions: 0.5.1/);

--- a/tests/semanticEventEngine.test.js
+++ b/tests/semanticEventEngine.test.js
@@ -1,0 +1,87 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createInitialState } from '../js/text/gameState.js';
+import { setPositionAndDiscover } from '../js/text/systems/atlasEngine.js';
+import {
+    createSemanticEventState,
+    emitSemanticEvent,
+    hasSemanticEvent,
+    listSemanticEvents,
+    validateSemanticEventState,
+} from '../js/text/systems/semanticEventEngine.js';
+import { advanceTravel, startTravel } from '../js/text/systems/travelEngine.js';
+
+
+test('semantic events use stable sequential ids and typed semantic data', () => {
+    const state = { events: createSemanticEventState() };
+
+    const first = emitSemanticEvent(state, 'fixture.started', { targetId: 'a' }, { source: 'test' });
+    const second = emitSemanticEvent(state, 'fixture.completed', { targetId: 'a' }, { source: 'test' });
+
+    assert.equal(first.id, 'evt-000001');
+    assert.equal(first.sequence, 1);
+    assert.equal(first.type, 'fixture.started');
+    assert.deepEqual(first.data, { targetId: 'a' });
+    assert.equal(second.id, 'evt-000002');
+    assert.equal(state.events.nextSequence, 3);
+    assert.deepEqual(validateSemanticEventState(state.events), []);
+});
+
+test('semantic event consumers filter structured outcomes without parsing log prose', () => {
+    const state = {
+        log: [{ entry: 'This prose deliberately says nothing useful about the objective.' }],
+        events: createSemanticEventState(),
+    };
+    emitSemanticEvent(state, 'project.material-added', { projectId: 'shed', materialId: 'lumber', quantity: 8 });
+
+    const satisfied = hasSemanticEvent(
+        state,
+        'project.material-added',
+        (event) => event.data.projectId === 'shed' && event.data.quantity >= 8,
+    );
+
+    assert.equal(satisfied, true);
+    assert.equal(state.log.some((entry) => entry.entry.includes('shed')), false);
+});
+
+test('event history is bounded without becoming authoritative state history', () => {
+    const state = { events: createSemanticEventState() };
+
+    emitSemanticEvent(state, 'fixture.step', { n: 1 }, { historyLimit: 2 });
+    emitSemanticEvent(state, 'fixture.step', { n: 2 }, { historyLimit: 2 });
+    emitSemanticEvent(state, 'fixture.step', { n: 3 }, { historyLimit: 2 });
+
+    assert.deepEqual(listSemanticEvents(state).map((event) => event.data.n), [2, 3]);
+    assert.equal(state.events.nextSequence, 4);
+});
+
+test('travel emits semantic start and arrival events independently of display prose', () => {
+    const state = createInitialState();
+    setPositionAndDiscover(state, 'southern-sandoria', { coord: 'F-10' });
+
+    const started = startTravel(state, 'West Ronfaure');
+    assert.equal(started.ok, true);
+    assert.equal(hasSemanticEvent(state, 'travel.started', (event) => event.data.to === 'west-ronfaure'), true);
+    assert.equal(started.data.eventId, 'evt-000001');
+
+    const advanced = advanceTravel(state, 45);
+    assert.equal(advanced.completed, true);
+    assert.equal(advanced.eventId, 'evt-000002');
+    assert.equal(hasSemanticEvent(state, 'travel.arrived', (event) => event.data.to === 'west-ronfaure'), true);
+
+    const travelEvents = listSemanticEvents(state);
+    assert.deepEqual(travelEvents.map((event) => event.type), ['travel.started', 'travel.arrived']);
+});
+
+test('old state without an event container is upgraded lazily without a save-version bump', () => {
+    const state = createInitialState();
+    delete state.events;
+    assert.equal(state.version, 3);
+
+    const event = emitSemanticEvent(state, 'fixture.started', { value: 1 });
+
+    assert.equal(event.id, 'evt-000001');
+    assert.equal(state.events.records.length, 1);
+    assert.equal(state.version, 3);
+});


### PR DESCRIPTION
## Target

Product track: `0.4.500` — Lightweight semantic event foundation.

## Changes

- adds a deterministic, bounded semantic event history with stable sequential IDs and typed event names
- separates semantic event data from command/log prose
- adds filtering, predicate, introspection, and validation helpers for event consumers
- initializes event history for new games and lazily initializes older state without forcing a save-version bump
- emits `travel.started` and `travel.arrived` as the first representative gameplay events
- links the travel ActionResult to its emitted event ID
- deliberately keeps events observational and bounded; this is not an event-sourcing architecture

## Version impact

- Product: `0.4.400.0` -> `0.4.500.0`
- Package: `0.4.400` -> `0.4.500`
- `semanticEvents`: `0.1.0`
- `travel`: `0.4.1` -> `0.4.2`
- Game State remains `3`; semantic event history is optional/lazily initialized rather than authoritative save state
- Account Save / Data: unchanged

## Tests

- stable event IDs and ordering
- bounded event history
- structured consumers operate without parsing log prose
- travel start/arrival semantic events
- lazy initialization for older state with no event container
- full repository test/benchmark gate via GitHub Actions

## Next track

`0.4.600` — current-system stabilization and transitional architecture documentation.