### PR TITLE
Implement 0.5.400 simulation interrupt model

### DIFF
--- a/js/text/systems/simulationControlEngine.js
+++ b/js/text/systems/simulationControlEngine.js
@@ -49,8 +49,12 @@ export function setSimulationSpeed(state, requestedSpeed) {
     return result(true, 'simulation.speed', 'simulation.speed-changed', 'changed', { ...simulation, previousSpeed, eventId: event.id }, `Simulation speed set to ${speed}x.`);
 }
 
-export function createSimulationAdvanceDriver() {
+export function createSimulationAdvanceDriver(driverOptions = {}) {
     let remainderMs = 0;
+    const advanceSeconds = driverOptions.advanceSeconds
+        ?? ((state, seconds, options) => advanceWorldTime(state, seconds, options));
+    if (typeof advanceSeconds !== 'function') throw new Error('advanceSeconds must be a function.');
+
     return {
         advance(state, elapsedWallMilliseconds, options = {}) {
             const elapsedMs = Number(elapsedWallMilliseconds);
@@ -58,11 +62,35 @@ export function createSimulationAdvanceDriver() {
             const simulation = ensureSimulationControlState(state);
             if (simulation.paused) return result(true, 'simulation.scheduled-advance', 'simulation.paused-no-advance', 'paused', { elapsedWallMilliseconds: elapsedMs, speedMultiplier: simulation.speedMultiplier, secondsAdvanced: 0, remainderMs }, 'Simulation is paused; world time did not advance.');
             remainderMs += elapsedMs * simulation.speedMultiplier;
-            const secondsAdvanced = Math.floor(remainderMs / 1000);
+            const requestedSimulationSeconds = Math.floor(remainderMs / 1000);
             remainderMs %= 1000;
-            if (!secondsAdvanced) return result(true, 'simulation.scheduled-advance', 'simulation.accumulating', 'accumulating', { elapsedWallMilliseconds: elapsedMs, speedMultiplier: simulation.speedMultiplier, secondsAdvanced: 0, remainderMs }, 'No full simulated second elapsed yet.');
-            const timeResult = advanceWorldTime(state, secondsAdvanced, options);
-            return result(true, 'simulation.scheduled-advance', 'simulation.advanced', 'advanced', { elapsedWallMilliseconds: elapsedMs, speedMultiplier: simulation.speedMultiplier, secondsAdvanced, remainderMs, worldTime: timeResult.data }, timeResult.display.text);
+            if (!requestedSimulationSeconds) return result(true, 'simulation.scheduled-advance', 'simulation.accumulating', 'accumulating', { elapsedWallMilliseconds: elapsedMs, speedMultiplier: simulation.speedMultiplier, secondsAdvanced: 0, remainderMs }, 'No full simulated second elapsed yet.');
+
+            const advanceResult = advanceSeconds(state, requestedSimulationSeconds, options);
+            if (!advanceResult?.ok) {
+                return result(false, 'simulation.scheduled-advance', 'simulation.advance-failed', 'rejected', {
+                    elapsedWallMilliseconds: elapsedMs,
+                    speedMultiplier: simulation.speedMultiplier,
+                    requestedSimulationSeconds,
+                    secondsAdvanced: 0,
+                    remainderMs,
+                    advanceResult: advanceResult?.data ?? null,
+                }, advanceResult?.display?.text ?? 'Simulation advancement failed.');
+            }
+
+            const secondsAdvanced = Number.isInteger(advanceResult.data?.secondsAdvanced)
+                ? advanceResult.data.secondsAdvanced
+                : requestedSimulationSeconds;
+            const interrupted = advanceResult.data?.interrupted === true || advanceResult.outcome === 'interrupted';
+            return result(true, 'simulation.scheduled-advance', interrupted ? 'simulation.interrupted' : 'simulation.advanced', interrupted ? 'interrupted' : 'advanced', {
+                elapsedWallMilliseconds: elapsedMs,
+                speedMultiplier: simulation.speedMultiplier,
+                requestedSimulationSeconds,
+                secondsAdvanced,
+                remainderMs,
+                worldTime: advanceResult.data,
+                interrupted,
+            }, advanceResult.display?.text ?? `Advanced ${secondsAdvanced}s.`);
         },
         resetRemainder() { remainderMs = 0; },
         get remainderMs() { return remainderMs; },

--- a/js/text/systems/simulationInterruptEngine.js
+++ b/js/text/systems/simulationInterruptEngine.js
@@ -1,0 +1,209 @@
+import { actionFailure, actionSuccess } from './actionResult.js';
+import { emitSemanticEvent } from './semanticEventEngine.js';
+import { listTimedTasks, reconcileTimedTasks } from './timedTaskEngine.js';
+import { advanceWorldTime, ensureWorldTimeState } from './worldTimeEngine.js';
+
+export const INTERRUPT_PRIORITIES = Object.freeze({
+    CRITICAL: 1000,
+    COMBAT: 900,
+    EXHAUSTION: 800,
+    TOOL_FAILURE: 700,
+    PROJECT_COMPLETION: 600,
+    TASK_COMPLETION: 500,
+    DAY_BOUNDARY: 400,
+    DEFAULT: 100,
+});
+
+export function createInterruptCandidate(options = {}) {
+    const type = String(options.type ?? '').trim();
+    const atWorldSeconds = Number(options.atWorldSeconds);
+    const priority = options.priority ?? priorityForInterruptType(type);
+    const source = String(options.source ?? 'system').trim() || 'system';
+    const data = options.data ?? {};
+    const id = String(options.id ?? `${type}@${atWorldSeconds}`).trim();
+
+    if (!validType(type)) throw new Error(`Invalid interrupt type: ${type}`);
+    if (!nonNegativeInteger(atWorldSeconds)) throw new Error('Interrupt atWorldSeconds must be a non-negative integer.');
+    if (!Number.isInteger(priority)) throw new Error('Interrupt priority must be an integer.');
+    if (!plainObject(data)) throw new Error('Interrupt data must be an object.');
+
+    return Object.freeze({ id, type, atWorldSeconds, priority, source, data: Object.freeze({ ...data }) });
+}
+
+export function priorityForInterruptType(type) {
+    const value = String(type ?? '');
+    if (value.startsWith('critical.')) return INTERRUPT_PRIORITIES.CRITICAL;
+    if (value.startsWith('combat.')) return INTERRUPT_PRIORITIES.COMBAT;
+    if (value.startsWith('exhaustion.')) return INTERRUPT_PRIORITIES.EXHAUSTION;
+    if (value.startsWith('tool.failure')) return INTERRUPT_PRIORITIES.TOOL_FAILURE;
+    if (value.startsWith('project.completed')) return INTERRUPT_PRIORITIES.PROJECT_COMPLETION;
+    if (value.startsWith('task.completed')) return INTERRUPT_PRIORITIES.TASK_COMPLETION;
+    if (value.startsWith('day.boundary')) return INTERRUPT_PRIORITIES.DAY_BOUNDARY;
+    return INTERRUPT_PRIORITIES.DEFAULT;
+}
+
+export function collectInterruptCandidates(state, options = {}) {
+    const now = ensureWorldTimeState(state).totalSeconds;
+    const horizon = options.maxSeconds === undefined
+        ? Number.POSITIVE_INFINITY
+        : now + normalizeRequestedSeconds(options.maxSeconds);
+    const candidates = [];
+
+    if (options.includeTaskCompletions !== false) {
+        for (const task of listTimedTasks(state, { status: 'active' })) {
+            if (task.completesAtWorldSeconds < now || task.completesAtWorldSeconds > horizon) continue;
+            candidates.push(createInterruptCandidate({
+                id: `task-completion:${task.id}`,
+                type: 'task.completed',
+                atWorldSeconds: task.completesAtWorldSeconds,
+                priority: INTERRUPT_PRIORITIES.TASK_COMPLETION,
+                source: 'timedTaskEngine',
+                data: { taskId: task.id, kind: task.kind, channel: task.channel },
+            }));
+        }
+    }
+
+    for (const raw of options.candidates ?? []) {
+        const candidate = createInterruptCandidate(raw);
+        if (candidate.atWorldSeconds >= now && candidate.atWorldSeconds <= horizon) candidates.push(candidate);
+    }
+
+    for (const provider of options.providers ?? []) {
+        if (typeof provider !== 'function') throw new Error('Interrupt providers must be functions.');
+        const provided = provider({ state, nowWorldSeconds: now, horizonWorldSeconds: horizon }) ?? [];
+        for (const raw of provided) {
+            const candidate = createInterruptCandidate(raw);
+            if (candidate.atWorldSeconds >= now && candidate.atWorldSeconds <= horizon) candidates.push(candidate);
+        }
+    }
+
+    return candidates.sort(compareInterrupts);
+}
+
+export function findNextInterrupt(state, options = {}) {
+    return collectInterruptCandidates(state, options)[0] ?? null;
+}
+
+export function advanceSimulationUntilInterrupt(state, requestedSeconds, options = {}) {
+    const seconds = Number(requestedSeconds);
+    if (!nonNegativeInteger(seconds)) {
+        return actionFailure({
+            action: 'simulation.advance-until-interrupt',
+            code: 'simulation.invalid-advance',
+            outcome: 'rejected',
+            data: { requestedSeconds },
+            display: { text: 'Simulation advancement must be a non-negative whole number of seconds.' },
+        });
+    }
+
+    const worldTime = ensureWorldTimeState(state);
+    const beforeWorldSeconds = worldTime.totalSeconds;
+    const alreadyCompleted = reconcileTimedTasks(state);
+    if (alreadyCompleted.length) {
+        const first = alreadyCompleted[0].task;
+        return interruptResult(state, {
+            id: `observed-completion:${first.id}`,
+            type: 'task.completed',
+            atWorldSeconds: beforeWorldSeconds,
+            priority: INTERRUPT_PRIORITIES.TASK_COMPLETION,
+            source: 'timedTaskEngine',
+            data: { taskId: first.id, kind: first.kind, observedLate: true },
+        }, seconds, 0, beforeWorldSeconds, alreadyCompleted);
+    }
+
+    const interrupt = findNextInterrupt(state, {
+        ...options,
+        maxSeconds: seconds,
+    });
+    const targetWorldSeconds = interrupt?.atWorldSeconds ?? beforeWorldSeconds + seconds;
+    const secondsAdvanced = Math.max(0, targetWorldSeconds - beforeWorldSeconds);
+    const timeResult = secondsAdvanced > 0
+        ? advanceWorldTime(state, secondsAdvanced, options.worldTimeOptions)
+        : null;
+    const completedTasks = reconcileTimedTasks(state);
+
+    if (interrupt) {
+        return interruptResult(
+            state,
+            interrupt,
+            seconds,
+            secondsAdvanced,
+            beforeWorldSeconds,
+            completedTasks,
+            timeResult,
+        );
+    }
+
+    return actionSuccess({
+        action: 'simulation.advance-until-interrupt',
+        code: 'simulation.advance-complete',
+        outcome: 'advanced',
+        data: {
+            requestedSeconds: seconds,
+            secondsAdvanced,
+            beforeWorldSeconds,
+            afterWorldSeconds: worldTime.totalSeconds,
+            interrupted: false,
+            interrupt: null,
+            completedTasks,
+            timeEventId: timeResult?.data?.eventId ?? null,
+        },
+        display: { text: `Advanced simulation ${secondsAdvanced}s without interruption.` },
+    });
+}
+
+export function createInterruptAwareAdvanceFunction(defaultOptions = {}) {
+    return (state, requestedSeconds, callOptions = {}) => advanceSimulationUntilInterrupt(
+        state,
+        requestedSeconds,
+        { ...defaultOptions, ...callOptions },
+    );
+}
+
+function interruptResult(state, rawInterrupt, requestedSeconds, secondsAdvanced, beforeWorldSeconds, completedTasks, timeResult = null) {
+    const interrupt = createInterruptCandidate(rawInterrupt);
+    const event = emitSemanticEvent(state, 'simulation.interrupted', {
+        interruptId: interrupt.id,
+        interruptType: interrupt.type,
+        interruptPriority: interrupt.priority,
+        interruptSource: interrupt.source,
+        interruptAtWorldSeconds: interrupt.atWorldSeconds,
+        interruptData: { ...interrupt.data },
+        requestedSeconds,
+        secondsAdvanced,
+    }, { source: 'simulationInterruptEngine' });
+
+    return actionSuccess({
+        action: 'simulation.advance-until-interrupt',
+        code: 'simulation.interrupted',
+        outcome: 'interrupted',
+        data: {
+            requestedSeconds,
+            secondsAdvanced,
+            beforeWorldSeconds,
+            afterWorldSeconds: ensureWorldTimeState(state).totalSeconds,
+            interrupted: true,
+            interrupt,
+            interruptEventId: event.id,
+            completedTasks,
+            timeEventId: timeResult?.data?.eventId ?? null,
+        },
+        display: { text: `Simulation stopped for ${interrupt.type} after ${secondsAdvanced}s.` },
+    });
+}
+
+function compareInterrupts(a, b) {
+    return a.atWorldSeconds - b.atWorldSeconds
+        || b.priority - a.priority
+        || a.type.localeCompare(b.type)
+        || a.id.localeCompare(b.id);
+}
+
+function normalizeRequestedSeconds(value) {
+    const number = Number(value);
+    if (!nonNegativeInteger(number)) throw new Error('maxSeconds must be a non-negative integer.');
+    return number;
+}
+function validType(value) { return /^[a-z][a-z0-9]*(?:[.-][a-z0-9]+)+$/.test(value); }
+function nonNegativeInteger(value) { return Number.isInteger(value) && value >= 0; }
+function plainObject(value) { return Boolean(value && typeof value === 'object' && !Array.isArray(value)); }

--- a/tests/simulationInterruptEngine.test.js
+++ b/tests/simulationInterruptEngine.test.js
@@ -1,0 +1,144 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createInitialState } from '../js/text/gameState.js';
+import { createSimulationAdvanceDriver, setSimulationSpeed } from '../js/text/systems/simulationControlEngine.js';
+import {
+    advanceSimulationUntilInterrupt,
+    collectInterruptCandidates,
+    createInterruptAwareAdvanceFunction,
+    createInterruptCandidate,
+    findNextInterrupt,
+    INTERRUPT_PRIORITIES,
+} from '../js/text/systems/simulationInterruptEngine.js';
+import { listSemanticEvents } from '../js/text/systems/semanticEventEngine.js';
+import { startTimedTask } from '../js/text/systems/timedTaskEngine.js';
+
+
+test('interrupt candidates sort by earliest time then higher priority deterministically', () => {
+    const state = createInitialState();
+    const candidates = collectInterruptCandidates(state, {
+        maxSeconds: 100,
+        candidates: [
+            { id: 'later', type: 'combat.encounter', atWorldSeconds: 50 },
+            { id: 'low', type: 'day.boundary', atWorldSeconds: 20 },
+            { id: 'high', type: 'combat.encounter', atWorldSeconds: 20 },
+        ],
+    });
+
+    assert.deepEqual(candidates.map((candidate) => candidate.id), ['high', 'low', 'later']);
+    assert.equal(candidates[0].priority, INTERRUPT_PRIORITIES.COMBAT);
+});
+
+test('task completion is a built-in interrupt source', () => {
+    const state = createInitialState();
+    const started = startTimedTask(state, { kind: 'work.test', durationSeconds: 30 });
+
+    const next = findNextInterrupt(state, { maxSeconds: 60 });
+
+    assert.equal(next.type, 'task.completed');
+    assert.equal(next.atWorldSeconds, 30);
+    assert.equal(next.data.taskId, started.data.task.id);
+});
+
+test('advance-until-interrupt stops exactly at task completion and reconciles the task', () => {
+    const state = createInitialState();
+    startTimedTask(state, { kind: 'work.test', durationSeconds: 30 });
+
+    const result = advanceSimulationUntilInterrupt(state, 120);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.code, 'simulation.interrupted');
+    assert.equal(result.data.secondsAdvanced, 30);
+    assert.equal(result.data.afterWorldSeconds, 30);
+    assert.equal(result.data.interrupt.type, 'task.completed');
+    assert.equal(result.data.completedTasks.length, 1);
+    assert.equal(result.data.completedTasks[0].task.status, 'completed');
+    assert.deepEqual(listSemanticEvents(state).map((event) => event.type), [
+        'task.started',
+        'time.advanced',
+        'task.completed',
+        'simulation.interrupted',
+    ]);
+});
+
+test('simulation advances the full request when no interrupt occurs', () => {
+    const state = createInitialState();
+
+    const result = advanceSimulationUntilInterrupt(state, 75);
+
+    assert.equal(result.code, 'simulation.advance-complete');
+    assert.equal(result.data.interrupted, false);
+    assert.equal(result.data.secondsAdvanced, 75);
+    assert.equal(state.worldTime.totalSeconds, 75);
+});
+
+test('higher-priority custom interrupt wins a same-time tie while due tasks still reconcile', () => {
+    const state = createInitialState();
+    startTimedTask(state, { kind: 'work.test', durationSeconds: 20 });
+
+    const result = advanceSimulationUntilInterrupt(state, 100, {
+        candidates: [{ id: 'ambush', type: 'combat.encounter', atWorldSeconds: 20, data: { enemyId: 'orc' } }],
+    });
+
+    assert.equal(result.data.interrupt.id, 'ambush');
+    assert.equal(result.data.interrupt.priority, INTERRUPT_PRIORITIES.COMBAT);
+    assert.equal(result.data.completedTasks.length, 1);
+    assert.equal(state.worldTime.totalSeconds, 20);
+});
+
+test('interrupt providers can contribute future conditions without coupling them to the clock', () => {
+    const state = createInitialState();
+    const provider = ({ nowWorldSeconds }) => [{
+        id: 'fatigue-threshold',
+        type: 'exhaustion.threshold',
+        atWorldSeconds: nowWorldSeconds + 45,
+        data: { resource: 'energy' },
+    }];
+
+    const result = advanceSimulationUntilInterrupt(state, 100, { providers: [provider] });
+
+    assert.equal(result.data.secondsAdvanced, 45);
+    assert.equal(result.data.interrupt.type, 'exhaustion.threshold');
+    assert.equal(result.data.interrupt.priority, INTERRUPT_PRIORITIES.EXHAUSTION);
+});
+
+test('accelerated scheduler advancement discards remaining budget after an interrupt', () => {
+    const state = createInitialState();
+    setSimulationSpeed(state, 60);
+    startTimedTask(state, { kind: 'work.test', durationSeconds: 10 });
+    const driver = createSimulationAdvanceDriver({
+        advanceSeconds: createInterruptAwareAdvanceFunction(),
+    });
+
+    const result = driver.advance(state, 1000);
+
+    assert.equal(result.code, 'simulation.interrupted');
+    assert.equal(result.data.requestedSimulationSeconds, 60);
+    assert.equal(result.data.secondsAdvanced, 10);
+    assert.equal(state.worldTime.totalSeconds, 10);
+
+    const next = driver.advance(state, 1000);
+    assert.equal(next.data.secondsAdvanced, 60);
+    assert.equal(state.worldTime.totalSeconds, 70);
+});
+
+test('late task completion is surfaced immediately before new advancement', () => {
+    const state = createInitialState();
+    startTimedTask(state, { kind: 'work.test', durationSeconds: 10 });
+    state.worldTime.totalSeconds = 25;
+
+    const result = advanceSimulationUntilInterrupt(state, 100);
+
+    assert.equal(result.code, 'simulation.interrupted');
+    assert.equal(result.data.secondsAdvanced, 0);
+    assert.equal(result.data.interrupt.type, 'task.completed');
+    assert.equal(result.data.interrupt.data.observedLate, true);
+    assert.equal(state.worldTime.totalSeconds, 25);
+});
+
+test('interrupt candidate validation rejects unstable definitions', () => {
+    assert.throws(() => createInterruptCandidate({ type: '', atWorldSeconds: 1 }), /Invalid interrupt type/);
+    assert.throws(() => createInterruptCandidate({ type: 'combat.encounter', atWorldSeconds: -1 }), /non-negative integer/);
+    assert.throws(() => createInterruptCandidate({ type: 'combat.encounter', atWorldSeconds: 1, priority: 1.5 }), /priority must be an integer/);
+});


### PR DESCRIPTION
## Target

`0.5.400` — deterministic simulation interrupt model.

## Changes

- adds canonical interrupt candidates with exact world-time boundaries
- deterministic ordering: earliest time, then higher priority, then stable lexical tie-breaks
- task completion is the first built-in interrupt source
- generic providers/candidates allow later combat, exhaustion, tool failure, project, and day-boundary systems to contribute without owning the clock
- adds `advanceSimulationUntilInterrupt` for full-or-stop advancement
- surfaces late task completions immediately before new advancement
- emits structured `simulation.interrupted` events
- lets accelerated scheduler advancement use an interrupt-aware callback and discard unused fast-forward budget after a stop

## Version impact

- Product `0.5.400.0`
- Package `0.5.400`
- Game State remains `4`
- `simulationInterrupts` `0.1.0`
- `simulationControl` `0.2.0`

## Tests

Covers time/priority ordering, task completion stops, full clear advancement, same-time priority, provider hooks, accelerated interruption behavior, late completion, and candidate validation. GitHub Actions runs the full test/benchmark gate.

## Next

`0.5.500` — day boundary and end-of-day review.