### PR TITLE
Implement 0.5.100 deterministic world clock

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,15 +13,15 @@ Authoritative companion documents:
 
 ## Current baseline
 
-At the 0.4 exit gate:
+Current 0.5 world-time foundation target:
 
 ```text
-Product:      0.4.900.0
-Package:      0.4.900
+Product:      0.5.100.0
+Package:      0.5.100
 Account Save: 4
-Game State:   3
+Game State:   4
 Data:         13
-Codename:     Foundation Exit Gate
+Codename:     Deterministic World Clock
 ```
 
 This remains pre-alpha product development. The version is a milestone identity, not a completion percentage.
@@ -66,21 +66,23 @@ Key rules:
 - [x] `0.4.400` Structured `ActionResult` contract; travel-start pilot.
 - [x] `0.4.500` Bounded semantic-event foundation; travel start/arrival pilot.
 - [x] `0.4.600` Foundation stabilization/readiness tests and transitional architecture rules.
-- [x] `0.4.900` Foundation exit-gate certification, contingent on green CI for the integration PR.
+- [x] `0.4.900` Foundation exit-gate certification.
 
-Existing foundations preserved through the phase include canvas-first text UI, command adapters, accounts/saves, places/navigation/atlas/travel, POIs, inventory/equipment/items/shops, combat/rewards/status/RNG scaffolds, character-owned skills, validation, tests, benchmarks, and system-version tracking.
+## 0.5 — World Time, Tasks, and Projects — active
 
-## 0.5 — World Time, Tasks, and Projects — next
+### 0.5.100 Deterministic world clock — current
 
-### 0.5.100 Deterministic world clock
+- [x] Canonical simulated seconds stored in Game State v4.
+- [x] Exact deterministic advancement independent of `Date.now()`.
+- [x] Derived day/hour/minute/second inspection and formatting.
+- [x] Deterministic minute/hour/day/multi-day rollover tests.
+- [x] `time.advanced` semantic event records structured advancement observations.
+- [x] Ordered Game State v3 -> v4 migration adds canonical world time.
+- [x] Wall-clock `tickEngine` remains only a scheduler/dispatcher and does not mutate canonical world time by itself.
 
-- [ ] Canonical simulated time stored in game state.
-- [ ] Exact advancement independent of `Date.now()`.
-- [ ] Derived day/date/time inspection and formatting.
-- [ ] Deterministic rollover tests.
-- [ ] Wall-clock `tickEngine` remains only an optional scheduler/advancement requester.
+The clock intentionally has no seasons, named months, calendar lore, or speed controls yet. One canonical non-negative integer second count is the authoritative time state; richer calendar presentation can be layered over it later without changing time arithmetic.
 
-### 0.5.200 Pause and speed control
+### 0.5.200 Pause and speed control — next
 
 - [ ] Pause/resume semantics.
 - [ ] Simulation speed settings.
@@ -213,10 +215,10 @@ Refine formulas when they materially improve a meaningful player-facing loop. Do
 
 ## Immediate next pass
 
-After the 0.4.900 exit-gate PR is green and merged:
+After the 0.5.100 deterministic-clock PR is green and merged:
 
 ```text
-0.5.100 — Deterministic world clock
+0.5.200 — Pause and simulation speed control
 ```
 
-Keep that pass narrow: exact simulated time state, exact advancement, formatting/inspection, rollover tests, and no dependence on wall-clock time for canonical simulation state.
+Keep the wall-clock scheduler optional: speed/pause controls should request deterministic world-time advancement rather than redefine the canonical clock.

--- a/js/text/gameState.js
+++ b/js/text/gameState.js
@@ -9,6 +9,7 @@ import { createSemanticEventState } from './systems/semanticEventEngine.js';
 import { describePlace } from './systems/travelEngine.js';
 import { moveInDirection } from './systems/navigationEngine.js';
 import { calculateCombatProfile } from './systems/statEngine.js';
+import { createWorldTimeState } from './systems/worldTimeEngine.js';
 
 export function createInitialState() {
     return createNewGameState();
@@ -34,7 +35,8 @@ export function createNewGameState(options = {}) {
     });
 
     return {
-        version: 3,
+        version: 4,
+        worldTime: createWorldTimeState({ totalSeconds: options.startWorldTimeSeconds ?? 0 }),
         currentPlaceId: startPlace.id,
         location: startPlace.name,
         position: startCoordinate,
@@ -124,7 +126,6 @@ export function describeStats(state) {
     return [
         'Attributes:',
         `STR ${attrs.str}  DEX ${attrs.dex}  VIT ${attrs.vit}  AGI ${attrs.agi}`,
-        `INT ${attrs.int}  MND ${attrs.mnd}  CHR ${attrs.chr}`,
         '',
         'Derived:',
         `Attack ${derived.attack}  Defense ${derived.defense}`,

--- a/js/text/gameState.js
+++ b/js/text/gameState.js
@@ -126,6 +126,7 @@ export function describeStats(state) {
     return [
         'Attributes:',
         `STR ${attrs.str}  DEX ${attrs.dex}  VIT ${attrs.vit}  AGI ${attrs.agi}`,
+        `INT ${attrs.int}  MND ${attrs.mnd}  CHR ${attrs.chr}`,
         '',
         'Derived:',
         `Attack ${derived.attack}  Defense ${derived.defense}`,

--- a/js/text/systems/saveMigrations.js
+++ b/js/text/systems/saveMigrations.js
@@ -2,6 +2,7 @@ import { VERSION } from '../version.js';
 import { createInventoryState } from './inventoryEngine.js';
 import { migrateVersionedValue } from './migrationEngine.js';
 import { CURRENT_SAVE_VERSION } from './validation.js';
+import { createWorldTimeState } from './worldTimeEngine.js';
 
 function migrateGameState2To3(state) {
     const next = { ...state, version: 3 };
@@ -48,12 +49,30 @@ function migrateGameState2To3(state) {
     return next;
 }
 
+function migrateGameState3To4(state) {
+    return {
+        ...state,
+        version: 4,
+        worldTime: createWorldTimeState({
+            totalSeconds: Number.isInteger(state.worldTime?.totalSeconds) && state.worldTime.totalSeconds >= 0
+                ? state.worldTime.totalSeconds
+                : 0,
+        }),
+    };
+}
+
 const GAME_STATE_MIGRATIONS = Object.freeze([
     Object.freeze({
         id: 'game-state-2-to-3-inventory-and-progression',
         from: 2,
         to: 3,
         migrate: migrateGameState2To3,
+    }),
+    Object.freeze({
+        id: 'game-state-3-to-4-world-time',
+        from: 3,
+        to: 4,
+        migrate: migrateGameState3To4,
     }),
 ]);
 

--- a/js/text/systems/validation.js
+++ b/js/text/systems/validation.js
@@ -21,8 +21,9 @@ import {
 } from '../data/systemConstants.js';
 import { listSkillRankEntries, SKILL_RANK_CAP_RULES } from '../data/skillCaps.js';
 import { getContainerCapacity } from './inventoryEngine.js';
+import { validateWorldTimeState } from './worldTimeEngine.js';
 
-export const CURRENT_SAVE_VERSION = 3;
+export const CURRENT_SAVE_VERSION = 4;
 
 export function validateGameState(state) {
     const issues = [];
@@ -33,6 +34,12 @@ export function validateGameState(state) {
 
     if (state.version !== CURRENT_SAVE_VERSION) {
         issues.push(`Expected state version ${CURRENT_SAVE_VERSION}, received ${String(state.version)}.`);
+    }
+
+    if (!isObject(state.worldTime)) {
+        issues.push('worldTime must be an object.');
+    } else {
+        issues.push(...validateWorldTimeState(state.worldTime));
     }
 
     const place = getPlace(state.currentPlaceId);

--- a/js/text/systems/worldTimeEngine.js
+++ b/js/text/systems/worldTimeEngine.js
@@ -1,0 +1,130 @@
+import { actionFailure, actionSuccess } from './actionResult.js';
+import { emitSemanticEvent } from './semanticEventEngine.js';
+
+export const SECONDS_PER_MINUTE = 60;
+export const MINUTES_PER_HOUR = 60;
+export const HOURS_PER_DAY = 24;
+export const SECONDS_PER_HOUR = SECONDS_PER_MINUTE * MINUTES_PER_HOUR;
+export const SECONDS_PER_DAY = SECONDS_PER_HOUR * HOURS_PER_DAY;
+
+export function createWorldTimeState(options = {}) {
+    const totalSeconds = options.totalSeconds ?? 0;
+    if (!isValidTotalSeconds(totalSeconds)) {
+        throw new Error('worldTime.totalSeconds must be a non-negative integer.');
+    }
+    return { totalSeconds };
+}
+
+export function ensureWorldTimeState(state, options = {}) {
+    if (!state || typeof state !== 'object') throw new Error('World time requires game state.');
+    if (!state.worldTime || typeof state.worldTime !== 'object' || Array.isArray(state.worldTime)) {
+        state.worldTime = createWorldTimeState(options);
+    }
+    if (!isValidTotalSeconds(state.worldTime.totalSeconds)) {
+        throw new Error('worldTime.totalSeconds must be a non-negative integer.');
+    }
+    return state.worldTime;
+}
+
+export function getWorldTimeParts(worldTimeOrState) {
+    const worldTime = resolveWorldTime(worldTimeOrState);
+    const totalSeconds = worldTime.totalSeconds;
+    const dayIndex = Math.floor(totalSeconds / SECONDS_PER_DAY);
+    const secondsOfDay = totalSeconds % SECONDS_PER_DAY;
+    const hour = Math.floor(secondsOfDay / SECONDS_PER_HOUR);
+    const minute = Math.floor((secondsOfDay % SECONDS_PER_HOUR) / SECONDS_PER_MINUTE);
+    const second = secondsOfDay % SECONDS_PER_MINUTE;
+
+    return Object.freeze({
+        totalSeconds,
+        day: dayIndex + 1,
+        dayIndex,
+        secondsOfDay,
+        hour,
+        minute,
+        second,
+    });
+}
+
+export function describeWorldTime(worldTimeOrState) {
+    const parts = getWorldTimeParts(worldTimeOrState);
+    return `Day ${parts.day}, ${pad2(parts.hour)}:${pad2(parts.minute)}:${pad2(parts.second)}`;
+}
+
+export function advanceWorldTime(state, seconds, options = {}) {
+    const amount = Number(seconds);
+    if (!Number.isInteger(amount) || amount < 0) {
+        return actionFailure({
+            action: 'time.advance',
+            code: 'time.invalid-advance',
+            outcome: 'rejected',
+            data: { requestedSeconds: seconds },
+            display: { text: 'World-time advancement must be a non-negative whole number of seconds.' },
+        });
+    }
+
+    const worldTime = ensureWorldTimeState(state);
+    const before = worldTime.totalSeconds;
+    const beforeParts = getWorldTimeParts(worldTime);
+    worldTime.totalSeconds += amount;
+    const afterParts = getWorldTimeParts(worldTime);
+    const crossedDays = afterParts.dayIndex - beforeParts.dayIndex;
+
+    let event = null;
+    if (options.emitEvent !== false) {
+        event = emitSemanticEvent(state, 'time.advanced', {
+            secondsAdvanced: amount,
+            beforeTotalSeconds: before,
+            afterTotalSeconds: worldTime.totalSeconds,
+            crossedDays,
+        }, { source: 'worldTimeEngine' });
+    }
+
+    return actionSuccess({
+        action: 'time.advance',
+        code: 'time.advanced',
+        outcome: 'advanced',
+        data: {
+            secondsAdvanced: amount,
+            beforeTotalSeconds: before,
+            afterTotalSeconds: worldTime.totalSeconds,
+            crossedDays,
+            day: afterParts.day,
+            hour: afterParts.hour,
+            minute: afterParts.minute,
+            second: afterParts.second,
+            eventId: event?.id ?? null,
+        },
+        display: { text: `Advanced ${amount}s. ${describeWorldTime(worldTime)}` },
+    });
+}
+
+export function validateWorldTimeState(worldTime) {
+    const issues = [];
+    if (!worldTime || typeof worldTime !== 'object' || Array.isArray(worldTime)) {
+        return ['worldTime must be an object.'];
+    }
+    if (!isValidTotalSeconds(worldTime.totalSeconds)) {
+        issues.push('worldTime.totalSeconds must be a non-negative integer.');
+    }
+    return issues;
+}
+
+function resolveWorldTime(value) {
+    const worldTime = value?.worldTime ?? value;
+    if (!worldTime || typeof worldTime !== 'object' || Array.isArray(worldTime)) {
+        throw new Error('World time must be an object or game state containing worldTime.');
+    }
+    if (!isValidTotalSeconds(worldTime.totalSeconds)) {
+        throw new Error('worldTime.totalSeconds must be a non-negative integer.');
+    }
+    return worldTime;
+}
+
+function isValidTotalSeconds(value) {
+    return Number.isInteger(value) && value >= 0;
+}
+
+function pad2(value) {
+    return String(value).padStart(2, '0');
+}

--- a/js/text/version.js
+++ b/js/text/version.js
@@ -1,14 +1,14 @@
-export const PRODUCT_VERSION = '0.4.900.0';
-export const PACKAGE_VERSION = '0.4.900';
+export const PRODUCT_VERSION = '0.5.100.0';
+export const PACKAGE_VERSION = '0.5.100';
 
 export const VERSION = Object.freeze({
     product: PRODUCT_VERSION,
     package: PACKAGE_VERSION,
     accountSave: 4,
-    gameState: 3,
+    gameState: 4,
     data: 13,
     benchmark: 1,
-    codename: 'Foundation Exit Gate',
+    codename: 'Deterministic World Clock',
     compatibility: 'migrate-supported-save-versions',
     released: false,
 
@@ -18,11 +18,12 @@ export const VERSION = Object.freeze({
 });
 
 export const SYSTEM_VERSIONS = Object.freeze({
-    versionManifest: '0.4.900',
-    saveMigrations: '0.1.0',
+    versionManifest: '0.5.100',
+    saveMigrations: '0.2.0',
     actionResults: '0.1.0',
     semanticEvents: '0.1.0',
     foundationReadiness: '0.2.0',
+    worldTime: '0.1.0',
     commandShell: '0.4.4',
     canvasUi: '0.7.0',
     uiIntents: '0.1.1',
@@ -30,7 +31,7 @@ export const SYSTEM_VERSIONS = Object.freeze({
     accountSaves: '0.6.0',
     saveEncoding: '0.4.1',
     parser: '0.2.0',
-    validation: '0.6.0',
+    validation: '0.7.0',
     playerEntity: '0.5.4',
     characterCreation: '0.4.1',
     nations: '0.3.1',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffxi-text-rpg",
-  "version": "0.4.900",
+  "version": "0.5.100",
   "private": true,
   "type": "module",
   "description": "Text-first fantasy life RPG foundation inspired by Final Fantasy XI systems.",

--- a/tests/foundationReadiness.test.js
+++ b/tests/foundationReadiness.test.js
@@ -10,17 +10,17 @@ import { advanceTravel, startTravel } from '../js/text/systems/travelEngine.js';
 import { validateGameState } from '../js/text/systems/validation.js';
 
 
-test('current state remains valid with optional deterministic world-time state attached', () => {
+test('current state requires valid deterministic world-time state', () => {
     const state = createInitialState();
-    state.worldTime = { totalSeconds: 0 };
 
     assert.deepEqual(validateGameState(state), []);
-    assert.equal(state.version, 3);
+    assert.equal(state.version, 4);
+    assert.deepEqual(state.worldTime, { totalSeconds: 0 });
 });
 
-test('travel action and event seams can observe world time without using log prose', () => {
+test('travel action and event seams can observe canonical world time without using log prose', () => {
     const state = createInitialState();
-    state.worldTime = { totalSeconds: 3600 };
+    state.worldTime.totalSeconds = 3600;
     setPositionAndDiscover(state, 'southern-sandoria', { coord: 'F-10' });
 
     const started = startTravel(state, 'West Ronfaure');
@@ -46,9 +46,9 @@ test('character-owned skill storage is outside the active job record', () => {
     assert.equal(Object.hasOwn(state.player.jobs, 'skills'), false);
 });
 
-test('wall-clock tick scaffold can remain a scheduler rather than canonical world time', () => {
+test('wall-clock tick scaffold remains a scheduler rather than canonical world time', () => {
     const state = createInitialState();
-    state.worldTime = { totalSeconds: 1234 };
+    state.worldTime.totalSeconds = 1234;
     const tickEngine = createTickEngine({ tickLengthMs: 1000 });
 
     tickEngine.tick({ state });

--- a/tests/migrationEngine.test.js
+++ b/tests/migrationEngine.test.js
@@ -46,10 +46,11 @@ test('ordered migration engine fails deterministically on missing or future vers
     assert.equal(future.code, 'future-version');
 });
 
-test('game-state migration upgrades version 2 inventory/progression shape to version 3', () => {
+test('game-state migration upgrades version 2 through inventory and world-time migrations to version 4', () => {
     const state = createInitialState();
     const flatInventory = [{ id: 'old-item', name: 'Old Item', kind: 'misc', quantity: 1 }];
     state.version = 2;
+    delete state.worldTime;
     delete state.meta;
     delete state.player.inventoryState;
     state.player.inventory = flatInventory;
@@ -59,14 +60,31 @@ test('game-state migration upgrades version 2 inventory/progression shape to ver
     const result = migrateGameStatePayload(state);
 
     assert.equal(result.ok, true);
-    assert.deepEqual(result.applied, ['game-state-2-to-3-inventory-and-progression']);
-    assert.equal(result.value.version, 3);
+    assert.deepEqual(result.applied, [
+        'game-state-2-to-3-inventory-and-progression',
+        'game-state-3-to-4-world-time',
+    ]);
+    assert.equal(result.value.version, 4);
+    assert.deepEqual(result.value.worldTime, { totalSeconds: 0 });
     assert.equal(result.value.player.inventoryState.containers.inventory.items[0].name, 'Old Item');
     assert.deepEqual(result.value.player.progression.skills, {});
 
     const revived = reviveGameState(result.value, 'migrated-character');
     assert.equal(revived.player.inventory, revived.player.inventoryState.containers.inventory.items);
     assert.equal(isValidGameState(revived), true);
+});
+
+test('game-state version 3 migration preserves an existing valid provisional world time', () => {
+    const state = createInitialState();
+    state.version = 3;
+    state.worldTime = { totalSeconds: 9876 };
+
+    const result = migrateGameStatePayload(state);
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.applied, ['game-state-3-to-4-world-time']);
+    assert.equal(result.value.version, 4);
+    assert.deepEqual(result.value.worldTime, { totalSeconds: 9876 });
 });
 
 test('account registry migrations advance stored version 2 records through version 4', () => {
@@ -88,7 +106,7 @@ test('account registry migrations advance stored version 2 records through versi
 test('save migration support describes current and oldest supported versions', () => {
     const support = describeSaveMigrationSupport();
 
-    assert.equal(support.gameState.currentVersion, 3);
+    assert.equal(support.gameState.currentVersion, 4);
     assert.equal(support.gameState.supportedFrom, 2);
     assert.equal(support.accountSave.currentVersion, 4);
     assert.equal(support.accountSave.supportedFrom, 2);

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -14,27 +14,28 @@ import {
 
 
 test('version manifest separates product package and persistence versions', () => {
-    assert.equal(PRODUCT_VERSION, '0.4.900.0');
-    assert.equal(PACKAGE_VERSION, '0.4.900');
+    assert.equal(PRODUCT_VERSION, '0.5.100.0');
+    assert.equal(PACKAGE_VERSION, '0.5.100');
     assert.equal(VERSION.product, PRODUCT_VERSION);
     assert.equal(VERSION.package, PACKAGE_VERSION);
     assert.equal(VERSION.app, PRODUCT_VERSION);
     assert.equal(VERSION.accountSave, 4);
-    assert.equal(VERSION.gameState, 3);
+    assert.equal(VERSION.gameState, 4);
     assert.equal(VERSION.data, 13);
     assert.equal(VERSION.benchmark, 1);
     assert.equal(VERSION.save, VERSION.accountSave);
-    assert.match(describeVersion(), /Product: 0\.4\.900\.0/);
-    assert.match(describeVersion(), /Package: 0\.4\.900/);
+    assert.match(describeVersion(), /Product: 0\.5\.100\.0/);
+    assert.match(describeVersion(), /Package: 0\.5\.100/);
     assert.match(describeVersion(), /Account Save: 4/);
-    assert.match(describeVersion(), /Game State: 3/);
-    assert.match(describeVersion(), /Codename: Foundation Exit Gate/);
+    assert.match(describeVersion(), /Game State: 4/);
+    assert.match(describeVersion(), /Codename: Deterministic World Clock/);
     assert.match(describeVersion(), /Compatibility: migrate-supported-save-versions/);
-    assert.match(describeSystemVersions(), /versionManifest: 0\.4\.900/);
-    assert.match(describeSystemVersions(), /saveMigrations: 0\.1\.0/);
+    assert.match(describeSystemVersions(), /versionManifest: 0\.5\.100/);
+    assert.match(describeSystemVersions(), /saveMigrations: 0\.2\.0/);
     assert.match(describeSystemVersions(), /actionResults: 0\.1\.0/);
     assert.match(describeSystemVersions(), /semanticEvents: 0\.1\.0/);
-    assert.match(describeSystemVersions(), /foundationReadiness: 0\.2\.0/);
+    assert.match(describeSystemVersions(), /worldTime: 0\.1\.0/);
+    assert.match(describeSystemVersions(), /validation: 0\.7\.0/);
     assert.match(describeSystemVersions(), /travel: 0\.4\.2/);
     assert.match(describeSystemVersions(), /characterCreation/);
     assert.match(describeSystemVersions(), /canvasUi: 0.7.0/);

--- a/tests/saveMigrationIntegration.test.js
+++ b/tests/saveMigrationIntegration.test.js
@@ -52,7 +52,7 @@ test('loading a version 2 account registry migrates and persists it as account s
     assert.equal(migratedRegistry.accounts[0].version, 4);
 });
 
-test('loading a version 2 character migrates and persists game state version 3', () => {
+test('loading a version 2 character migrates and persists game state version 4 with world time', () => {
     installStorage();
     const created = createAccountWithPassword('Legacy Character Account', 'pwd', { persistentLogin: true });
     assert.equal(created.ok, true);
@@ -66,6 +66,7 @@ test('loading a version 2 character migrates and persists game state version 3',
     const record = registry.accounts[0].characters[0];
     const oldState = decodePayload(record.encodedState);
     oldState.version = 2;
+    delete oldState.worldTime;
     delete oldState.meta;
     record.encodedState = encodePayload(oldState);
     globalThis.localStorage.setItem(key, encodePayload(registry));
@@ -74,8 +75,26 @@ test('loading a version 2 character migrates and persists game state version 3',
     const migratedRegistry = decodePayload(globalThis.localStorage.getItem(key));
     const migratedState = decodePayload(migratedRegistry.accounts[0].characters[0].encodedState);
 
-    assert.equal(loaded.version, 3);
+    assert.equal(loaded.version, 4);
     assert.equal(loaded.meta.characterId, record.id);
-    assert.equal(migratedState.version, 3);
+    assert.deepEqual(loaded.worldTime, { totalSeconds: 0 });
+    assert.equal(migratedState.version, 4);
+    assert.deepEqual(migratedState.worldTime, { totalSeconds: 0 });
     assert.equal(migratedState.meta.characterId, record.id);
+});
+
+test('world time persists through normal save and load without wall-clock recomputation', () => {
+    installStorage();
+    const created = createAccountWithPassword('World Time Account', 'pwd', { persistentLogin: true });
+    assert.equal(created.ok, true);
+
+    const state = createInitialState();
+    state.player.identity.name = 'Clockkeeper';
+    state.worldTime.totalSeconds = 123456;
+    assert.equal(saveGame(state), true);
+
+    const loaded = loadCharacter('Clockkeeper');
+
+    assert.equal(loaded.version, 4);
+    assert.equal(loaded.worldTime.totalSeconds, 123456);
 });

--- a/tests/semanticEventEngine.test.js
+++ b/tests/semanticEventEngine.test.js
@@ -74,14 +74,14 @@ test('travel emits semantic start and arrival events independently of display pr
     assert.deepEqual(travelEvents.map((event) => event.type), ['travel.started', 'travel.arrived']);
 });
 
-test('old state without an event container is upgraded lazily without a save-version bump', () => {
+test('state without an event container is upgraded lazily without changing its save version', () => {
     const state = createInitialState();
     delete state.events;
-    assert.equal(state.version, 3);
+    assert.equal(state.version, 4);
 
     const event = emitSemanticEvent(state, 'fixture.started', { value: 1 });
 
     assert.equal(event.id, 'evt-000001');
     assert.equal(state.events.records.length, 1);
-    assert.equal(state.version, 3);
+    assert.equal(state.version, 4);
 });

--- a/tests/worldTimeEngine.test.js
+++ b/tests/worldTimeEngine.test.js
@@ -1,0 +1,96 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createInitialState } from '../js/text/gameState.js';
+import { isActionResult } from '../js/text/systems/actionResult.js';
+import { listSemanticEvents } from '../js/text/systems/semanticEventEngine.js';
+import {
+    advanceWorldTime,
+    createWorldTimeState,
+    describeWorldTime,
+    getWorldTimeParts,
+    SECONDS_PER_DAY,
+    validateWorldTimeState,
+} from '../js/text/systems/worldTimeEngine.js';
+
+
+test('world clock derives day and clock fields from one canonical second count', () => {
+    const worldTime = createWorldTimeState({ totalSeconds: SECONDS_PER_DAY + 3661 });
+    const parts = getWorldTimeParts(worldTime);
+
+    assert.deepEqual(parts, {
+        totalSeconds: 90061,
+        day: 2,
+        dayIndex: 1,
+        secondsOfDay: 3661,
+        hour: 1,
+        minute: 1,
+        second: 1,
+    });
+    assert.equal(describeWorldTime(worldTime), 'Day 2, 01:01:01');
+});
+
+test('world time advances exactly across minute hour and day boundaries', () => {
+    const state = createInitialState();
+    state.worldTime.totalSeconds = SECONDS_PER_DAY - 2;
+
+    const result = advanceWorldTime(state, 5);
+
+    assert.equal(isActionResult(result), true);
+    assert.equal(result.ok, true);
+    assert.equal(result.code, 'time.advanced');
+    assert.equal(result.data.beforeTotalSeconds, SECONDS_PER_DAY - 2);
+    assert.equal(result.data.afterTotalSeconds, SECONDS_PER_DAY + 3);
+    assert.equal(result.data.crossedDays, 1);
+    assert.equal(describeWorldTime(state), 'Day 2, 00:00:03');
+});
+
+test('multi-day advancement is deterministic and independent of wall-clock time', () => {
+    const state = createInitialState();
+    const originalNow = Date.now;
+    Date.now = () => { throw new Error('world clock must not read Date.now'); };
+
+    try {
+        const result = advanceWorldTime(state, (3 * SECONDS_PER_DAY) + 90);
+        assert.equal(result.ok, true);
+        assert.equal(result.data.crossedDays, 3);
+        assert.equal(state.worldTime.totalSeconds, (3 * SECONDS_PER_DAY) + 90);
+        assert.equal(describeWorldTime(state), 'Day 4, 00:01:30');
+    } finally {
+        Date.now = originalNow;
+    }
+});
+
+test('world-time advancement emits structured semantic observation after advancement', () => {
+    const state = createInitialState();
+    const result = advanceWorldTime(state, 600);
+    const events = listSemanticEvents(state, { type: 'time.advanced' });
+
+    assert.equal(result.data.eventId, 'evt-000001');
+    assert.equal(events.length, 1);
+    assert.equal(events[0].worldTimeSeconds, 600);
+    assert.deepEqual(events[0].data, {
+        secondsAdvanced: 600,
+        beforeTotalSeconds: 0,
+        afterTotalSeconds: 600,
+        crossedDays: 0,
+    });
+});
+
+test('invalid time advancement is rejected without mutating state', () => {
+    const state = createInitialState();
+
+    for (const value of [-1, 1.5, Number.NaN]) {
+        const result = advanceWorldTime(state, value);
+        assert.equal(result.ok, false);
+        assert.equal(result.code, 'time.invalid-advance');
+        assert.equal(state.worldTime.totalSeconds, 0);
+    }
+});
+
+test('world-time validation accepts only non-negative integer canonical seconds', () => {
+    assert.deepEqual(validateWorldTimeState({ totalSeconds: 0 }), []);
+    assert.deepEqual(validateWorldTimeState({ totalSeconds: 12 }), []);
+    assert.match(validateWorldTimeState({ totalSeconds: -1 }).join('\n'), /non-negative integer/);
+    assert.match(validateWorldTimeState({ totalSeconds: 1.5 }).join('\n'), /non-negative integer/);
+});


### PR DESCRIPTION
## Target

Product track: `0.5.100` — Deterministic world clock.

## Changes

- adds `worldTimeEngine.js` with one canonical non-negative simulated-second count
- derives day/hour/minute/second presentation without using JS wall-clock dates
- adds exact deterministic advancement returning ActionResult data
- emits structured `time.advanced` semantic observations after advancement
- persists world time in new Game State v4 records
- adds ordered Game State v3 -> v4 migration for world time, preserving any valid provisional total
- validates canonical world-time state
- keeps `tickEngine.js` separate; a wall-clock tick does not itself mutate the canonical world clock
- updates roadmap to make 0.5.200 the next track

## Version impact

- Product: `0.4.900.0` -> `0.5.100.0`
- Package: `0.4.900` -> `0.5.100`
- Game State: `3` -> `4`
- Account Save: unchanged (`4`)
- Data: unchanged (`13`)
- `worldTime`: `0.1.0`
- `saveMigrations`: `0.1.0` -> `0.2.0`
- `validation`: `0.6.0` -> `0.7.0`

## Time semantics

`worldTime.totalSeconds` is authoritative. Day 1 begins at total second 0. Calendar names/seasons and simulation speed are intentionally outside this track.

## Tests

- exact time derivation and formatting
- minute/hour/day/multi-day rollovers
- explicit proof canonical advancement does not read `Date.now()`
- invalid advancement rejection
- structured `time.advanced` event
- Game State v2 -> v3 -> v4 and v3 -> v4 migration
- save/load persistence of canonical world time
- full repository test/benchmark gate via GitHub Actions

## Next track

`0.5.200` — pause and simulation speed control.