### PR TITLE
Implement 0.5.200 simulation pause and speed control

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,15 +13,15 @@ Authoritative companion documents:
 
 ## Current baseline
 
-Current 0.5 world-time foundation target:
+Current 0.5 simulation-control target:
 
 ```text
-Product:      0.5.100.0
-Package:      0.5.100
+Product:      0.5.200.0
+Package:      0.5.200
 Account Save: 4
 Game State:   4
 Data:         13
-Codename:     Deterministic World Clock
+Codename:     Simulation Speed Control
 ```
 
 This remains pre-alpha product development. The version is a milestone identity, not a completion percentage.
@@ -70,7 +70,7 @@ Key rules:
 
 ## 0.5 — World Time, Tasks, and Projects — active
 
-### 0.5.100 Deterministic world clock — current
+### 0.5.100 Deterministic world clock — complete
 
 - [x] Canonical simulated seconds stored in Game State v4.
 - [x] Exact deterministic advancement independent of `Date.now()`.
@@ -80,16 +80,20 @@ Key rules:
 - [x] Ordered Game State v3 -> v4 migration adds canonical world time.
 - [x] Wall-clock `tickEngine` remains only a scheduler/dispatcher and does not mutate canonical world time by itself.
 
-The clock intentionally has no seasons, named months, calendar lore, or speed controls yet. One canonical non-negative integer second count is the authoritative time state; richer calendar presentation can be layered over it later without changing time arithmetic.
+### 0.5.200 Pause and speed control — current
 
-### 0.5.200 Pause and speed control — next
+- [x] Simulation pause/resume state and semantic events.
+- [x] Engine accepts whole-number simulation-speed multipliers from 1x through 3600x without hard-coding UI presets.
+- [x] A scheduler adapter converts supplied wall-clock milliseconds into exact simulated seconds.
+- [x] Sub-second simulated remainder is retained deterministically rather than discarded.
+- [x] Wall-clock time observed while paused is discarded and cannot become a burst of simulation time after resume.
+- [x] Fast-forward advances the canonical world clock rather than merely changing render timing.
+- [x] Scheduler conversion does not call `Date.now()`; the existing tick engine may supply elapsed time without owning game time.
+- [x] New games initialize simulation control at running/1x while older Game State v4 saves remain valid and lazily acquire control state when used.
 
-- [ ] Pause/resume semantics.
-- [ ] Simulation speed settings.
-- [ ] Fast-forward advances simulation rather than merely changing render timing.
-- [ ] Clean scheduler/world-time boundary.
+The simulation-control engine deliberately separates three concerns: wall-clock observation, simulation speed/pause policy, and authoritative world-time advancement. Direct exact advancement remains available for tests/tools and later advance-to-completion/advance-to-event systems.
 
-### 0.5.300 Canonical timed task model
+### 0.5.300 Canonical timed task model — next
 
 - [ ] Shared duration representation.
 - [ ] Start/progress/complete/cancel semantics where appropriate.
@@ -215,10 +219,10 @@ Refine formulas when they materially improve a meaningful player-facing loop. Do
 
 ## Immediate next pass
 
-After the 0.5.100 deterministic-clock PR is green and merged:
+After the 0.5.200 simulation-control PR is green and merged:
 
 ```text
-0.5.200 — Pause and simulation speed control
+0.5.300 — Canonical timed task model
 ```
 
-Keep the wall-clock scheduler optional: speed/pause controls should request deterministic world-time advancement rather than redefine the canonical clock.
+The task model should consume deterministic world-time deltas and emit semantic outcomes without making any one activity type—especially travel—the universal implementation template.

--- a/js/text/gameState.js
+++ b/js/text/gameState.js
@@ -6,6 +6,7 @@ import { getPlace } from './data/places.js';
 import { createAtlasState, describeCurrentGrid, setPositionAndDiscover } from './systems/atlasEngine.js';
 import { describeCurrentPois, createPoiDiscoveryState } from './systems/poiEngine.js';
 import { createSemanticEventState } from './systems/semanticEventEngine.js';
+import { createSimulationControlState } from './systems/simulationControlEngine.js';
 import { describePlace } from './systems/travelEngine.js';
 import { moveInDirection } from './systems/navigationEngine.js';
 import { calculateCombatProfile } from './systems/statEngine.js';
@@ -37,6 +38,10 @@ export function createNewGameState(options = {}) {
     return {
         version: 4,
         worldTime: createWorldTimeState({ totalSeconds: options.startWorldTimeSeconds ?? 0 }),
+        simulation: createSimulationControlState({
+            paused: options.simulationPaused ?? false,
+            speedMultiplier: options.simulationSpeedMultiplier ?? 1,
+        }),
         currentPlaceId: startPlace.id,
         location: startPlace.name,
         position: startCoordinate,

--- a/js/text/systems/simulationControlEngine.js
+++ b/js/text/systems/simulationControlEngine.js
@@ -1,0 +1,83 @@
+import { actionFailure, actionSuccess } from './actionResult.js';
+import { emitSemanticEvent } from './semanticEventEngine.js';
+import { advanceWorldTime } from './worldTimeEngine.js';
+
+export const DEFAULT_SIMULATION_SPEED = 1;
+export const MAX_SIMULATION_SPEED = 3600;
+
+export function createSimulationControlState(options = {}) {
+    const state = {
+        paused: Boolean(options.paused ?? false),
+        speedMultiplier: options.speedMultiplier ?? DEFAULT_SIMULATION_SPEED,
+    };
+    const issues = validateSimulationControlState(state);
+    if (issues.length) throw new Error(issues.join(' '));
+    return state;
+}
+
+export function ensureSimulationControlState(state) {
+    if (!state?.simulation) state.simulation = createSimulationControlState();
+    const issues = validateSimulationControlState(state.simulation);
+    if (issues.length) throw new Error(issues.join(' '));
+    return state.simulation;
+}
+
+export function pauseSimulation(state) {
+    const simulation = ensureSimulationControlState(state);
+    if (simulation.paused) return result(true, 'simulation.pause', 'simulation.already-paused', 'unchanged', simulation, 'Simulation is already paused.');
+    simulation.paused = true;
+    const event = emitSemanticEvent(state, 'simulation.paused', { speedMultiplier: simulation.speedMultiplier }, { source: 'simulationControlEngine' });
+    return result(true, 'simulation.pause', 'simulation.paused', 'paused', { ...simulation, eventId: event.id }, 'Simulation paused.');
+}
+
+export function resumeSimulation(state) {
+    const simulation = ensureSimulationControlState(state);
+    if (!simulation.paused) return result(true, 'simulation.resume', 'simulation.already-running', 'unchanged', simulation, `Simulation is already running at ${simulation.speedMultiplier}x.`);
+    simulation.paused = false;
+    const event = emitSemanticEvent(state, 'simulation.resumed', { speedMultiplier: simulation.speedMultiplier }, { source: 'simulationControlEngine' });
+    return result(true, 'simulation.resume', 'simulation.resumed', 'running', { ...simulation, eventId: event.id }, `Simulation resumed at ${simulation.speedMultiplier}x.`);
+}
+
+export function setSimulationSpeed(state, requestedSpeed) {
+    const simulation = ensureSimulationControlState(state);
+    const speed = Number(requestedSpeed);
+    if (!validSpeed(speed)) return result(false, 'simulation.speed', 'simulation.invalid-speed', 'rejected', { requestedSpeed }, `Simulation speed must be a whole-number multiplier from 1x to ${MAX_SIMULATION_SPEED}x.`);
+    if (simulation.speedMultiplier === speed) return result(true, 'simulation.speed', 'simulation.speed-unchanged', 'unchanged', simulation, `Simulation speed is already ${speed}x.`);
+    const previousSpeed = simulation.speedMultiplier;
+    simulation.speedMultiplier = speed;
+    const event = emitSemanticEvent(state, 'simulation.speed-changed', { previousSpeed, speedMultiplier: speed, paused: simulation.paused }, { source: 'simulationControlEngine' });
+    return result(true, 'simulation.speed', 'simulation.speed-changed', 'changed', { ...simulation, previousSpeed, eventId: event.id }, `Simulation speed set to ${speed}x.`);
+}
+
+export function createSimulationAdvanceDriver() {
+    let remainderMs = 0;
+    return {
+        advance(state, elapsedWallMilliseconds, options = {}) {
+            const elapsedMs = Number(elapsedWallMilliseconds);
+            if (!Number.isInteger(elapsedMs) || elapsedMs < 0) return result(false, 'simulation.scheduled-advance', 'simulation.invalid-wall-delta', 'rejected', { elapsedWallMilliseconds }, 'Scheduler elapsed time must be a non-negative whole number of milliseconds.');
+            const simulation = ensureSimulationControlState(state);
+            if (simulation.paused) return result(true, 'simulation.scheduled-advance', 'simulation.paused-no-advance', 'paused', { elapsedWallMilliseconds: elapsedMs, speedMultiplier: simulation.speedMultiplier, secondsAdvanced: 0, remainderMs }, 'Simulation is paused; world time did not advance.');
+            remainderMs += elapsedMs * simulation.speedMultiplier;
+            const secondsAdvanced = Math.floor(remainderMs / 1000);
+            remainderMs %= 1000;
+            if (!secondsAdvanced) return result(true, 'simulation.scheduled-advance', 'simulation.accumulating', 'accumulating', { elapsedWallMilliseconds: elapsedMs, speedMultiplier: simulation.speedMultiplier, secondsAdvanced: 0, remainderMs }, 'No full simulated second elapsed yet.');
+            const timeResult = advanceWorldTime(state, secondsAdvanced, options);
+            return result(true, 'simulation.scheduled-advance', 'simulation.advanced', 'advanced', { elapsedWallMilliseconds: elapsedMs, speedMultiplier: simulation.speedMultiplier, secondsAdvanced, remainderMs, worldTime: timeResult.data }, timeResult.display.text);
+        },
+        resetRemainder() { remainderMs = 0; },
+        get remainderMs() { return remainderMs; },
+    };
+}
+
+export function validateSimulationControlState(simulation) {
+    if (!simulation || typeof simulation !== 'object' || Array.isArray(simulation)) return ['simulation must be an object.'];
+    const issues = [];
+    if (typeof simulation.paused !== 'boolean') issues.push('simulation.paused must be boolean.');
+    if (!validSpeed(simulation.speedMultiplier)) issues.push(`simulation.speedMultiplier must be an integer from 1 to ${MAX_SIMULATION_SPEED}.`);
+    return issues;
+}
+
+function validSpeed(value) { return Number.isInteger(value) && value >= 1 && value <= MAX_SIMULATION_SPEED; }
+function result(ok, action, code, outcome, data, text) {
+    return ok ? actionSuccess({ action, code, outcome, data: { ...data }, display: { text } }) : actionFailure({ action, code, outcome, data: { ...data }, display: { text } });
+}

--- a/js/text/version.js
+++ b/js/text/version.js
@@ -1,5 +1,5 @@
-export const PRODUCT_VERSION = '0.5.100.0';
-export const PACKAGE_VERSION = '0.5.100';
+export const PRODUCT_VERSION = '0.5.200.0';
+export const PACKAGE_VERSION = '0.5.200';
 
 export const VERSION = Object.freeze({
     product: PRODUCT_VERSION,
@@ -8,7 +8,7 @@ export const VERSION = Object.freeze({
     gameState: 4,
     data: 13,
     benchmark: 1,
-    codename: 'Deterministic World Clock',
+    codename: 'Simulation Speed Control',
     compatibility: 'migrate-supported-save-versions',
     released: false,
 
@@ -18,12 +18,13 @@ export const VERSION = Object.freeze({
 });
 
 export const SYSTEM_VERSIONS = Object.freeze({
-    versionManifest: '0.5.100',
+    versionManifest: '0.5.200',
     saveMigrations: '0.2.0',
     actionResults: '0.1.0',
     semanticEvents: '0.1.0',
     foundationReadiness: '0.2.0',
-    worldTime: '0.1.0',
+    worldTime: '0.2.0',
+    simulationControl: '0.1.0',
     commandShell: '0.4.4',
     canvasUi: '0.7.0',
     uiIntents: '0.1.1',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffxi-text-rpg",
-  "version": "0.5.100",
+  "version": "0.5.200",
   "private": true,
   "type": "module",
   "description": "Text-first fantasy life RPG foundation inspired by Final Fantasy XI systems.",

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -14,8 +14,8 @@ import {
 
 
 test('version manifest separates product package and persistence versions', () => {
-    assert.equal(PRODUCT_VERSION, '0.5.100.0');
-    assert.equal(PACKAGE_VERSION, '0.5.100');
+    assert.equal(PRODUCT_VERSION, '0.5.200.0');
+    assert.equal(PACKAGE_VERSION, '0.5.200');
     assert.equal(VERSION.product, PRODUCT_VERSION);
     assert.equal(VERSION.package, PACKAGE_VERSION);
     assert.equal(VERSION.app, PRODUCT_VERSION);
@@ -24,17 +24,18 @@ test('version manifest separates product package and persistence versions', () =
     assert.equal(VERSION.data, 13);
     assert.equal(VERSION.benchmark, 1);
     assert.equal(VERSION.save, VERSION.accountSave);
-    assert.match(describeVersion(), /Product: 0\.5\.100\.0/);
-    assert.match(describeVersion(), /Package: 0\.5\.100/);
+    assert.match(describeVersion(), /Product: 0\.5\.200\.0/);
+    assert.match(describeVersion(), /Package: 0\.5\.200/);
     assert.match(describeVersion(), /Account Save: 4/);
     assert.match(describeVersion(), /Game State: 4/);
-    assert.match(describeVersion(), /Codename: Deterministic World Clock/);
+    assert.match(describeVersion(), /Codename: Simulation Speed Control/);
     assert.match(describeVersion(), /Compatibility: migrate-supported-save-versions/);
-    assert.match(describeSystemVersions(), /versionManifest: 0\.5\.100/);
+    assert.match(describeSystemVersions(), /versionManifest: 0\.5\.200/);
     assert.match(describeSystemVersions(), /saveMigrations: 0\.2\.0/);
     assert.match(describeSystemVersions(), /actionResults: 0\.1\.0/);
     assert.match(describeSystemVersions(), /semanticEvents: 0\.1\.0/);
-    assert.match(describeSystemVersions(), /worldTime: 0\.1\.0/);
+    assert.match(describeSystemVersions(), /worldTime: 0\.2\.0/);
+    assert.match(describeSystemVersions(), /simulationControl: 0\.1\.0/);
     assert.match(describeSystemVersions(), /validation: 0\.7\.0/);
     assert.match(describeSystemVersions(), /travel: 0\.4\.2/);
     assert.match(describeSystemVersions(), /characterCreation/);

--- a/tests/simulationControlEngine.test.js
+++ b/tests/simulationControlEngine.test.js
@@ -1,0 +1,110 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createInitialState } from '../js/text/gameState.js';
+import { listSemanticEvents } from '../js/text/systems/semanticEventEngine.js';
+import {
+    createSimulationAdvanceDriver,
+    pauseSimulation,
+    resumeSimulation,
+    setSimulationSpeed,
+    validateSimulationControlState,
+} from '../js/text/systems/simulationControlEngine.js';
+
+
+test('new games start running at normal simulation speed', () => {
+    const state = createInitialState();
+
+    assert.deepEqual(state.simulation, { paused: false, speedMultiplier: 1 });
+    assert.deepEqual(validateSimulationControlState(state.simulation), []);
+});
+
+test('pause and resume change simulation control without advancing world time', () => {
+    const state = createInitialState();
+    state.worldTime.totalSeconds = 120;
+
+    const paused = pauseSimulation(state);
+    assert.equal(paused.code, 'simulation.paused');
+    assert.equal(state.simulation.paused, true);
+    assert.equal(state.worldTime.totalSeconds, 120);
+
+    const resumed = resumeSimulation(state);
+    assert.equal(resumed.code, 'simulation.resumed');
+    assert.equal(state.simulation.paused, false);
+    assert.equal(state.worldTime.totalSeconds, 120);
+
+    assert.deepEqual(listSemanticEvents(state).map((event) => event.type), [
+        'simulation.paused',
+        'simulation.resumed',
+    ]);
+});
+
+test('speed control accepts arbitrary whole-number multipliers within the engine limit', () => {
+    const state = createInitialState();
+
+    const result = setSimulationSpeed(state, 60);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.code, 'simulation.speed-changed');
+    assert.equal(state.simulation.speedMultiplier, 60);
+    const [event] = listSemanticEvents(state, { type: 'simulation.speed-changed' });
+    assert.deepEqual(event.data, { previousSpeed: 1, speedMultiplier: 60, paused: false });
+});
+
+test('scheduled advancement converts wall elapsed time into deterministic simulated seconds', () => {
+    const state = createInitialState();
+    setSimulationSpeed(state, 60);
+    const driver = createSimulationAdvanceDriver();
+    const originalNow = Date.now;
+    Date.now = () => { throw new Error('simulation driver must not read Date.now'); };
+
+    try {
+        const result = driver.advance(state, 500);
+        assert.equal(result.code, 'simulation.advanced');
+        assert.equal(result.data.secondsAdvanced, 30);
+        assert.equal(state.worldTime.totalSeconds, 30);
+    } finally {
+        Date.now = originalNow;
+    }
+});
+
+test('simulation driver preserves sub-second remainder without drift', () => {
+    const state = createInitialState();
+    const driver = createSimulationAdvanceDriver();
+
+    assert.equal(driver.advance(state, 250).data.secondsAdvanced, 0);
+    assert.equal(driver.advance(state, 250).data.secondsAdvanced, 0);
+    assert.equal(driver.advance(state, 250).data.secondsAdvanced, 0);
+    const fourth = driver.advance(state, 250);
+
+    assert.equal(fourth.data.secondsAdvanced, 1);
+    assert.equal(driver.remainderMs, 0);
+    assert.equal(state.worldTime.totalSeconds, 1);
+});
+
+test('paused scheduler time is discarded rather than accumulated for later advancement', () => {
+    const state = createInitialState();
+    const driver = createSimulationAdvanceDriver();
+    pauseSimulation(state);
+
+    const paused = driver.advance(state, 5000);
+    assert.equal(paused.code, 'simulation.paused-no-advance');
+    assert.equal(state.worldTime.totalSeconds, 0);
+    assert.equal(driver.remainderMs, 0);
+
+    resumeSimulation(state);
+    const running = driver.advance(state, 1000);
+    assert.equal(running.data.secondsAdvanced, 1);
+    assert.equal(state.worldTime.totalSeconds, 1);
+});
+
+test('invalid speed values are rejected without mutating simulation state', () => {
+    const state = createInitialState();
+
+    for (const speed of [0, -1, 1.5, 3601]) {
+        const result = setSimulationSpeed(state, speed);
+        assert.equal(result.ok, false);
+        assert.equal(result.code, 'simulation.invalid-speed');
+        assert.equal(state.simulation.speedMultiplier, 1);
+    }
+});


### PR DESCRIPTION
## Target

`0.5.200` — Pause and simulation speed control.

## Changes

- adds simulation control state: paused + speed multiplier
- adds pause/resume and speed-change ActionResults/events
- adds deterministic conversion from supplied scheduler milliseconds to simulated seconds
- preserves sub-second remainder
- discards scheduler elapsed time while paused
- keeps canonical world time independent of `Date.now()`
- new games start running at 1x; existing Game State v4 saves can lazily acquire control state

## Version impact

- Product `0.5.200.0`
- Package `0.5.200`
- Game State remains `4`
- `simulationControl` `0.1.0`
- `worldTime` `0.2.0`

## Tests

Covers pause/resume, speed changes, accelerated canonical time, remainder handling, paused-time discard, invalid speeds, and wall-clock independence. GitHub Actions runs the full test/benchmark gate.

## Next

`0.5.300` — canonical timed task model.