### PR TITLE
Certify 0.4 foundation exit gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # FFXI Text RPG
 
-A text-first fantasy life RPG foundation inspired by the weight, preparation, progression, jobs, equipment, travel, and earned accomplishment of Final Fantasy XI.
+A text-first fantasy life RPG foundation inspired by the weight, preparation, dangerous travel, equipment, mastery, jobs/disciplines, and earned accomplishment of Final Fantasy XI.
 
-The project is **not** intended to become a text transcription of retail FFXI. The long-term direction is a persistent life/adventure RPG built around simulated time, measurable mastery, livelihoods, projects, infrastructure, relationships, logical equipment/preparation, dangerous expeditions, and a continuous character who can develop across multiple disciplines.
+This is **not** intended to become a text transcription of retail FFXI. The long-term game is a persistent life/adventure RPG built around simulated time, measurable mastery, livelihoods, projects, infrastructure, relationships, logical loadouts, exploration, and a continuous character who can develop across multiple disciplines.
 
 Core progression law:
 
@@ -10,63 +10,55 @@ Core progression law:
 effort -> mastery -> efficiency -> capability -> larger ambition
 ```
 
-The active browser UI remains canvas-first and text-led. Limited icons, tokens, meters, cards, and diagrams are welcome when they improve comprehension without creating a full graphical-world production burden.
-
-## Read these first
-
-For a new development session, use this order:
-
-1. `docs/DEVELOPMENT_DIRECTION.md` — authoritative game/design direction.
-2. `docs/VERSIONING_AND_RELEASE_ROADMAP.md` — four-part product-version protocol and detailed path to 1.0.
-3. `docs/ROADMAP.md` — current implementation summary and phase index.
-4. `docs/THREAD_HANDOFF.md` — concise repo state and next implementation sequence.
-5. `docs/ARCHITECTURE.md` — runtime/module boundaries.
-6. `CHANGELOG.md` — notable historical changes.
-
-The older `docs/planning/DEVELOPMENT_PIPELINE_AND_MILESTONES.md` is historical planning from the earlier formula/item-behavior phase. Its milestone order is superseded.
+The browser UI is canvas-first and text-led. Restrained icons, tokens, meters, cards, and diagrams are welcome when they improve comprehension without turning the project into a full graphical-world production.
 
 ## Current version
 
-Historical runtime baseline:
+At the 0.4 foundation exit gate:
 
 ```text
-App/package: 0.4.4
+Product:      0.4.900.0
+Package:      0.4.900
 Account Save: 4
-Game State: 3
-Data: 13
-Codename: Conservative Skill Gains
+Game State:   3
+Data:         13
+Codename:     Foundation Exit Gate
 ```
 
-`js/text/version.js` remains the current runtime/system manifest.
-
-A new four-part product protocol is planned:
+Product versions use:
 
 ```text
 MAJOR.PHASE.TRACK.REVISION
 ```
 
-Example:
+`package.json.version` remains valid three-part SemVer and normally mirrors `MAJOR.PHASE.TRACK`.
 
-```text
-0.5.300.4
-```
+`js/text/version.js` is the authoritative runtime/system version manifest.
 
-The product version will be decoupled from `package.json.version` because npm uses three-part SemVer. See `docs/VERSIONING_AND_RELEASE_ROADMAP.md` before changing version numbers.
+## Read these first
+
+1. `docs/DEVELOPMENT_DIRECTION.md` — design north star.
+2. `docs/VERSIONING_AND_RELEASE_ROADMAP.md` — version protocol and detailed route to 1.0.
+3. `docs/TRANSITIONAL_ARCHITECTURE.md` — temporary seams and migration constraints.
+4. `docs/ROADMAP.md` — current phase index.
+5. `docs/PHASE_0_4_EXIT_GATE.md` — evidence for closing the foundation phase.
+6. `docs/THREAD_HANDOFF.md` — current repo state and immediate sequence.
+7. `docs/ARCHITECTURE.md` — current runtime/module boundaries.
+
+`docs/planning/DEVELOPMENT_PIPELINE_AND_MILESTONES.md` is superseded historical planning from the earlier formula-first direction.
 
 ## Running
 
-Do not open `index.html` directly with a `file://` URL. ES module imports require serving the project over localhost.
+Serve the repo over localhost; do not open `index.html` directly with `file://` because browser ES-module imports require an HTTP origin.
 
-On Windows, from the repo root:
+Windows launchers:
 
 ```text
-Start Server.cmd  - starts the local server
-Play.cmd          - opens http://127.0.0.1:4173/
+Start Server.cmd
+Play.cmd
 ```
 
-The older `server.cmd` remains a compatibility wrapper; `server.ps1` is also available.
-
-Or run:
+Or:
 
 ```bash
 npm run serve
@@ -80,15 +72,9 @@ http://127.0.0.1:4173/
 
 No build step is required.
 
-Suggested local repo path for Codex desktop work:
+## Development gate
 
-```text
-C:\Codex\ffxi-text-rpg
-```
-
-## Development
-
-Node 20+ is recommended.
+Use Node 20+.
 
 ```bash
 npm test
@@ -96,13 +82,13 @@ npm run benchmark
 npm run check
 ```
 
+GitHub Actions runs the test and benchmark gate for pull requests and pushes to `main`.
+
 ## Product direction in brief
 
 ### Continuous character, not magical job switching
 
-Jobs remain recognizable disciplines/training traditions, but changing equipment should not magically transform the character.
-
-Long-term vocabulary:
+Long-term rule:
 
 ```text
 Jobs describe.
@@ -110,25 +96,29 @@ Capabilities enable.
 Loadouts constrain and enhance.
 ```
 
-A character may learn capabilities associated with multiple disciplines and use them when the real prerequisites are satisfied: proficiency, equipment, focus, ammunition, tools, reagents, resources, condition, preparation, and context.
+Jobs remain recognizable disciplines/training traditions, but changing equipment should not magically replace the character's identity or erase learned knowledge.
 
-Some prerequisites are hard requirements; some allow use at a penalty; some are enhancers. The current `mainJob`/support-job model is transitional and should be migrated incrementally rather than removed in a broad rewrite.
+Capabilities may cross traditional job boundaries when their real prerequisites are met: proficiency, equipment, focus, ammunition, tools, reagents, resources, condition, preparation, context, and formal advanced training where logically required.
 
-### Long fictional time, short real waiting
+The current `mainJob`/support-job/current-job code remains transitional compatibility scaffolding until the 0.6 migration. See `docs/TRANSITIONAL_ARCHITECTURE.md` before expanding job-gated behavior.
 
-Simulation time and wall-clock time should be separate.
+### Long fictional time without unnecessary real waiting
 
-The game may contain meaningful fictional grind, but the player should be able to pause, fast-forward, advance to completion, or advance until a meaningful interrupt. End-of-day review should make slow cumulative progress legible.
+Simulation time and wall-clock time are separate.
+
+The game may contain substantial fictional grind while still allowing pause, fast-forward, exact advancement, advance-to-completion, and advance-until-interrupt. End-of-day review should make cumulative progress legible.
+
+The existing `tickEngine.js` is only a wall-clock scheduler/dispatcher. It is not the canonical game calendar.
 
 ### Logical resource scaling
 
 Repeated identical construction should not become exponentially more expensive merely because another copy already exists.
 
-Advanced resource demand should come from larger structures, renovations, specialization, logistics, automation, capacity, transport, maintenance, and prestige/regional projects.
+Resource demand should grow through physical scale, larger structures, upgrades, renovation, specialization, logistics, automation, capacity, transport, maintenance, quality, and ambitious regional/prestige projects.
 
 ### Life and adventure are one loop
 
-The first representative target is **A Week Beyond the West Gate**: a multi-day slice combining origin, home foothold, livelihood, shop/economy, project progress, preparation, travel, danger/combat, recovery, end-of-day review, and a permanent accomplishment.
+The first representative target is **A Week Beyond the West Gate**: a multi-day slice combining origin, home foothold, livelihood, local economy, project progress, preparation, travel, danger/combat, recovery, end-of-day review, and a permanent accomplishment.
 
 ## Current architecture
 
@@ -139,10 +129,10 @@ index.html
           -> loadActiveCharacter() or createInitialState()
           -> createCommandRouter(state)
           -> createSlashCommandRouter(state)
-          -> canvas layout/input/render loop
+          -> canvas render/input loop
 ```
 
-Game logic should remain separate from canvas/DOM rendering.
+Game logic stays separate from canvas/DOM rendering.
 
 Primary areas:
 
@@ -161,28 +151,31 @@ tests/
 docs/
 ```
 
-## Current implemented foundation
+## 0.4 foundation delivered
 
-The repo already contains useful scaffolds for:
+The current foundation includes:
 
 - canvas-first text UI and command adapters;
 - account/character local saves;
-- character creation;
+- four-part product versioning separated from package SemVer;
+- ordered persistence migrations;
 - structured player/NPC/enemy entities;
-- places, San d'Oria coordinates, navigation, atlas discovery, travel, and aggro;
-- POIs, shops, guild hooks, and starter quest hooks;
+- places, San d'Oria coordinates, navigation, atlas, travel and aggro scaffolds;
+- POIs, shops, guild hooks and starter quest hooks;
 - inventory/storage/wardrobes;
-- item normalization, equipment, item inspection, buying, and selling;
-- character-owned skills and deterministic skill-gain hooks;
-- battle state, attacks, placeholder WS/cast actions, rewards, EXP, gil, and loot;
-- status effects and wall-clock tick scaffold;
-- validation, tests, benchmarks, database registry, and system version tracking.
+- item schema, equipment, inspection, buying and selling;
+- character-owned skills and deterministic representative skill-gain hooks;
+- battle/reward/EXP/loot/status/RNG scaffolds;
+- versioned `ActionResult` with travel-start pilot;
+- bounded semantic events with travel start/arrival pilot;
+- validation, tests, benchmarks, CI, database registry and system-version tracking;
+- explicit transitional architecture rules for world time and future capability work.
 
-The existing breadth is a foundation, not evidence that the product is close to complete.
+This breadth is foundation code, not evidence that the product is near content completion.
 
 ## Command compatibility
 
-The canvas input accepts bare gameplay commands and leading-slash account/menu or compatible FFXI-style commands.
+The canvas input accepts bare gameplay commands plus leading-slash account/menu or compatible FFXI-style commands.
 
 Representative gameplay commands:
 
@@ -198,7 +191,6 @@ travel West Ronfaure
 wait 60
 battle
 item Bronze Sword
-inspect item Bronze Sword
 equip Bronze Sword
 shop Ashene
 buy Bronze Sword
@@ -221,23 +213,7 @@ Representative account/menu commands:
 /reset
 ```
 
-The normal game should eventually be discoverable through UI/actions without requiring command memorization; typed commands remain a powerful adapter and debugging interface.
-
-## Current character creation
-
-The current transitional flow is:
-
-```text
-/newcharacter
-CharacterName
-sandoria
-hume
-male
-warrior
-yes
-```
-
-Future 0.6 work moves toward origins/starting circumstances and discipline/capability progression rather than a magical current-job identity.
+Typed commands remain a powerful adapter/debug interface. Normal play should increasingly expose discoverable UI actions so command memorization is not required.
 
 ## Save model
 
@@ -254,45 +230,46 @@ Encoding:
 base64-json-v1
 ```
 
-This is encoded storage, not strong encryption.
+This is encoding, not cryptographic protection.
 
-`reviveGameState()` currently restores object-reference compatibility after JSON load, including relinking `player.inventory` to the Inventory container.
+Ordered migrations handle registered persistent-version transitions. `reviveGameState()` remains responsible for post-JSON reference repair such as relinking `player.inventory` to the Inventory container.
 
-Ordered save migrations are a required 0.4 closeout step before large amounts of new persistent simulation state are added.
+## New integration seams
+
+### ActionResult
+
+`js/text/systems/actionResult.js` separates semantic action outcome/code/data from display prose. Non-enumerable `.message` / `.reason` aliases exist only for transitional command compatibility.
+
+### Semantic events
+
+`js/text/systems/semanticEventEngine.js` provides bounded observational events with stable sequential IDs/types. Events are not event sourcing and are not authoritative state history.
+
+Travel currently emits:
+
+```text
+travel.started
+travel.arrived
+```
+
+Future objectives, achievements, day summaries, projects, and relationship reactions should consume structured event data rather than parse command-log prose.
 
 ## Formula policy
 
-Current formulas are conservative scaffolds.
-
-Formula confidence should be explicit:
+Formula confidence must remain explicit:
 
 - exact / sourced;
 - researched approximation;
 - intentional simplification;
 - placeholder.
 
-Formula refinement matters, but it no longer leads the product roadmap. Improve formulas when they materially improve a meaningful gameplay loop.
+Formula refinement matters, but it does not lead the roadmap. Improve formulas when they materially improve a meaningful player-facing loop.
 
-## Rebuild rules
+## Immediate next implementation target
 
-- Keep the active runtime text-first.
-- Keep game logic separate from rendering.
-- Prefer small modules over giant files.
-- Keep stable IDs and data-driven content where practical.
-- Preserve command compatibility while letting UI actions dispatch the same gameplay semantics.
-- Do not add full event sourcing merely to support lightweight semantic events.
-- Do not store new saves as raw plain JSON.
-- Add explicit migrations when persistent schema changes.
-- Do not claim exact FFXI behavior without source/confidence notes.
-- Add tests/version/docs for major runtime changes.
-- Pre-1.0 backwards compatibility is not automatic; migration/reset decisions must be explicit.
+After the 0.4.900 integration gate passes and merges:
 
-## Current next implementation target
+```text
+0.5.100 — Deterministic world clock
+```
 
-After the direction/version planning branch is reviewed and merged, the next runtime target is `0.4.200`:
-
-1. introduce the authoritative four-part product-version field;
-2. decouple it from private npm package SemVer;
-3. update version display/tests/docs;
-4. proceed to ordered persistence migrations (`0.4.300`);
-5. then add structured action/event seams before beginning deterministic world time in 0.5.
+That pass should add canonical simulated time, exact deterministic advancement, derived day/time inspection, rollover tests, and **no dependency on `Date.now()` for canonical simulation state**.

--- a/docs/PHASE_0_4_EXIT_GATE.md
+++ b/docs/PHASE_0_4_EXIT_GATE.md
@@ -1,0 +1,136 @@
+# 0.4 Foundation Exit Gate
+
+This document records the evidence used to close the 0.4 foundation phase and authorize the start of 0.5 deterministic simulation-time work.
+
+The authoritative design direction is `docs/DEVELOPMENT_DIRECTION.md`. The release criteria are defined by `docs/VERSIONING_AND_RELEASE_ROADMAP.md`.
+
+## Exit decision
+
+0.4 may close when the project has a stable enough architectural seam to add deterministic world time without another reset or broad rewrite.
+
+The required gates are satisfied by the 0.4.100 through 0.4.600 tracks, subject to the repository test/benchmark gate remaining green on the 0.4.900 integration PR.
+
+## Gate 1 — Direction and version protocol are authoritative
+
+Satisfied.
+
+- `docs/DEVELOPMENT_DIRECTION.md` defines the long-term fantasy-life RPG direction.
+- `docs/VERSIONING_AND_RELEASE_ROADMAP.md` defines `MAJOR.PHASE.TRACK.REVISION` product versions and release gates through 1.0.
+- `docs/TRANSITIONAL_ARCHITECTURE.md` identifies scaffolds that must not be mistaken for final design.
+- formula reconstruction is no longer the roadmap spine.
+
+## Gate 2 — Product and package versions are separated
+
+Satisfied by 0.4.200.
+
+- `PRODUCT_VERSION` is the four-segment game-development identity.
+- `PACKAGE_VERSION` / `package.json.version` remain valid three-part SemVer.
+- Account Save, Game State, Data, Benchmark, and system versions remain independent counters.
+
+## Gate 3 — Ordered persistence migration exists
+
+Satisfied by 0.4.300.
+
+- versioned values migrate one registered step at a time;
+- missing paths and future versions fail deterministically;
+- supported Account Save and Game State migrations have unit/integration coverage;
+- `reviveGameState()` remains reference repair rather than the compatibility strategy.
+
+## Gate 4 — Structured action seam exists
+
+Satisfied by 0.4.400.
+
+- `ActionResult` separates semantic action/outcome/code/data from display text;
+- travel start is the representative migrated path;
+- command-facing compatibility remains available through transitional adapters;
+- new semantic consumers do not need to parse action prose.
+
+## Gate 5 — Semantic event seam exists
+
+Satisfied by 0.4.500.
+
+- bounded semantic event history exists;
+- event IDs and event types are stable structured identifiers;
+- travel emits `travel.started` and `travel.arrived`;
+- event consumers can filter on structured data without parsing command logs;
+- event history is observational, not event sourcing or authoritative state history.
+
+## Gate 6 — Existing foundation remains functional
+
+Satisfied by the repository test and benchmark suite plus 0.4.600 readiness checks.
+
+The preserved foundation includes:
+
+- canvas-first text UI and command adapters;
+- account/character persistence;
+- inventory/container/equipment systems;
+- shops and basic economy;
+- places, coordinates, atlas, POIs, travel and aggro scaffolds;
+- battle/reward/status/RNG scaffolds;
+- character-owned skill state;
+- validation, benchmark, version and CI pipelines.
+
+No broad rewrite was required to introduce migrations, ActionResult, or semantic events.
+
+## Gate 7 — Transitional job assumptions are explicit
+
+Satisfied by 0.4.600 documentation/readiness work.
+
+Current main-job fields remain compatibility scaffolding until the 0.6 capability migration.
+
+The intended long-term rule remains:
+
+```text
+Jobs describe.
+Capabilities enable.
+Loadouts constrain and enhance.
+```
+
+0.5 world-time work must not deepen magical job-switching assumptions.
+
+## Gate 8 — Deterministic world time has a clean insertion point
+
+Satisfied.
+
+The existing `tickEngine.js` remains a wall-clock scheduler/dispatcher and is not authoritative simulation time.
+
+Readiness tests prove optional deterministic `worldTime` state can coexist with current state and can be observed by semantic events without being mutated by the wall-clock tick scaffold.
+
+The 0.5 architecture can therefore introduce:
+
+```text
+optional wall-clock scheduler
+        -> request exact simulation advancement
+        -> deterministic world clock
+        -> tasks/travel/projects/status/events
+```
+
+without making `Date.now()` the game calendar.
+
+## 0.4 closure rule
+
+The 0.4 phase is considered complete when the 0.4.900 PR:
+
+1. reports product version `0.4.900.0`;
+2. passes the complete Node test suite;
+3. passes the repository benchmark;
+4. leaves `main` with no unresolved foundation-blocking regression.
+
+The existence of unfinished gameplay systems does not block 0.4 closure. 0.4 is a foundation phase, not a content-complete game phase.
+
+## Authorized next phase
+
+After 0.4.900 merges, begin:
+
+```text
+0.5.100 — Deterministic world clock
+```
+
+The first world-time implementation should remain deliberately small:
+
+- canonical simulated time stored in game state;
+- exact deterministic advancement by a requested number of seconds/minutes;
+- derived day/time formatting;
+- no dependence on `Date.now()` for canonical time;
+- tests for exact rollover behavior;
+- no fast-forward scheduler, task engine, or day-summary system until their dedicated 0.5 tracks.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,222 +1,222 @@
 # Roadmap
 
-This roadmap is the current implementation summary and release-phase index for the text-first fantasy life RPG.
+This is the current implementation summary and phase index for the text-first fantasy life RPG.
 
 Authoritative companion documents:
 
-- `docs/DEVELOPMENT_DIRECTION.md` — design north star and non-negotiable product direction.
-- `docs/VERSIONING_AND_RELEASE_ROADMAP.md` — detailed four-part version protocol, sub-milestones, exit gates, and path to 1.0.
+- `docs/DEVELOPMENT_DIRECTION.md` — design north star.
+- `docs/VERSIONING_AND_RELEASE_ROADMAP.md` — detailed version protocol and path to 1.0.
+- `docs/TRANSITIONAL_ARCHITECTURE.md` — temporary seams that must not harden into final design.
+- `docs/PHASE_0_4_EXIT_GATE.md` — evidence for closing the foundation phase.
+- `docs/THREAD_HANDOFF.md` — current implementation handoff.
 - `docs/ARCHITECTURE.md` — current runtime/module boundaries.
-- `docs/THREAD_HANDOFF.md` — current implementation state for a new development thread.
-
-The older `docs/planning/DEVELOPMENT_PIPELINE_AND_MILESTONES.md` remains useful as historical planning context for the formula/item-behavior era, but its recommended milestone order is superseded by this roadmap and the two authoritative direction documents above.
 
 ## Current baseline
 
-Historical product version:
+At the 0.4 exit gate:
 
 ```text
-0.4.4
+Product:      0.4.900.0
+Package:      0.4.900
+Account Save: 4
+Game State:   3
+Data:         13
+Codename:     Foundation Exit Gate
 ```
 
-Current baseline remains a rough pre-alpha foundation rather than a nearly half-complete product.
+This remains pre-alpha product development. The version is a milestone identity, not a completion percentage.
 
-Implemented foundations include:
+## Product direction
 
-- canvas-first text UI and command compatibility;
-- local account/character saves;
-- character creation;
-- structured player/NPC/enemy entities;
-- San d'Oria coordinate navigation and atlas discovery;
-- world places, travel, aggro, POIs, shops, guild hooks, and starter quest hooks;
-- inventory/storage/wardrobes;
-- item schema, inspection, equipment, buying, and selling;
-- character-owned skills and deterministic skill-gain hooks;
-- combat/reward/EXP/loot scaffolds;
-- status and live-tick scaffolds;
-- validation, tests, benchmarks, version/system manifests, and documentation.
-
-Important transitional assumptions:
-
-- the current wall-clock tick engine is not the final world-time model;
-- `mainJob`/support-job/current-job behavior is not the final capability model;
-- current formulas are conservative scaffolds, not the main product roadmap;
-- current broad FFXI data/system coverage is less important than proving a cohesive life/adventure loop.
-
-## Product direction summary
-
-The intended game is a long-form, text-first fantasy life RPG built around:
+Core progression law:
 
 ```text
 effort -> mastery -> efficiency -> capability -> larger ambition
 ```
 
-The character should remain one continuous person. Jobs become recognizable disciplines/classifications rather than magical transformations. Learned capabilities may cross discipline boundaries when the character satisfies their proficiency, equipment, preparation, resource, and context requirements.
+The intended game is a persistent, long-form fantasy life RPG where work, infrastructure, relationships, preparation, travel, danger, combat, and exploration belong to one connected simulation.
 
-Simulation time and wall-clock time must be separable so fictional grind can retain weight without forcing unnecessary real-world waiting.
+Key rules:
 
-Construction/resource progression should be driven by physical scale, upgrades, specialization, logistics, and infrastructure rather than arbitrary exponential costs for repeated identical work.
+- simulation time and real-world waiting are separate concepts;
+- identical construction does not receive arbitrary exponential cost multipliers;
+- mastered chores should eventually demand less player attention;
+- jobs remain recognizable disciplines, but do not magically replace the character's identity;
+- learned capabilities may cross discipline boundaries when equipment/preparation/proficiency/resource/context requirements are met;
+- text and imagination do most rendering while restrained icons/tokens/meters/diagrams may improve comprehension;
+- FFXI contributes weight, danger, preparation, equipment, mastery, and accomplishment, but retail feature/formula replication is not the roadmap spine.
 
-The game remains text-first; limited icons, tokens, meters, cards, and diagrams are encouraged where they improve comprehension without creating a full graphical-world production burden.
+## Product phases
 
-See `docs/DEVELOPMENT_DIRECTION.md` for the full policy.
-
-## Release phases
-
-| Product phase | Theme | Player-facing gate |
+| Phase | Theme | Exit promise |
 | --- | --- | --- |
-| `0.4` | Foundation closeout and direction lock | Architecture is ready for simulation/capability work without another rewrite. |
-| `0.5` | World time, tasks, projects | Multi-hour/day fictional work can be advanced, interrupted, summarized, and completed without real-time waiting. |
-| `0.6` | Capabilities, disciplines, origins, livelihood | One continuous character can mix learned disciplines logically through loadout/preparation and participate in a livelihood. |
-| `0.7` | First complete game loop | A new player can live through a representative first week combining work, preparation, travel, danger, recovery, and permanent progress. |
+| `0.4` | Foundation and direction lock | Architecture can accept deterministic simulation/capability work without another reset. |
+| `0.5` | World time, tasks, projects | Multi-hour/day fictional work can advance, pause, interrupt, summarize, and complete without real-time waiting. |
+| `0.6` | Capabilities, disciplines, origins, livelihood | One continuous character can logically mix learned disciplines through preparation/loadout and pursue a livelihood. |
+| `0.7` | First complete game loop | A representative first week combines work, preparation, travel, danger, recovery, and permanent progress. |
 | `0.8` | Life/infrastructure expansion | Buildings, tools, farming/gathering, crafting, taming, relationships, and logistics materially transform earlier work. |
-| `0.9` | Adventure depth and release hardening | Combat/magic/content/balance/UI/persistence are content-complete and release-candidate quality. |
-| `1.0` | Live Foundation | Core product promise is coherent, stable, migratable, and playable as a persistent long-form RPG. |
+| `0.9` | Adventure depth and release hardening | Combat/magic/content/balance/UI/persistence reach release-candidate quality. |
+| `1.0` | Live Foundation | The core product promise is coherent, stable, migratable, and playable as a persistent long-form RPG. |
 
-Detailed sub-milestones (`0.x.100`, `0.x.200`, etc.) are defined in `docs/VERSIONING_AND_RELEASE_ROADMAP.md`.
+## 0.4 — Foundation — complete
 
-## Version protocol summary
+- [x] `0.4.100` Direction and version-roadmap lock.
+- [x] `0.4.200` Four-part product version separated from package SemVer; CI test/benchmark gate added.
+- [x] `0.4.300` Ordered persistence migration mechanism with deterministic unsupported-version handling.
+- [x] `0.4.400` Structured `ActionResult` contract; travel-start pilot.
+- [x] `0.4.500` Bounded semantic-event foundation; travel start/arrival pilot.
+- [x] `0.4.600` Foundation stabilization/readiness tests and transitional architecture rules.
+- [x] `0.4.900` Foundation exit-gate certification, contingent on green CI for the integration PR.
 
-Future product versions use:
+Existing foundations preserved through the phase include canvas-first text UI, command adapters, accounts/saves, places/navigation/atlas/travel, POIs, inventory/equipment/items/shops, combat/rewards/status/RNG scaffolds, character-owned skills, validation, tests, benchmarks, and system-version tracking.
+
+## 0.5 — World Time, Tasks, and Projects — next
+
+### 0.5.100 Deterministic world clock
+
+- [ ] Canonical simulated time stored in game state.
+- [ ] Exact advancement independent of `Date.now()`.
+- [ ] Derived day/date/time inspection and formatting.
+- [ ] Deterministic rollover tests.
+- [ ] Wall-clock `tickEngine` remains only an optional scheduler/advancement requester.
+
+### 0.5.200 Pause and speed control
+
+- [ ] Pause/resume semantics.
+- [ ] Simulation speed settings.
+- [ ] Fast-forward advances simulation rather than merely changing render timing.
+- [ ] Clean scheduler/world-time boundary.
+
+### 0.5.300 Canonical timed task model
+
+- [ ] Shared duration representation.
+- [ ] Start/progress/complete/cancel semantics where appropriate.
+- [ ] Deterministic completion.
+- [ ] Travel becomes one consumer rather than the template every activity must copy.
+
+### 0.5.400 Interrupt model
+
+- [ ] Advance-until-event.
+- [ ] Deterministic interrupt priority.
+- [ ] Combat/exhaustion/tool failure/project completion hooks or placeholders.
+
+### 0.5.500 Day boundary and end-of-day review
+
+- [ ] Day transition.
+- [ ] Configurable EoD auto-pause.
+- [ ] Structured daily summary data.
+- [ ] Review/continue/save/inspect flow.
+
+### 0.5.600 Persistent projects
+
+- [ ] Material requirements.
+- [ ] Accumulated labor/time.
+- [ ] Visible progress.
+- [ ] Completion events.
+- [ ] No arbitrary duplicate-building exponential multiplier.
+
+### 0.5.700 Time-cost integration pilot
+
+- [ ] Travel on canonical time.
+- [ ] At least one non-travel work activity on canonical time.
+- [ ] Energy/fatigue hooks where appropriate.
+- [ ] Fast-forward through low-information periods without missing meaningful interrupts.
+
+### 0.5.900 Exit gate
+
+0.5 closes when multi-hour/multi-day fictional activities can be advanced safely, reach day boundaries, produce readable progress, and complete persistent projects without depending on real-world waiting.
+
+## 0.6 — Character Capability, Disciplines, Origins, Livelihood
+
+- [ ] `0.6.100` Learned capability/proficiency model independent of current equipment.
+- [ ] `0.6.200` Jobs represented as disciplines/classifications rather than magical active states.
+- [ ] `0.6.300` Hard/soft/enhancing equipment and preparation requirements.
+- [ ] `0.6.400` Cross-discipline ability access when actual prerequisites are satisfied.
+- [ ] `0.6.500` Origin-based starting circumstances/loadouts.
+- [ ] `0.6.600` First complete livelihood loop.
+- [ ] `0.6.700` Loadout/capability UX.
+- [ ] `0.6.900` Capability/livelihood exit gate.
+
+Transitional rule until this phase lands:
 
 ```text
-MAJOR.PHASE.TRACK.REVISION
+Jobs describe.
+Capabilities enable.
+Loadouts constrain and enhance.
 ```
 
-Example:
+Do not deepen the current `mainJob` scaffold into the final ability-lock model.
 
-```text
-0.5.300.4
-```
-
-- `MAJOR`: product stability generation (`0` pre-live, `1` live).
-- `PHASE`: major release milestone.
-- `TRACK`: three-digit scoped sub-milestone, normally in increments of 100.
-- `REVISION`: simple integration counter within the track.
-
-The historical `0.4.4` release is not retroactively renumbered.
-
-Because npm package versions are three-part SemVer, the product version must be decoupled from `package.json.version` when the new protocol is implemented. Do not write a four-numeric-segment product version directly into `package.json.version`.
-
-## 0.4 current work
-
-### Complete enough
-
-- [x] Text/canvas shell.
-- [x] Command adapters.
-- [x] Current account/save foundation.
-- [x] Core entity/state/data separation.
-- [x] World/travel/atlas scaffolds.
-- [x] Inventory/equipment/item/shop foundations.
-- [x] Combat/reward/progression scaffolds.
-- [x] Validation/test/benchmark infrastructure.
-- [x] Development direction documented on planning branch.
-- [x] Four-part version protocol and 1.0 milestone plan documented on planning branch.
-
-### Remaining 0.4 closeout
-
-- [ ] Implement product/package version separation.
-- [ ] Add ordered persistence migrations.
-- [ ] Introduce a small structured action-result contract.
-- [ ] Add lightweight semantic events without full event sourcing.
-- [ ] Stabilize existing systems against the new contracts.
-
-## 0.5 focus — simulation substrate
-
-- [ ] Deterministic world clock independent of `Date.now()`.
-- [ ] Pause and speed/fast-forward semantics.
-- [ ] Canonical timed task model.
-- [ ] Meaningful interrupt model.
-- [ ] Day boundary and end-of-day auto-pause/review.
-- [ ] Persistent material/labor project model.
-- [ ] Integrate travel plus one work activity with world time.
-
-## 0.6 focus — continuous character capability
-
-- [ ] Learned capability/proficiency model.
-- [ ] Jobs represented as disciplines/classifications rather than magical active states.
-- [ ] Hard/soft/enhancing equipment and preparation prerequisites.
-- [ ] Cross-discipline capability use where prerequisites are met.
-- [ ] Origin-based starting circumstances.
-- [ ] First complete livelihood loop.
-- [ ] Loadout UX showing enabled/penalized/blocked capabilities.
-
-## 0.7 focus — first complete representative game
+## 0.7 — First Complete Representative Game
 
 Working slice: **A Week Beyond the West Gate**.
 
-- [ ] Lightweight objective/quest state foundation.
-- [ ] Real starting foothold/home-base context.
-- [ ] One permanent project.
-- [ ] One livelihood/economy loop.
-- [ ] One meaningful West Gate expedition route.
-- [ ] Combat/KO/recovery adequate for the slice.
-- [ ] Multiple simulated days and end-of-day summaries.
-- [ ] Permanent end-of-week accomplishment/unlock.
-- [ ] At least two meaningfully different origin openings.
-- [ ] UI/action discoverability without command memorization.
+The slice should combine:
 
-## 0.8 focus — systemic life expansion
+- multiple origins;
+- a modest foothold/home-base context;
+- one livelihood/gathering/economy loop;
+- one persistent material/labor project;
+- simulated days and EoD review;
+- preparation/loadout decisions;
+- one meaningful West Gate expedition;
+- travel danger and combat;
+- recovery/return-home loop;
+- measurable capability growth;
+- one permanent end-of-week accomplishment/unlock;
+- UI/action discoverability without requiring command memorization.
 
-- [ ] Construction instances, renovations, capacity, and efficiency upgrades.
-- [ ] Gathering/farming depth.
-- [ ] Crafting/tools/facilities.
-- [ ] Taming/husbandry with practical value.
-- [ ] Persistent relationships and local/guild reputation.
-- [ ] Logistics and labor-saving infrastructure.
-- [ ] Additional disciplines/livelihood interactions.
-- [ ] Economy/resource sink balancing.
+0.7 should be judged primarily by whether this connected loop is compelling enough to continue playing.
 
-## 0.9 focus — content, adventure, and release candidate
+## 0.8 — Long-form Life Expansion
 
-- [ ] Deeper enemy/combat behavior.
-- [ ] Structured magic and advanced capabilities consistent with the loadout model.
-- [ ] Second dense region proving content scalability.
-- [ ] Long-form progression/economy balance.
-- [ ] UI/accessibility/readability hardening.
-- [ ] Save migration/compatibility hardening.
-- [ ] Deterministic simulation/content validation/performance gates.
-- [ ] Content-complete beta.
-- [ ] Release-candidate feature freeze.
+Planned focus:
 
-## 1.0 minimum promise
+- construction/renovation/capacity/efficiency upgrades;
+- farming and gathering depth;
+- crafting, tools and facilities;
+- taming/husbandry with practical value;
+- relationships and reputation;
+- logistics and labor-saving infrastructure;
+- additional discipline/livelihood interactions;
+- resource/economy sink balancing based on scale and ambition rather than arbitrary multipliers.
 
-1.0 should not be declared merely because a checklist is large. It requires a coherent persistent game.
+## 0.9 — Adventure Depth and Release Hardening
 
-At minimum, a player must be able to:
+Planned focus:
 
-- begin from meaningful starting circumstances;
-- develop one persistent character across disciplines;
-- alter practical capability through logical equipment/preparation rather than magical job changes;
-- work, learn, build, travel, prepare, fight, recover, and improve;
-- use pause/fast-forward while preserving fictional time costs and meaningful interrupts;
-- pursue long-duration projects with logical material/labor costs;
-- improve infrastructure so mastered chores consume less attention;
-- build relationships/reputation that affect available opportunities;
-- experience representative taming/creature systems if retained in the 1.0 scope;
-- play through at least two dense regional content spaces;
-- save/load under an explicit supported migration contract;
-- play normal flows without command-line expertise;
-- understand game state through text-first presentation with limited visual polish.
+- deeper enemy/combat behavior;
+- structured magic/advanced capabilities consistent with the loadout model;
+- second dense region proving scalable content architecture;
+- long-form progression/economy balance;
+- UI/accessibility/readability hardening;
+- save migration/compatibility hardening;
+- deterministic simulation/content validation/performance;
+- content-complete beta and release-candidate freeze.
+
+## 1.0 — Live Foundation
+
+1.0 is a compatibility/product promise, not an assertion that all possible content is finished.
+
+A 1.0 player should be able to establish a persistent character, learn across disciplines, prepare logical loadouts, live through simulated days, pursue livelihoods and projects, build useful infrastructure, travel and fight, form meaningful relationships/reputation, experience representative creature/taming systems if retained, explore at least two dense regions, and save/load under an explicit migration contract.
 
 ## Formula policy
 
-Formula work remains important but no longer leads the product roadmap.
-
-Use formula confidence categories:
+Formula confidence categories remain:
 
 - exact / sourced;
 - researched approximation;
 - intentional simplification;
 - placeholder.
 
-Refine formulas when they improve a player-facing loop that already has a reason to exist. Do not delay world time, capabilities, livelihoods, objectives, projects, or the first complete slice merely to chase retail-exact combat math.
+Refine formulas when they materially improve a meaningful player-facing loop. Do not block simulation time, capabilities, livelihoods, projects, objectives, or the representative slice merely to chase retail-exact math.
 
-## Current recommended next pass
+## Immediate next pass
 
-After this planning branch is reviewed/merged, the next runtime pass should target `0.4.200`:
+After the 0.4.900 exit-gate PR is green and merged:
 
-1. introduce an authoritative four-part product version;
-2. decouple it from the private npm package SemVer;
-3. update version display/tests/docs;
-4. then proceed to ordered persistence migrations before adding new persistent simulation state.
+```text
+0.5.100 — Deterministic world clock
+```
+
+Keep that pass narrow: exact simulated time state, exact advancement, formatting/inspection, rollover tests, and no dependence on wall-clock time for canonical simulation state.

--- a/js/text/version.js
+++ b/js/text/version.js
@@ -1,5 +1,5 @@
-export const PRODUCT_VERSION = '0.4.600.0';
-export const PACKAGE_VERSION = '0.4.600';
+export const PRODUCT_VERSION = '0.4.900.0';
+export const PACKAGE_VERSION = '0.4.900';
 
 export const VERSION = Object.freeze({
     product: PRODUCT_VERSION,
@@ -8,7 +8,7 @@ export const VERSION = Object.freeze({
     gameState: 3,
     data: 13,
     benchmark: 1,
-    codename: 'Foundation Stabilization',
+    codename: 'Foundation Exit Gate',
     compatibility: 'migrate-supported-save-versions',
     released: false,
 
@@ -18,11 +18,11 @@ export const VERSION = Object.freeze({
 });
 
 export const SYSTEM_VERSIONS = Object.freeze({
-    versionManifest: '0.4.600',
+    versionManifest: '0.4.900',
     saveMigrations: '0.1.0',
     actionResults: '0.1.0',
     semanticEvents: '0.1.0',
-    foundationReadiness: '0.1.0',
+    foundationReadiness: '0.2.0',
     commandShell: '0.4.4',
     canvasUi: '0.7.0',
     uiIntents: '0.1.1',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffxi-text-rpg",
-  "version": "0.4.600",
+  "version": "0.4.900",
   "private": true,
   "type": "module",
   "description": "Text-first fantasy life RPG foundation inspired by Final Fantasy XI systems.",

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -14,8 +14,8 @@ import {
 
 
 test('version manifest separates product package and persistence versions', () => {
-    assert.equal(PRODUCT_VERSION, '0.4.600.0');
-    assert.equal(PACKAGE_VERSION, '0.4.600');
+    assert.equal(PRODUCT_VERSION, '0.4.900.0');
+    assert.equal(PACKAGE_VERSION, '0.4.900');
     assert.equal(VERSION.product, PRODUCT_VERSION);
     assert.equal(VERSION.package, PACKAGE_VERSION);
     assert.equal(VERSION.app, PRODUCT_VERSION);
@@ -24,17 +24,17 @@ test('version manifest separates product package and persistence versions', () =
     assert.equal(VERSION.data, 13);
     assert.equal(VERSION.benchmark, 1);
     assert.equal(VERSION.save, VERSION.accountSave);
-    assert.match(describeVersion(), /Product: 0\.4\.600\.0/);
-    assert.match(describeVersion(), /Package: 0\.4\.600/);
+    assert.match(describeVersion(), /Product: 0\.4\.900\.0/);
+    assert.match(describeVersion(), /Package: 0\.4\.900/);
     assert.match(describeVersion(), /Account Save: 4/);
     assert.match(describeVersion(), /Game State: 3/);
-    assert.match(describeVersion(), /Codename: Foundation Stabilization/);
+    assert.match(describeVersion(), /Codename: Foundation Exit Gate/);
     assert.match(describeVersion(), /Compatibility: migrate-supported-save-versions/);
-    assert.match(describeSystemVersions(), /versionManifest: 0\.4\.600/);
+    assert.match(describeSystemVersions(), /versionManifest: 0\.4\.900/);
     assert.match(describeSystemVersions(), /saveMigrations: 0\.1\.0/);
     assert.match(describeSystemVersions(), /actionResults: 0\.1\.0/);
     assert.match(describeSystemVersions(), /semanticEvents: 0\.1\.0/);
-    assert.match(describeSystemVersions(), /foundationReadiness: 0\.1\.0/);
+    assert.match(describeSystemVersions(), /foundationReadiness: 0\.2\.0/);
     assert.match(describeSystemVersions(), /travel: 0\.4\.2/);
     assert.match(describeSystemVersions(), /characterCreation/);
     assert.match(describeSystemVersions(), /canvasUi: 0.7.0/);


### PR DESCRIPTION
## Target

Product track: `0.4.900` — Foundation exit-gate certification.

## Changes

- records the evidence used to close the 0.4 foundation phase in `docs/PHASE_0_4_EXIT_GATE.md`
- synchronizes `README.md` and `docs/ROADMAP.md` to the actual 0.4 foundation delivered state
- marks the 0.4.100 through 0.4.600 foundation tracks as complete and documents the 0.5 sequence
- advances product/package versions to the 0.4 exit-gate identity

## Version impact

- Product: `0.4.600.0` -> `0.4.900.0`
- Package: `0.4.600` -> `0.4.900`
- `foundationReadiness`: `0.1.0` -> `0.2.0`
- Account Save: unchanged (`4`)
- Game State: unchanged (`3`)
- Data: unchanged (`13`)

## Exit gates certified

- authoritative development direction and version protocol
- product/package version separation
- ordered persistence migrations
- structured ActionResult seam
- bounded semantic event seam
- current-system stabilization/readiness checks
- explicit transitional job/capability architecture
- clean deterministic-world-time insertion point separate from wall-clock scheduling

## Runtime impact

No new gameplay behavior or persistent schema change. This is the 0.4 integration/version/docs certification pass.

## Gate

GitHub Actions must pass the full Node test suite and benchmark before merge.

## Authorized next track

`0.5.100` — deterministic world clock.