### PR TITLE
Implement 0.5.500 day boundary and end-of-day review

### DIFF
--- a/js/text/systems/dayCycleEngine.js
+++ b/js/text/systems/dayCycleEngine.js
@@ -1,0 +1,268 @@
+import { actionFailure, actionSuccess } from './actionResult.js';
+import { pauseSimulation, ensureSimulationControlState } from './simulationControlEngine.js';
+import { advanceSimulationUntilInterrupt, INTERRUPT_PRIORITIES } from './simulationInterruptEngine.js';
+import { emitSemanticEvent, listSemanticEvents } from './semanticEventEngine.js';
+import { ensureWorldTimeState, SECONDS_PER_DAY } from './worldTimeEngine.js';
+
+export const DAY_CYCLE_STATE_VERSION = 1;
+export const DEFAULT_DAY_SUMMARY_LIMIT = 120;
+
+export function createDayCycleState(options = {}) {
+    return {
+        version: DAY_CYCLE_STATE_VERSION,
+        lastFinalizedDay: nonNegativeInteger(options.lastFinalizedDay) ? options.lastFinalizedDay : 0,
+        summaries: Array.isArray(options.summaries) ? [...options.summaries] : [],
+    };
+}
+
+export function ensureDayCycleState(state) {
+    if (!state || typeof state !== 'object') throw new Error('Day cycle requires game state.');
+    if (!state.dayCycle || typeof state.dayCycle !== 'object' || Array.isArray(state.dayCycle)) {
+        const worldTime = ensureWorldTimeState(state);
+        state.dayCycle = createDayCycleState({
+            // Existing saves cannot reconstruct already elapsed days reliably from bounded event history.
+            lastFinalizedDay: Math.floor(worldTime.totalSeconds / SECONDS_PER_DAY),
+        });
+    }
+    const issues = validateDayCycleState(state.dayCycle);
+    if (issues.length) throw new Error(issues.join(' '));
+    return state.dayCycle;
+}
+
+export function createDayBoundaryInterruptProvider() {
+    return ({ nowWorldSeconds, horizonWorldSeconds }) => {
+        const nextBoundary = (Math.floor(nowWorldSeconds / SECONDS_PER_DAY) + 1) * SECONDS_PER_DAY;
+        if (nextBoundary > horizonWorldSeconds) return [];
+        const dayEnded = Math.floor(nextBoundary / SECONDS_PER_DAY);
+        return [{
+            id: `day-boundary:${dayEnded}`,
+            type: 'day.boundary',
+            atWorldSeconds: nextBoundary,
+            priority: INTERRUPT_PRIORITIES.DAY_BOUNDARY,
+            source: 'dayCycleEngine',
+            data: { dayEnded, nextDay: dayEnded + 1 },
+        }];
+    };
+}
+
+export function buildDaySummary(state, dayNumber) {
+    const day = Number(dayNumber);
+    if (!positiveInteger(day)) throw new Error('dayNumber must be a positive integer.');
+    const startWorldSeconds = (day - 1) * SECONDS_PER_DAY;
+    const endWorldSeconds = day * SECONDS_PER_DAY;
+    const events = listSemanticEvents(state).filter((event) => {
+        if (!Number.isFinite(event.worldTimeSeconds)) return false;
+        return day === 1
+            ? event.worldTimeSeconds >= startWorldSeconds && event.worldTimeSeconds <= endWorldSeconds
+            : event.worldTimeSeconds > startWorldSeconds && event.worldTimeSeconds <= endWorldSeconds;
+    });
+    const eventTypeCounts = {};
+    const categoryCounts = {};
+    for (const event of events) {
+        eventTypeCounts[event.type] = (eventTypeCounts[event.type] ?? 0) + 1;
+        const category = classifyEvent(event.type);
+        categoryCounts[category] = (categoryCounts[category] ?? 0) + 1;
+    }
+
+    return Object.freeze({
+        day,
+        startWorldSeconds,
+        endWorldSeconds,
+        eventCount: events.length,
+        eventTypeCounts: Object.freeze(eventTypeCounts),
+        categoryCounts: Object.freeze(categoryCounts),
+        notableEvents: Object.freeze(events
+            .filter((event) => isNotableEvent(event.type))
+            .slice(-20)
+            .map((event) => Object.freeze({
+                id: event.id,
+                type: event.type,
+                worldTimeSeconds: event.worldTimeSeconds,
+                data: event.data,
+            }))),
+    });
+}
+
+export function finalizeCompletedDays(state, options = {}) {
+    const dayCycle = ensureDayCycleState(state);
+    const currentCompletedDay = Math.floor(ensureWorldTimeState(state).totalSeconds / SECONDS_PER_DAY);
+    const summaries = [];
+
+    for (let day = dayCycle.lastFinalizedDay + 1; day <= currentCompletedDay; day += 1) {
+        const summary = buildDaySummary(state, day);
+        recordDaySummary(dayCycle, summary, options.summaryLimit);
+        dayCycle.lastFinalizedDay = day;
+        const endedEvent = emitSemanticEvent(state, 'day.ended', summaryEventData(summary), { source: 'dayCycleEngine' });
+        const startedEvent = emitSemanticEvent(state, 'day.started', { day: day + 1 }, { source: 'dayCycleEngine' });
+        summaries.push({ summary, endedEventId: endedEvent.id, startedEventId: startedEvent.id });
+    }
+
+    return summaries;
+}
+
+export function advanceSimulationWithDayPolicy(state, requestedSeconds, options = {}) {
+    const requested = Number(requestedSeconds);
+    if (!nonNegativeInteger(requested)) {
+        return actionFailure({
+            action: 'day.advance',
+            code: 'day.invalid-advance',
+            outcome: 'rejected',
+            data: { requestedSeconds },
+            display: { text: 'Day-aware advancement must be a non-negative whole number of seconds.' },
+        });
+    }
+
+    const simulation = ensureSimulationControlState(state);
+    ensureDayCycleState(state);
+    const dayProvider = createDayBoundaryInterruptProvider();
+    const providers = [...(options.providers ?? []), dayProvider];
+    const originalStart = ensureWorldTimeState(state).totalSeconds;
+    let remainingSeconds = requested;
+    const finalizedDays = [];
+
+    while (remainingSeconds > 0) {
+        const result = advanceSimulationUntilInterrupt(state, remainingSeconds, {
+            ...options,
+            providers,
+        });
+        if (!result.ok) return result;
+
+        const advanced = result.data.secondsAdvanced ?? 0;
+        remainingSeconds = Math.max(0, remainingSeconds - advanced);
+        finalizedDays.push(...finalizeCompletedDays(state, options));
+
+        if (!result.data.interrupted) {
+            return completedAdvanceResult(state, requested, originalStart, finalizedDays, result);
+        }
+
+        if (result.data.interrupt?.type !== 'day.boundary') {
+            return interruptedAdvanceResult(state, requested, originalStart, remainingSeconds, finalizedDays, result);
+        }
+
+        if (simulation.endOfDayPause) {
+            const pauseResult = pauseSimulation(state);
+            const latest = finalizedDays.at(-1)?.summary ?? null;
+            return actionSuccess({
+                action: 'day.advance',
+                code: 'day.end-paused',
+                outcome: 'interrupted',
+                data: {
+                    requestedSeconds: requested,
+                    secondsAdvanced: ensureWorldTimeState(state).totalSeconds - originalStart,
+                    remainingSeconds,
+                    interrupted: true,
+                    interrupt: result.data.interrupt,
+                    summary: latest,
+                    finalizedDays,
+                    pauseEventId: pauseResult.data.eventId ?? null,
+                },
+                display: { text: `Day ${latest?.day ?? '?'} ended. Simulation paused for review.` },
+            });
+        }
+
+        // With auto-pause disabled, a day boundary is informational. Continue any
+        // remaining advancement until a higher-value interrupt or the request ends.
+        if (advanced === 0) {
+            return actionFailure({
+                action: 'day.advance',
+                code: 'day.zero-progress-boundary',
+                outcome: 'blocked',
+                data: { requestedSeconds: requested, remainingSeconds },
+                display: { text: 'Day advancement could not make progress past a boundary.' },
+            });
+        }
+    }
+
+    return completedAdvanceResult(state, requested, originalStart, finalizedDays, null);
+}
+
+export function getLatestDaySummary(state) {
+    return ensureDayCycleState(state).summaries.at(-1) ?? null;
+}
+
+export function listDaySummaries(state, options = {}) {
+    const limit = positiveInteger(options.limit) ? options.limit : DEFAULT_DAY_SUMMARY_LIMIT;
+    return ensureDayCycleState(state).summaries.slice(-limit);
+}
+
+export function validateDayCycleState(dayCycle) {
+    if (!dayCycle || typeof dayCycle !== 'object' || Array.isArray(dayCycle)) return ['dayCycle must be an object.'];
+    const issues = [];
+    if (dayCycle.version !== DAY_CYCLE_STATE_VERSION) issues.push(`dayCycle.version must be ${DAY_CYCLE_STATE_VERSION}.`);
+    if (!nonNegativeInteger(dayCycle.lastFinalizedDay)) issues.push('dayCycle.lastFinalizedDay must be a non-negative integer.');
+    if (!Array.isArray(dayCycle.summaries)) issues.push('dayCycle.summaries must be an array.');
+    return issues;
+}
+
+function recordDaySummary(dayCycle, summary, requestedLimit) {
+    const limit = positiveInteger(requestedLimit) ? requestedLimit : DEFAULT_DAY_SUMMARY_LIMIT;
+    dayCycle.summaries.push(summary);
+    if (dayCycle.summaries.length > limit) dayCycle.summaries.splice(0, dayCycle.summaries.length - limit);
+}
+
+function completedAdvanceResult(state, requested, originalStart, finalizedDays, underlying) {
+    const advanced = ensureWorldTimeState(state).totalSeconds - originalStart;
+    return actionSuccess({
+        action: 'day.advance',
+        code: 'day.advance-complete',
+        outcome: 'advanced',
+        data: {
+            requestedSeconds: requested,
+            secondsAdvanced: advanced,
+            remainingSeconds: Math.max(0, requested - advanced),
+            interrupted: false,
+            finalizedDays,
+            underlying: underlying?.data ?? null,
+        },
+        display: { text: `Advanced ${advanced}s with day-boundary policy.` },
+    });
+}
+
+function interruptedAdvanceResult(state, requested, originalStart, remainingSeconds, finalizedDays, result) {
+    return actionSuccess({
+        action: 'day.advance',
+        code: 'day.interrupted',
+        outcome: 'interrupted',
+        data: {
+            requestedSeconds: requested,
+            secondsAdvanced: ensureWorldTimeState(state).totalSeconds - originalStart,
+            remainingSeconds,
+            interrupted: true,
+            interrupt: result.data.interrupt,
+            finalizedDays,
+            underlying: result.data,
+        },
+        display: { text: result.display.text },
+    });
+}
+
+function classifyEvent(type) {
+    const prefix = String(type).split('.')[0];
+    if (['task', 'work', 'craft'].includes(prefix)) return 'work';
+    if (['travel', 'navigation'].includes(prefix)) return 'travel';
+    if (['combat', 'battle'].includes(prefix)) return 'combat';
+    if (['project', 'construction'].includes(prefix)) return 'projects';
+    if (['skill', 'level', 'progression', 'capability'].includes(prefix)) return 'progression';
+    if (['resource', 'inventory', 'shop', 'economy'].includes(prefix)) return 'resources';
+    if (['relationship', 'reputation'].includes(prefix)) return 'relationships';
+    if (['day'].includes(prefix)) return 'day';
+    return 'other';
+}
+
+function isNotableEvent(type) {
+    return /(?:completed|arrived|victory|defeat|level|unlocked|relationship|reputation|project)/.test(type);
+}
+
+function summaryEventData(summary) {
+    return {
+        day: summary.day,
+        startWorldSeconds: summary.startWorldSeconds,
+        endWorldSeconds: summary.endWorldSeconds,
+        eventCount: summary.eventCount,
+        eventTypeCounts: { ...summary.eventTypeCounts },
+        categoryCounts: { ...summary.categoryCounts },
+    };
+}
+
+function positiveInteger(value) { return Number.isInteger(value) && value > 0; }
+function nonNegativeInteger(value) { return Number.isInteger(value) && value >= 0; }

--- a/tests/dayCycleEngine.test.js
+++ b/tests/dayCycleEngine.test.js
@@ -1,0 +1,149 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createInitialState } from '../js/text/gameState.js';
+import {
+    advanceSimulationWithDayPolicy,
+    buildDaySummary,
+    createDayBoundaryInterruptProvider,
+    ensureDayCycleState,
+    getLatestDaySummary,
+    listDaySummaries,
+} from '../js/text/systems/dayCycleEngine.js';
+import { emitSemanticEvent, listSemanticEvents } from '../js/text/systems/semanticEventEngine.js';
+import { resumeSimulation, setEndOfDayPause } from '../js/text/systems/simulationControlEngine.js';
+import { SECONDS_PER_DAY } from '../js/text/systems/worldTimeEngine.js';
+
+
+test('day boundary provider schedules the next boundary strictly after current time', () => {
+    const provider = createDayBoundaryInterruptProvider();
+    const first = provider({ nowWorldSeconds: 0, horizonWorldSeconds: SECONDS_PER_DAY });
+    assert.equal(first.length, 1);
+    assert.equal(first[0].type, 'day.boundary');
+    assert.equal(first[0].atWorldSeconds, SECONDS_PER_DAY);
+    assert.deepEqual(first[0].data, { dayEnded: 1, nextDay: 2 });
+
+    const second = provider({ nowWorldSeconds: SECONDS_PER_DAY, horizonWorldSeconds: 2 * SECONDS_PER_DAY });
+    assert.equal(second[0].atWorldSeconds, 2 * SECONDS_PER_DAY);
+    assert.deepEqual(second[0].data, { dayEnded: 2, nextDay: 3 });
+});
+
+test('default end-of-day policy stops exactly at midnight and pauses for review', () => {
+    const state = createInitialState();
+    state.worldTime.totalSeconds = SECONDS_PER_DAY - 10;
+    ensureDayCycleState(state);
+
+    const result = advanceSimulationWithDayPolicy(state, 100);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.code, 'day.end-paused');
+    assert.equal(result.data.secondsAdvanced, 10);
+    assert.equal(result.data.remainingSeconds, 90);
+    assert.equal(state.worldTime.totalSeconds, SECONDS_PER_DAY);
+    assert.equal(state.simulation.paused, true);
+    assert.equal(result.data.summary.day, 1);
+    assert.equal(getLatestDaySummary(state).day, 1);
+    assert.equal(state.dayCycle.lastFinalizedDay, 1);
+});
+
+test('resuming after end-of-day review continues from the boundary without catch-up', () => {
+    const state = createInitialState();
+    state.worldTime.totalSeconds = SECONDS_PER_DAY - 1;
+    ensureDayCycleState(state);
+
+    const first = advanceSimulationWithDayPolicy(state, 60);
+    assert.equal(first.data.secondsAdvanced, 1);
+    assert.equal(state.simulation.paused, true);
+
+    resumeSimulation(state);
+    const second = advanceSimulationWithDayPolicy(state, 59);
+    assert.equal(second.code, 'day.advance-complete');
+    assert.equal(second.data.secondsAdvanced, 59);
+    assert.equal(state.worldTime.totalSeconds, SECONDS_PER_DAY + 59);
+});
+
+test('disabling end-of-day pause records summaries while allowing multi-day advancement', () => {
+    const state = createInitialState();
+    setEndOfDayPause(state, false);
+    ensureDayCycleState(state);
+
+    const result = advanceSimulationWithDayPolicy(state, (2 * SECONDS_PER_DAY) + 30);
+
+    assert.equal(result.code, 'day.advance-complete');
+    assert.equal(result.data.secondsAdvanced, (2 * SECONDS_PER_DAY) + 30);
+    assert.equal(state.simulation.paused, false);
+    assert.equal(state.dayCycle.lastFinalizedDay, 2);
+    assert.deepEqual(listDaySummaries(state).map((summary) => summary.day), [1, 2]);
+    assert.equal(state.worldTime.totalSeconds, (2 * SECONDS_PER_DAY) + 30);
+});
+
+test('day summaries aggregate structured semantic event types and categories without parsing prose', () => {
+    const state = createInitialState();
+    emitSemanticEvent(state, 'task.completed', { taskId: 'task-a' }, { source: 'test' });
+    state.worldTime.totalSeconds = 100;
+    emitSemanticEvent(state, 'travel.arrived', { to: 'west-ronfaure' }, { source: 'test' });
+    state.worldTime.totalSeconds = 200;
+    emitSemanticEvent(state, 'project.completed', { projectId: 'shed' }, { source: 'test' });
+
+    const summary = buildDaySummary(state, 1);
+
+    assert.equal(summary.eventCount, 3);
+    assert.deepEqual(summary.eventTypeCounts, {
+        'task.completed': 1,
+        'travel.arrived': 1,
+        'project.completed': 1,
+    });
+    assert.deepEqual(summary.categoryCounts, { work: 1, travel: 1, projects: 1 });
+    assert.deepEqual(summary.notableEvents.map((event) => event.type), [
+        'task.completed',
+        'travel.arrived',
+        'project.completed',
+    ]);
+});
+
+test('same-time higher-priority interrupt finalizes the day but remains the surfaced interrupt', () => {
+    const state = createInitialState();
+    state.worldTime.totalSeconds = SECONDS_PER_DAY - 5;
+    ensureDayCycleState(state);
+
+    const result = advanceSimulationWithDayPolicy(state, 20, {
+        candidates: [{
+            id: 'midnight-ambush',
+            type: 'combat.encounter',
+            atWorldSeconds: SECONDS_PER_DAY,
+            data: { enemyId: 'orc' },
+        }],
+    });
+
+    assert.equal(result.code, 'day.interrupted');
+    assert.equal(result.data.interrupt.id, 'midnight-ambush');
+    assert.equal(result.data.secondsAdvanced, 5);
+    assert.equal(state.dayCycle.lastFinalizedDay, 1);
+    assert.equal(getLatestDaySummary(state).day, 1);
+    assert.equal(state.simulation.paused, false);
+});
+
+test('day transition emits structured day-ended and day-started events', () => {
+    const state = createInitialState();
+    setEndOfDayPause(state, false);
+    ensureDayCycleState(state);
+
+    advanceSimulationWithDayPolicy(state, SECONDS_PER_DAY);
+
+    const dayEvents = listSemanticEvents(state).filter((event) => event.type.startsWith('day.'));
+    assert.deepEqual(dayEvents.map((event) => event.type), ['day.ended', 'day.started']);
+    assert.equal(dayEvents[0].data.day, 1);
+    assert.equal(dayEvents[1].data.day, 2);
+});
+
+test('older saves initialize day-cycle bookkeeping at the current completed-day boundary', () => {
+    const state = createInitialState();
+    delete state.dayCycle;
+    state.worldTime.totalSeconds = (3 * SECONDS_PER_DAY) + 500;
+
+    const dayCycle = ensureDayCycleState(state);
+
+    assert.equal(dayCycle.lastFinalizedDay, 3);
+    assert.deepEqual(dayCycle.summaries, []);
+    assert.equal(state.version, 4);
+});


### PR DESCRIPTION
Superseded by #308 after 0.5.400 merged. The replacement PR is based on current `main`, includes the missing end-of-day simulation preference, version metadata, and compatibility tests, and is the canonical 0.5.500 implementation.