### PR TITLE
Implement 0.5.300 canonical timed task model

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -13,15 +13,15 @@ Authoritative companion documents:
 
 ## Current baseline
 
-Current 0.5 simulation-control target:
+Current 0.5 timed-task target:
 
 ```text
-Product:      0.5.200.0
-Package:      0.5.200
+Product:      0.5.300.0
+Package:      0.5.300
 Account Save: 4
 Game State:   4
 Data:         13
-Codename:     Simulation Speed Control
+Codename:     Canonical Timed Tasks
 ```
 
 This remains pre-alpha product development. The version is a milestone identity, not a completion percentage.
@@ -80,27 +80,32 @@ Key rules:
 - [x] Ordered Game State v3 -> v4 migration adds canonical world time.
 - [x] Wall-clock `tickEngine` remains only a scheduler/dispatcher and does not mutate canonical world time by itself.
 
-### 0.5.200 Pause and speed control — current
+### 0.5.200 Pause and speed control — complete
 
 - [x] Simulation pause/resume state and semantic events.
 - [x] Engine accepts whole-number simulation-speed multipliers from 1x through 3600x without hard-coding UI presets.
-- [x] A scheduler adapter converts supplied wall-clock milliseconds into exact simulated seconds.
+- [x] Scheduler adapter converts supplied wall-clock milliseconds into exact simulated seconds.
 - [x] Sub-second simulated remainder is retained deterministically rather than discarded.
 - [x] Wall-clock time observed while paused is discarded and cannot become a burst of simulation time after resume.
 - [x] Fast-forward advances the canonical world clock rather than merely changing render timing.
-- [x] Scheduler conversion does not call `Date.now()`; the existing tick engine may supply elapsed time without owning game time.
-- [x] New games initialize simulation control at running/1x while older Game State v4 saves remain valid and lazily acquire control state when used.
+- [x] Scheduler conversion does not call `Date.now()`.
+- [x] New games initialize simulation control at running/1x while older Game State v4 saves can lazily acquire control state.
 
-The simulation-control engine deliberately separates three concerns: wall-clock observation, simulation speed/pause policy, and authoritative world-time advancement. Direct exact advancement remains available for tests/tools and later advance-to-completion/advance-to-event systems.
+### 0.5.300 Canonical timed task model — current
 
-### 0.5.300 Canonical timed task model — next
+- [x] Versioned task registry with stable task IDs.
+- [x] Tasks use canonical start/completion world-time boundaries and positive whole-second durations.
+- [x] Start semantics return structured ActionResult data and emit `task.started`.
+- [x] Progress is derived from canonical world time instead of maintaining a second competing task clock.
+- [x] Reconciliation completes due tasks deterministically and emits `task.completed`.
+- [x] Cancellation freezes progress at cancellation time and emits `task.cancelled`.
+- [x] Overshoot preserves the scheduled completion time while the completion event records when the simulation observed it.
+- [x] Multiple channels may coexist; concurrency/exclusivity policy is intentionally deferred to activity-specific systems.
+- [x] New games initialize an empty task registry while older Game State v4 saves can lazily acquire one without a schema migration.
 
-- [ ] Shared duration representation.
-- [ ] Start/progress/complete/cancel semantics where appropriate.
-- [ ] Deterministic completion.
-- [ ] Travel becomes one consumer rather than the template every activity must copy.
+The timed-task engine does not own time advancement. It observes `worldTime.totalSeconds`. This keeps task semantics reusable for work, crafting, travel, construction, recovery, and later systems without making travel the universal implementation template.
 
-### 0.5.400 Interrupt model
+### 0.5.400 Interrupt model — next
 
 - [ ] Advance-until-event.
 - [ ] Deterministic interrupt priority.
@@ -219,10 +224,10 @@ Refine formulas when they materially improve a meaningful player-facing loop. Do
 
 ## Immediate next pass
 
-After the 0.5.200 simulation-control PR is green and merged:
+After the 0.5.300 timed-task PR is green and merged:
 
 ```text
-0.5.300 — Canonical timed task model
+0.5.400 — Interrupt model
 ```
 
-The task model should consume deterministic world-time deltas and emit semantic outcomes without making any one activity type—especially travel—the universal implementation template.
+The interrupt layer should coordinate advancement stopping points and priorities without moving combat, project, or tool-specific policy into the world clock itself.

--- a/js/text/gameState.js
+++ b/js/text/gameState.js
@@ -7,6 +7,7 @@ import { createAtlasState, describeCurrentGrid, setPositionAndDiscover } from '.
 import { describeCurrentPois, createPoiDiscoveryState } from './systems/poiEngine.js';
 import { createSemanticEventState } from './systems/semanticEventEngine.js';
 import { createSimulationControlState } from './systems/simulationControlEngine.js';
+import { createTimedTaskState } from './systems/timedTaskEngine.js';
 import { describePlace } from './systems/travelEngine.js';
 import { moveInDirection } from './systems/navigationEngine.js';
 import { calculateCombatProfile } from './systems/statEngine.js';
@@ -42,6 +43,7 @@ export function createNewGameState(options = {}) {
             paused: options.simulationPaused ?? false,
             speedMultiplier: options.simulationSpeedMultiplier ?? 1,
         }),
+        tasks: createTimedTaskState(),
         currentPlaceId: startPlace.id,
         location: startPlace.name,
         position: startCoordinate,

--- a/js/text/systems/timedTaskEngine.js
+++ b/js/text/systems/timedTaskEngine.js
@@ -1,0 +1,200 @@
+import { actionFailure, actionSuccess } from './actionResult.js';
+import { emitSemanticEvent } from './semanticEventEngine.js';
+import { ensureWorldTimeState } from './worldTimeEngine.js';
+
+export const TIMED_TASK_STATE_VERSION = 1;
+export const TIMED_TASK_STATUSES = Object.freeze({
+    ACTIVE: 'active',
+    COMPLETED: 'completed',
+    CANCELLED: 'cancelled',
+});
+
+export function createTimedTaskState(options = {}) {
+    return {
+        version: TIMED_TASK_STATE_VERSION,
+        nextSequence: positiveInteger(options.nextSequence) ? options.nextSequence : 1,
+        records: Array.isArray(options.records) ? [...options.records] : [],
+    };
+}
+
+export function ensureTimedTaskState(state) {
+    if (!state || typeof state !== 'object') throw new Error('Timed tasks require game state.');
+    if (!state.tasks || typeof state.tasks !== 'object' || Array.isArray(state.tasks)) {
+        state.tasks = createTimedTaskState();
+    }
+    const issues = validateTimedTaskState(state.tasks);
+    if (issues.length) throw new Error(issues.join(' '));
+    return state.tasks;
+}
+
+export function startTimedTask(state, definition = {}) {
+    const kind = String(definition.kind ?? '').trim();
+    const durationSeconds = Number(definition.durationSeconds);
+    const label = String(definition.label ?? kind).trim();
+    const channel = String(definition.channel ?? 'character').trim() || 'character';
+    const data = definition.data ?? {};
+
+    if (!validKind(kind)) return failure('task.invalid-kind', { kind }, 'Timed task kind is required and must be a stable identifier.');
+    if (!positiveInteger(durationSeconds)) return failure('task.invalid-duration', { durationSeconds: definition.durationSeconds }, 'Timed task duration must be a positive whole number of seconds.');
+    if (!plainObject(data)) return failure('task.invalid-data', {}, 'Timed task data must be an object.');
+
+    const worldTime = ensureWorldTimeState(state);
+    const tasks = ensureTimedTaskState(state);
+    const sequence = tasks.nextSequence++;
+    const id = `task-${String(sequence).padStart(6, '0')}`;
+    const startedAtWorldSeconds = worldTime.totalSeconds;
+    const task = {
+        id,
+        version: TIMED_TASK_STATE_VERSION,
+        kind,
+        label: label || kind,
+        channel,
+        status: TIMED_TASK_STATUSES.ACTIVE,
+        durationSeconds,
+        startedAtWorldSeconds,
+        completesAtWorldSeconds: startedAtWorldSeconds + durationSeconds,
+        completedAtWorldSeconds: null,
+        cancelledAtWorldSeconds: null,
+        data: { ...data },
+    };
+    tasks.records.push(task);
+
+    const event = emitSemanticEvent(state, 'task.started', taskEventData(task), { source: 'timedTaskEngine' });
+    return actionSuccess({
+        action: 'task.start',
+        code: 'task.started',
+        outcome: 'started',
+        data: { task: snapshotTask(task), eventId: event.id },
+        display: { text: `Started ${task.label}; duration ${durationSeconds}s.` },
+    });
+}
+
+export function reconcileTimedTasks(state) {
+    const tasks = ensureTimedTaskState(state);
+    const now = ensureWorldTimeState(state).totalSeconds;
+    const completed = [];
+
+    for (const task of tasks.records) {
+        if (task.status !== TIMED_TASK_STATUSES.ACTIVE) continue;
+        if (now < task.completesAtWorldSeconds) continue;
+        task.status = TIMED_TASK_STATUSES.COMPLETED;
+        task.completedAtWorldSeconds = task.completesAtWorldSeconds;
+        const event = emitSemanticEvent(state, 'task.completed', taskEventData(task), { source: 'timedTaskEngine' });
+        completed.push({ task: snapshotTask(task), eventId: event.id });
+    }
+
+    return completed;
+}
+
+export function cancelTimedTask(state, taskId) {
+    const task = findTimedTask(state, taskId);
+    if (!task) return failure('task.not-found', { taskId }, `Unknown timed task: ${taskId}`);
+    if (task.status !== TIMED_TASK_STATUSES.ACTIVE) {
+        return failure('task.not-active', { task: snapshotTask(task) }, `${task.label} is ${task.status} and cannot be cancelled.`);
+    }
+
+    task.status = TIMED_TASK_STATUSES.CANCELLED;
+    task.cancelledAtWorldSeconds = ensureWorldTimeState(state).totalSeconds;
+    const event = emitSemanticEvent(state, 'task.cancelled', taskEventData(task), { source: 'timedTaskEngine' });
+    return actionSuccess({
+        action: 'task.cancel',
+        code: 'task.cancelled',
+        outcome: 'cancelled',
+        data: { task: snapshotTask(task), eventId: event.id },
+        display: { text: `Cancelled ${task.label}.` },
+    });
+}
+
+export function getTimedTaskProgress(state, taskId) {
+    const task = findTimedTask(state, taskId);
+    if (!task) return null;
+    const now = ensureWorldTimeState(state).totalSeconds;
+    const terminalAt = task.completedAtWorldSeconds ?? task.cancelledAtWorldSeconds ?? now;
+    const observedAt = task.status === TIMED_TASK_STATUSES.ACTIVE ? now : terminalAt;
+    const elapsedSeconds = Math.max(0, Math.min(task.durationSeconds, observedAt - task.startedAtWorldSeconds));
+    const remainingSeconds = Math.max(0, task.durationSeconds - elapsedSeconds);
+    return Object.freeze({
+        taskId: task.id,
+        status: task.status,
+        elapsedSeconds,
+        remainingSeconds,
+        progress: elapsedSeconds / task.durationSeconds,
+        due: task.status === TIMED_TASK_STATUSES.ACTIVE && now >= task.completesAtWorldSeconds,
+    });
+}
+
+export function findTimedTask(state, taskId) {
+    const id = String(taskId ?? '').trim();
+    if (!id) return null;
+    return ensureTimedTaskState(state).records.find((task) => task.id === id) ?? null;
+}
+
+export function listTimedTasks(state, options = {}) {
+    const status = options.status ? String(options.status) : null;
+    const channel = options.channel ? String(options.channel) : null;
+    return ensureTimedTaskState(state).records
+        .filter((task) => (!status || task.status === status) && (!channel || task.channel === channel))
+        .map(snapshotTask);
+}
+
+export function validateTimedTaskState(tasks) {
+    if (!tasks || typeof tasks !== 'object' || Array.isArray(tasks)) return ['tasks must be an object.'];
+    const issues = [];
+    if (tasks.version !== TIMED_TASK_STATE_VERSION) issues.push(`tasks.version must be ${TIMED_TASK_STATE_VERSION}.`);
+    if (!positiveInteger(tasks.nextSequence)) issues.push('tasks.nextSequence must be a positive integer.');
+    if (!Array.isArray(tasks.records)) return [...issues, 'tasks.records must be an array.'];
+
+    const ids = new Set();
+    let maxSequence = 0;
+    for (const [index, task] of tasks.records.entries()) {
+        const prefix = `tasks.records[${index}]`;
+        if (!task || typeof task !== 'object' || Array.isArray(task)) {
+            issues.push(`${prefix} must be an object.`);
+            continue;
+        }
+        if (!/^task-\d{6,}$/.test(task.id ?? '')) issues.push(`${prefix}.id is invalid.`);
+        if (ids.has(task.id)) issues.push(`${prefix}.id duplicates ${task.id}.`);
+        ids.add(task.id);
+        maxSequence = Math.max(maxSequence, Number.parseInt(String(task.id ?? '').replace('task-', ''), 10) || 0);
+        if (!validKind(task.kind)) issues.push(`${prefix}.kind is invalid.`);
+        if (!Object.values(TIMED_TASK_STATUSES).includes(task.status)) issues.push(`${prefix}.status is invalid.`);
+        if (!positiveInteger(task.durationSeconds)) issues.push(`${prefix}.durationSeconds must be positive.`);
+        if (!nonNegativeInteger(task.startedAtWorldSeconds)) issues.push(`${prefix}.startedAtWorldSeconds is invalid.`);
+        if (!nonNegativeInteger(task.completesAtWorldSeconds)) issues.push(`${prefix}.completesAtWorldSeconds is invalid.`);
+        if (nonNegativeInteger(task.startedAtWorldSeconds) && nonNegativeInteger(task.completesAtWorldSeconds)
+            && task.completesAtWorldSeconds !== task.startedAtWorldSeconds + task.durationSeconds) {
+            issues.push(`${prefix}.completesAtWorldSeconds does not match duration.`);
+        }
+        if (!plainObject(task.data)) issues.push(`${prefix}.data must be an object.`);
+    }
+    if (tasks.nextSequence <= maxSequence) issues.push('tasks.nextSequence must be greater than stored task sequences.');
+    return issues;
+}
+
+function snapshotTask(task) {
+    return Object.freeze({ ...task, data: Object.freeze({ ...task.data }) });
+}
+
+function taskEventData(task) {
+    return {
+        taskId: task.id,
+        kind: task.kind,
+        label: task.label,
+        channel: task.channel,
+        status: task.status,
+        durationSeconds: task.durationSeconds,
+        startedAtWorldSeconds: task.startedAtWorldSeconds,
+        completesAtWorldSeconds: task.completesAtWorldSeconds,
+        completedAtWorldSeconds: task.completedAtWorldSeconds,
+        cancelledAtWorldSeconds: task.cancelledAtWorldSeconds,
+        data: { ...task.data },
+    };
+}
+
+function failure(code, data, text) {
+    return actionFailure({ action: 'task', code, outcome: 'rejected', data, display: { text } });
+}
+function validKind(value) { return /^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)*$/.test(value); }
+function positiveInteger(value) { return Number.isInteger(value) && value > 0; }
+function nonNegativeInteger(value) { return Number.isInteger(value) && value >= 0; }
+function plainObject(value) { return Boolean(value && typeof value === 'object' && !Array.isArray(value)); }

--- a/js/text/version.js
+++ b/js/text/version.js
@@ -1,5 +1,5 @@
-export const PRODUCT_VERSION = '0.5.200.0';
-export const PACKAGE_VERSION = '0.5.200';
+export const PRODUCT_VERSION = '0.5.300.0';
+export const PACKAGE_VERSION = '0.5.300';
 
 export const VERSION = Object.freeze({
     product: PRODUCT_VERSION,
@@ -8,7 +8,7 @@ export const VERSION = Object.freeze({
     gameState: 4,
     data: 13,
     benchmark: 1,
-    codename: 'Simulation Speed Control',
+    codename: 'Canonical Timed Tasks',
     compatibility: 'migrate-supported-save-versions',
     released: false,
 
@@ -18,13 +18,14 @@ export const VERSION = Object.freeze({
 });
 
 export const SYSTEM_VERSIONS = Object.freeze({
-    versionManifest: '0.5.200',
+    versionManifest: '0.5.300',
     saveMigrations: '0.2.0',
     actionResults: '0.1.0',
     semanticEvents: '0.1.0',
     foundationReadiness: '0.2.0',
     worldTime: '0.2.0',
     simulationControl: '0.1.0',
+    timedTasks: '0.1.0',
     commandShell: '0.4.4',
     canvasUi: '0.7.0',
     uiIntents: '0.1.1',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffxi-text-rpg",
-  "version": "0.5.200",
+  "version": "0.5.300",
   "private": true,
   "type": "module",
   "description": "Text-first fantasy life RPG foundation inspired by Final Fantasy XI systems.",

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -14,8 +14,8 @@ import {
 
 
 test('version manifest separates product package and persistence versions', () => {
-    assert.equal(PRODUCT_VERSION, '0.5.200.0');
-    assert.equal(PACKAGE_VERSION, '0.5.200');
+    assert.equal(PRODUCT_VERSION, '0.5.300.0');
+    assert.equal(PACKAGE_VERSION, '0.5.300');
     assert.equal(VERSION.product, PRODUCT_VERSION);
     assert.equal(VERSION.package, PACKAGE_VERSION);
     assert.equal(VERSION.app, PRODUCT_VERSION);
@@ -24,18 +24,19 @@ test('version manifest separates product package and persistence versions', () =
     assert.equal(VERSION.data, 13);
     assert.equal(VERSION.benchmark, 1);
     assert.equal(VERSION.save, VERSION.accountSave);
-    assert.match(describeVersion(), /Product: 0\.5\.200\.0/);
-    assert.match(describeVersion(), /Package: 0\.5\.200/);
+    assert.match(describeVersion(), /Product: 0\.5\.300\.0/);
+    assert.match(describeVersion(), /Package: 0\.5\.300/);
     assert.match(describeVersion(), /Account Save: 4/);
     assert.match(describeVersion(), /Game State: 4/);
-    assert.match(describeVersion(), /Codename: Simulation Speed Control/);
+    assert.match(describeVersion(), /Codename: Canonical Timed Tasks/);
     assert.match(describeVersion(), /Compatibility: migrate-supported-save-versions/);
-    assert.match(describeSystemVersions(), /versionManifest: 0\.5\.200/);
+    assert.match(describeSystemVersions(), /versionManifest: 0\.5\.300/);
     assert.match(describeSystemVersions(), /saveMigrations: 0\.2\.0/);
     assert.match(describeSystemVersions(), /actionResults: 0\.1\.0/);
     assert.match(describeSystemVersions(), /semanticEvents: 0\.1\.0/);
     assert.match(describeSystemVersions(), /worldTime: 0\.2\.0/);
     assert.match(describeSystemVersions(), /simulationControl: 0\.1\.0/);
+    assert.match(describeSystemVersions(), /timedTasks: 0\.1\.0/);
     assert.match(describeSystemVersions(), /validation: 0\.7\.0/);
     assert.match(describeSystemVersions(), /travel: 0\.4\.2/);
     assert.match(describeSystemVersions(), /characterCreation/);

--- a/tests/timedTaskEngine.test.js
+++ b/tests/timedTaskEngine.test.js
@@ -1,0 +1,144 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createInitialState } from '../js/text/gameState.js';
+import { listSemanticEvents } from '../js/text/systems/semanticEventEngine.js';
+import {
+    cancelTimedTask,
+    getTimedTaskProgress,
+    listTimedTasks,
+    reconcileTimedTasks,
+    startTimedTask,
+    TIMED_TASK_STATUSES,
+    validateTimedTaskState,
+} from '../js/text/systems/timedTaskEngine.js';
+import { advanceWorldTime } from '../js/text/systems/worldTimeEngine.js';
+
+
+test('new games initialize an empty versioned timed-task registry', () => {
+    const state = createInitialState();
+
+    assert.equal(state.tasks.version, 1);
+    assert.equal(state.tasks.nextSequence, 1);
+    assert.deepEqual(state.tasks.records, []);
+    assert.deepEqual(validateTimedTaskState(state.tasks), []);
+});
+
+test('timed task start records canonical world-time boundaries and structured event data', () => {
+    const state = createInitialState();
+    state.worldTime.totalSeconds = 90;
+
+    const result = startTimedTask(state, {
+        kind: 'work.gather',
+        label: 'Gather firewood',
+        durationSeconds: 120,
+        data: { resourceId: 'firewood' },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.code, 'task.started');
+    assert.equal(result.data.task.id, 'task-000001');
+    assert.equal(result.data.task.startedAtWorldSeconds, 90);
+    assert.equal(result.data.task.completesAtWorldSeconds, 210);
+    assert.equal(result.data.task.status, TIMED_TASK_STATUSES.ACTIVE);
+    const [event] = listSemanticEvents(state, { type: 'task.started' });
+    assert.equal(event.data.taskId, 'task-000001');
+    assert.equal(event.data.kind, 'work.gather');
+});
+
+test('task progress is derived from canonical world time and completes exactly at its deadline', () => {
+    const state = createInitialState();
+    const started = startTimedTask(state, { kind: 'work.test', label: 'Test work', durationSeconds: 60 });
+    const taskId = started.data.task.id;
+
+    advanceWorldTime(state, 30);
+    assert.deepEqual(getTimedTaskProgress(state, taskId), {
+        taskId,
+        status: 'active',
+        elapsedSeconds: 30,
+        remainingSeconds: 30,
+        progress: 0.5,
+        due: false,
+    });
+    assert.deepEqual(reconcileTimedTasks(state), []);
+
+    advanceWorldTime(state, 30);
+    const beforeReconcile = getTimedTaskProgress(state, taskId);
+    assert.equal(beforeReconcile.due, true);
+    assert.equal(beforeReconcile.remainingSeconds, 0);
+
+    const completed = reconcileTimedTasks(state);
+    assert.equal(completed.length, 1);
+    assert.equal(completed[0].task.status, 'completed');
+    assert.equal(completed[0].task.completedAtWorldSeconds, 60);
+    assert.equal(getTimedTaskProgress(state, taskId).progress, 1);
+});
+
+test('overshooting world time records scheduled completion time rather than observation time', () => {
+    const state = createInitialState();
+    const started = startTimedTask(state, { kind: 'work.test', durationSeconds: 10 });
+
+    advanceWorldTime(state, 100);
+    const [completed] = reconcileTimedTasks(state);
+
+    assert.equal(state.worldTime.totalSeconds, 100);
+    assert.equal(completed.task.completedAtWorldSeconds, 10);
+    const [event] = listSemanticEvents(state, { type: 'task.completed' });
+    assert.equal(event.worldTimeSeconds, 100);
+    assert.equal(event.data.completedAtWorldSeconds, 10);
+});
+
+test('cancelled tasks stop progressing and never complete during reconciliation', () => {
+    const state = createInitialState();
+    const started = startTimedTask(state, { kind: 'work.test', durationSeconds: 100 });
+    const taskId = started.data.task.id;
+
+    advanceWorldTime(state, 25);
+    const cancelled = cancelTimedTask(state, taskId);
+    assert.equal(cancelled.code, 'task.cancelled');
+    assert.equal(cancelled.data.task.cancelledAtWorldSeconds, 25);
+
+    advanceWorldTime(state, 500);
+    assert.deepEqual(reconcileTimedTasks(state), []);
+    const progress = getTimedTaskProgress(state, taskId);
+    assert.equal(progress.status, 'cancelled');
+    assert.equal(progress.elapsedSeconds, 25);
+    assert.equal(progress.remainingSeconds, 75);
+});
+
+test('multiple task channels can coexist without premature concurrency policy', () => {
+    const state = createInitialState();
+    startTimedTask(state, { kind: 'craft.smelt', channel: 'workshop', durationSeconds: 30 });
+    startTimedTask(state, { kind: 'travel.walk', channel: 'character', durationSeconds: 60 });
+
+    assert.equal(listTimedTasks(state, { status: 'active' }).length, 2);
+    assert.equal(listTimedTasks(state, { channel: 'workshop' }).length, 1);
+
+    advanceWorldTime(state, 30);
+    const completed = reconcileTimedTasks(state);
+    assert.equal(completed.length, 1);
+    assert.equal(completed[0].task.kind, 'craft.smelt');
+    assert.equal(listTimedTasks(state, { status: 'active' })[0].kind, 'travel.walk');
+});
+
+test('older Game State v4 records can lazily acquire an empty task registry', () => {
+    const state = createInitialState();
+    delete state.tasks;
+    assert.equal(state.version, 4);
+
+    const started = startTimedTask(state, { kind: 'work.test', durationSeconds: 5 });
+
+    assert.equal(started.ok, true);
+    assert.equal(state.tasks.version, 1);
+    assert.equal(state.version, 4);
+});
+
+test('invalid task definitions are rejected without allocating task IDs', () => {
+    const state = createInitialState();
+
+    assert.equal(startTimedTask(state, { kind: '', durationSeconds: 10 }).ok, false);
+    assert.equal(startTimedTask(state, { kind: 'work.test', durationSeconds: 0 }).ok, false);
+    assert.equal(startTimedTask(state, { kind: 'work.test', durationSeconds: 2.5 }).ok, false);
+    assert.equal(state.tasks.nextSequence, 1);
+    assert.equal(state.tasks.records.length, 0);
+});


### PR DESCRIPTION
## Target

`0.5.300` — Canonical timed task model.

## Changes

- adds a versioned timed-task registry with stable task IDs
- tasks store canonical start/completion world-time boundaries and positive whole-second durations
- start returns structured ActionResult data and emits `task.started`
- task progress is derived from `worldTime.totalSeconds`, avoiding a competing task clock
- reconciliation deterministically completes due tasks and emits `task.completed`
- cancellation freezes progress at cancellation time and emits `task.cancelled`
- overshoot preserves scheduled completion time while the completion event records observation time
- multiple channels can coexist without prematurely hard-coding concurrency policy
- new games initialize an empty task registry; older Game State v4 saves can lazily acquire one

## Version impact

- Product `0.5.300.0`
- Package `0.5.300`
- Game State remains `4`
- `timedTasks` `0.1.0`

## Tests

Covers start boundaries, progress, exact completion, overshoot, cancellation, channels, lazy initialization, invalid definitions, and semantic events. GitHub Actions runs the full test/benchmark gate.

## Next

`0.5.400` — interrupt model.