### PR TITLE
Implement 0.5.500 day boundary and end-of-day review (rebased)

### DIFF
--- a/js/text/systems/dayCycleEngine.js
+++ b/js/text/systems/dayCycleEngine.js
@@ -1,0 +1,268 @@
+import { actionFailure, actionSuccess } from './actionResult.js';
+import { pauseSimulation, ensureSimulationControlState } from './simulationControlEngine.js';
+import { advanceSimulationUntilInterrupt, INTERRUPT_PRIORITIES } from './simulationInterruptEngine.js';
+import { emitSemanticEvent, listSemanticEvents } from './semanticEventEngine.js';
+import { ensureWorldTimeState, SECONDS_PER_DAY } from './worldTimeEngine.js';
+
+export const DAY_CYCLE_STATE_VERSION = 1;
+export const DEFAULT_DAY_SUMMARY_LIMIT = 120;
+
+export function createDayCycleState(options = {}) {
+    return {
+        version: DAY_CYCLE_STATE_VERSION,
+        lastFinalizedDay: nonNegativeInteger(options.lastFinalizedDay) ? options.lastFinalizedDay : 0,
+        summaries: Array.isArray(options.summaries) ? [...options.summaries] : [],
+    };
+}
+
+export function ensureDayCycleState(state) {
+    if (!state || typeof state !== 'object') throw new Error('Day cycle requires game state.');
+    if (!state.dayCycle || typeof state.dayCycle !== 'object' || Array.isArray(state.dayCycle)) {
+        const worldTime = ensureWorldTimeState(state);
+        state.dayCycle = createDayCycleState({
+            // Existing saves cannot reconstruct already elapsed days reliably from bounded event history.
+            lastFinalizedDay: Math.floor(worldTime.totalSeconds / SECONDS_PER_DAY),
+        });
+    }
+    const issues = validateDayCycleState(state.dayCycle);
+    if (issues.length) throw new Error(issues.join(' '));
+    return state.dayCycle;
+}
+
+export function createDayBoundaryInterruptProvider() {
+    return ({ nowWorldSeconds, horizonWorldSeconds }) => {
+        const nextBoundary = (Math.floor(nowWorldSeconds / SECONDS_PER_DAY) + 1) * SECONDS_PER_DAY;
+        if (nextBoundary > horizonWorldSeconds) return [];
+        const dayEnded = Math.floor(nextBoundary / SECONDS_PER_DAY);
+        return [{
+            id: `day-boundary:${dayEnded}`,
+            type: 'day.boundary',
+            atWorldSeconds: nextBoundary,
+            priority: INTERRUPT_PRIORITIES.DAY_BOUNDARY,
+            source: 'dayCycleEngine',
+            data: { dayEnded, nextDay: dayEnded + 1 },
+        }];
+    };
+}
+
+export function buildDaySummary(state, dayNumber) {
+    const day = Number(dayNumber);
+    if (!positiveInteger(day)) throw new Error('dayNumber must be a positive integer.');
+    const startWorldSeconds = (day - 1) * SECONDS_PER_DAY;
+    const endWorldSeconds = day * SECONDS_PER_DAY;
+    const events = listSemanticEvents(state).filter((event) => {
+        if (!Number.isFinite(event.worldTimeSeconds)) return false;
+        return day === 1
+            ? event.worldTimeSeconds >= startWorldSeconds && event.worldTimeSeconds <= endWorldSeconds
+            : event.worldTimeSeconds > startWorldSeconds && event.worldTimeSeconds <= endWorldSeconds;
+    });
+    const eventTypeCounts = {};
+    const categoryCounts = {};
+    for (const event of events) {
+        eventTypeCounts[event.type] = (eventTypeCounts[event.type] ?? 0) + 1;
+        const category = classifyEvent(event.type);
+        categoryCounts[category] = (categoryCounts[category] ?? 0) + 1;
+    }
+
+    return Object.freeze({
+        day,
+        startWorldSeconds,
+        endWorldSeconds,
+        eventCount: events.length,
+        eventTypeCounts: Object.freeze(eventTypeCounts),
+        categoryCounts: Object.freeze(categoryCounts),
+        notableEvents: Object.freeze(events
+            .filter((event) => isNotableEvent(event.type))
+            .slice(-20)
+            .map((event) => Object.freeze({
+                id: event.id,
+                type: event.type,
+                worldTimeSeconds: event.worldTimeSeconds,
+                data: event.data,
+            }))),
+    });
+}
+
+export function finalizeCompletedDays(state, options = {}) {
+    const dayCycle = ensureDayCycleState(state);
+    const currentCompletedDay = Math.floor(ensureWorldTimeState(state).totalSeconds / SECONDS_PER_DAY);
+    const summaries = [];
+
+    for (let day = dayCycle.lastFinalizedDay + 1; day <= currentCompletedDay; day += 1) {
+        const summary = buildDaySummary(state, day);
+        recordDaySummary(dayCycle, summary, options.summaryLimit);
+        dayCycle.lastFinalizedDay = day;
+        const endedEvent = emitSemanticEvent(state, 'day.ended', summaryEventData(summary), { source: 'dayCycleEngine' });
+        const startedEvent = emitSemanticEvent(state, 'day.started', { day: day + 1 }, { source: 'dayCycleEngine' });
+        summaries.push({ summary, endedEventId: endedEvent.id, startedEventId: startedEvent.id });
+    }
+
+    return summaries;
+}
+
+export function advanceSimulationWithDayPolicy(state, requestedSeconds, options = {}) {
+    const requested = Number(requestedSeconds);
+    if (!nonNegativeInteger(requested)) {
+        return actionFailure({
+            action: 'day.advance',
+            code: 'day.invalid-advance',
+            outcome: 'rejected',
+            data: { requestedSeconds },
+            display: { text: 'Day-aware advancement must be a non-negative whole number of seconds.' },
+        });
+    }
+
+    const simulation = ensureSimulationControlState(state);
+    ensureDayCycleState(state);
+    const dayProvider = createDayBoundaryInterruptProvider();
+    const providers = [...(options.providers ?? []), dayProvider];
+    const originalStart = ensureWorldTimeState(state).totalSeconds;
+    let remainingSeconds = requested;
+    const finalizedDays = [];
+
+    while (remainingSeconds > 0) {
+        const result = advanceSimulationUntilInterrupt(state, remainingSeconds, {
+            ...options,
+            providers,
+        });
+        if (!result.ok) return result;
+
+        const advanced = result.data.secondsAdvanced ?? 0;
+        remainingSeconds = Math.max(0, remainingSeconds - advanced);
+        finalizedDays.push(...finalizeCompletedDays(state, options));
+
+        if (!result.data.interrupted) {
+            return completedAdvanceResult(state, requested, originalStart, finalizedDays, result);
+        }
+
+        if (result.data.interrupt?.type !== 'day.boundary') {
+            return interruptedAdvanceResult(state, requested, originalStart, remainingSeconds, finalizedDays, result);
+        }
+
+        if (simulation.endOfDayPause) {
+            const pauseResult = pauseSimulation(state);
+            const latest = finalizedDays.at(-1)?.summary ?? null;
+            return actionSuccess({
+                action: 'day.advance',
+                code: 'day.end-paused',
+                outcome: 'interrupted',
+                data: {
+                    requestedSeconds: requested,
+                    secondsAdvanced: ensureWorldTimeState(state).totalSeconds - originalStart,
+                    remainingSeconds,
+                    interrupted: true,
+                    interrupt: result.data.interrupt,
+                    summary: latest,
+                    finalizedDays,
+                    pauseEventId: pauseResult.data.eventId ?? null,
+                },
+                display: { text: `Day ${latest?.day ?? '?'} ended. Simulation paused for review.` },
+            });
+        }
+
+        // With auto-pause disabled, a day boundary is informational. Continue any
+        // remaining advancement until a higher-value interrupt or the request ends.
+        if (advanced === 0) {
+            return actionFailure({
+                action: 'day.advance',
+                code: 'day.zero-progress-boundary',
+                outcome: 'blocked',
+                data: { requestedSeconds: requested, remainingSeconds },
+                display: { text: 'Day advancement could not make progress past a boundary.' },
+            });
+        }
+    }
+
+    return completedAdvanceResult(state, requested, originalStart, finalizedDays, null);
+}
+
+export function getLatestDaySummary(state) {
+    return ensureDayCycleState(state).summaries.at(-1) ?? null;
+}
+
+export function listDaySummaries(state, options = {}) {
+    const limit = positiveInteger(options.limit) ? options.limit : DEFAULT_DAY_SUMMARY_LIMIT;
+    return ensureDayCycleState(state).summaries.slice(-limit);
+}
+
+export function validateDayCycleState(dayCycle) {
+    if (!dayCycle || typeof dayCycle !== 'object' || Array.isArray(dayCycle)) return ['dayCycle must be an object.'];
+    const issues = [];
+    if (dayCycle.version !== DAY_CYCLE_STATE_VERSION) issues.push(`dayCycle.version must be ${DAY_CYCLE_STATE_VERSION}.`);
+    if (!nonNegativeInteger(dayCycle.lastFinalizedDay)) issues.push('dayCycle.lastFinalizedDay must be a non-negative integer.');
+    if (!Array.isArray(dayCycle.summaries)) issues.push('dayCycle.summaries must be an array.');
+    return issues;
+}
+
+function recordDaySummary(dayCycle, summary, requestedLimit) {
+    const limit = positiveInteger(requestedLimit) ? requestedLimit : DEFAULT_DAY_SUMMARY_LIMIT;
+    dayCycle.summaries.push(summary);
+    if (dayCycle.summaries.length > limit) dayCycle.summaries.splice(0, dayCycle.summaries.length - limit);
+}
+
+function completedAdvanceResult(state, requested, originalStart, finalizedDays, underlying) {
+    const advanced = ensureWorldTimeState(state).totalSeconds - originalStart;
+    return actionSuccess({
+        action: 'day.advance',
+        code: 'day.advance-complete',
+        outcome: 'advanced',
+        data: {
+            requestedSeconds: requested,
+            secondsAdvanced: advanced,
+            remainingSeconds: Math.max(0, requested - advanced),
+            interrupted: false,
+            finalizedDays,
+            underlying: underlying?.data ?? null,
+        },
+        display: { text: `Advanced ${advanced}s with day-boundary policy.` },
+    });
+}
+
+function interruptedAdvanceResult(state, requested, originalStart, remainingSeconds, finalizedDays, result) {
+    return actionSuccess({
+        action: 'day.advance',
+        code: 'day.interrupted',
+        outcome: 'interrupted',
+        data: {
+            requestedSeconds: requested,
+            secondsAdvanced: ensureWorldTimeState(state).totalSeconds - originalStart,
+            remainingSeconds,
+            interrupted: true,
+            interrupt: result.data.interrupt,
+            finalizedDays,
+            underlying: result.data,
+        },
+        display: { text: result.display.text },
+    });
+}
+
+function classifyEvent(type) {
+    const prefix = String(type).split('.')[0];
+    if (['task', 'work', 'craft'].includes(prefix)) return 'work';
+    if (['travel', 'navigation'].includes(prefix)) return 'travel';
+    if (['combat', 'battle'].includes(prefix)) return 'combat';
+    if (['project', 'construction'].includes(prefix)) return 'projects';
+    if (['skill', 'level', 'progression', 'capability'].includes(prefix)) return 'progression';
+    if (['resource', 'inventory', 'shop', 'economy'].includes(prefix)) return 'resources';
+    if (['relationship', 'reputation'].includes(prefix)) return 'relationships';
+    if (['day'].includes(prefix)) return 'day';
+    return 'other';
+}
+
+function isNotableEvent(type) {
+    return /(?:completed|arrived|victory|defeat|level|unlocked|relationship|reputation|project)/.test(type);
+}
+
+function summaryEventData(summary) {
+    return {
+        day: summary.day,
+        startWorldSeconds: summary.startWorldSeconds,
+        endWorldSeconds: summary.endWorldSeconds,
+        eventCount: summary.eventCount,
+        eventTypeCounts: { ...summary.eventTypeCounts },
+        categoryCounts: { ...summary.categoryCounts },
+    };
+}
+
+function positiveInteger(value) { return Number.isInteger(value) && value > 0; }
+function nonNegativeInteger(value) { return Number.isInteger(value) && value >= 0; }

--- a/js/text/systems/simulationControlEngine.js
+++ b/js/text/systems/simulationControlEngine.js
@@ -4,11 +4,13 @@ import { advanceWorldTime } from './worldTimeEngine.js';
 
 export const DEFAULT_SIMULATION_SPEED = 1;
 export const MAX_SIMULATION_SPEED = 3600;
+export const DEFAULT_END_OF_DAY_PAUSE = true;
 
 export function createSimulationControlState(options = {}) {
     const state = {
         paused: Boolean(options.paused ?? false),
         speedMultiplier: options.speedMultiplier ?? DEFAULT_SIMULATION_SPEED,
+        endOfDayPause: Boolean(options.endOfDayPause ?? DEFAULT_END_OF_DAY_PAUSE),
     };
     const issues = validateSimulationControlState(state);
     if (issues.length) throw new Error(issues.join(' '));
@@ -17,6 +19,9 @@ export function createSimulationControlState(options = {}) {
 
 export function ensureSimulationControlState(state) {
     if (!state?.simulation) state.simulation = createSimulationControlState();
+    if (typeof state.simulation.endOfDayPause !== 'boolean') {
+        state.simulation.endOfDayPause = DEFAULT_END_OF_DAY_PAUSE;
+    }
     const issues = validateSimulationControlState(state.simulation);
     if (issues.length) throw new Error(issues.join(' '));
     return state.simulation;
@@ -47,6 +52,27 @@ export function setSimulationSpeed(state, requestedSpeed) {
     simulation.speedMultiplier = speed;
     const event = emitSemanticEvent(state, 'simulation.speed-changed', { previousSpeed, speedMultiplier: speed, paused: simulation.paused }, { source: 'simulationControlEngine' });
     return result(true, 'simulation.speed', 'simulation.speed-changed', 'changed', { ...simulation, previousSpeed, eventId: event.id }, `Simulation speed set to ${speed}x.`);
+}
+
+export function setEndOfDayPause(state, enabled) {
+    const simulation = ensureSimulationControlState(state);
+    if (typeof enabled !== 'boolean') {
+        return result(false, 'simulation.end-of-day-pause', 'simulation.invalid-end-of-day-pause', 'rejected', { enabled }, 'End-of-day pause preference must be true or false.');
+    }
+    if (simulation.endOfDayPause === enabled) {
+        return result(true, 'simulation.end-of-day-pause', 'simulation.end-of-day-pause-unchanged', 'unchanged', simulation, `End-of-day pause is already ${enabled ? 'enabled' : 'disabled'}.`);
+    }
+    const previousEndOfDayPause = simulation.endOfDayPause;
+    simulation.endOfDayPause = enabled;
+    const event = emitSemanticEvent(state, 'simulation.end-of-day-pause-changed', {
+        previousEndOfDayPause,
+        endOfDayPause: enabled,
+    }, { source: 'simulationControlEngine' });
+    return result(true, 'simulation.end-of-day-pause', 'simulation.end-of-day-pause-changed', 'changed', {
+        ...simulation,
+        previousEndOfDayPause,
+        eventId: event.id,
+    }, `End-of-day pause ${enabled ? 'enabled' : 'disabled'}.`);
 }
 
 export function createSimulationAdvanceDriver(driverOptions = {}) {
@@ -102,6 +128,7 @@ export function validateSimulationControlState(simulation) {
     const issues = [];
     if (typeof simulation.paused !== 'boolean') issues.push('simulation.paused must be boolean.');
     if (!validSpeed(simulation.speedMultiplier)) issues.push(`simulation.speedMultiplier must be an integer from 1 to ${MAX_SIMULATION_SPEED}.`);
+    if (typeof simulation.endOfDayPause !== 'boolean') issues.push('simulation.endOfDayPause must be boolean.');
     return issues;
 }
 

--- a/js/text/version.js
+++ b/js/text/version.js
@@ -1,5 +1,5 @@
-export const PRODUCT_VERSION = '0.5.300.0';
-export const PACKAGE_VERSION = '0.5.300';
+export const PRODUCT_VERSION = '0.5.500.0';
+export const PACKAGE_VERSION = '0.5.500';
 
 export const VERSION = Object.freeze({
     product: PRODUCT_VERSION,
@@ -8,7 +8,7 @@ export const VERSION = Object.freeze({
     gameState: 4,
     data: 13,
     benchmark: 1,
-    codename: 'Canonical Timed Tasks',
+    codename: 'Day Boundary Review',
     compatibility: 'migrate-supported-save-versions',
     released: false,
 
@@ -18,14 +18,16 @@ export const VERSION = Object.freeze({
 });
 
 export const SYSTEM_VERSIONS = Object.freeze({
-    versionManifest: '0.5.300',
+    versionManifest: '0.5.500',
     saveMigrations: '0.2.0',
     actionResults: '0.1.0',
     semanticEvents: '0.1.0',
     foundationReadiness: '0.2.0',
     worldTime: '0.2.0',
-    simulationControl: '0.1.0',
+    simulationControl: '0.3.0',
+    simulationInterrupts: '0.1.0',
     timedTasks: '0.1.0',
+    dayCycle: '0.1.0',
     commandShell: '0.4.4',
     canvasUi: '0.7.0',
     uiIntents: '0.1.1',

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "ffxi-text-rpg",
-  "version": "0.5.300",
+  "version": "0.5.500",
   "private": true,
   "type": "module",
-  "description": "Text-first fantasy life RPG foundation inspired by Final Fantasy XI systems.",
+  "description": "Text-first persistent fantasy life RPG with deterministic simulation, exploration, livelihoods, relationships, and dangerous travel.",
   "scripts": {
     "serve": "node scripts/serve.js",
     "start": "npm run serve",

--- a/tests/dayCycleEngine.test.js
+++ b/tests/dayCycleEngine.test.js
@@ -1,0 +1,149 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createInitialState } from '../js/text/gameState.js';
+import {
+    advanceSimulationWithDayPolicy,
+    buildDaySummary,
+    createDayBoundaryInterruptProvider,
+    ensureDayCycleState,
+    getLatestDaySummary,
+    listDaySummaries,
+} from '../js/text/systems/dayCycleEngine.js';
+import { emitSemanticEvent, listSemanticEvents } from '../js/text/systems/semanticEventEngine.js';
+import { resumeSimulation, setEndOfDayPause } from '../js/text/systems/simulationControlEngine.js';
+import { SECONDS_PER_DAY } from '../js/text/systems/worldTimeEngine.js';
+
+
+test('day boundary provider schedules the next boundary strictly after current time', () => {
+    const provider = createDayBoundaryInterruptProvider();
+    const first = provider({ nowWorldSeconds: 0, horizonWorldSeconds: SECONDS_PER_DAY });
+    assert.equal(first.length, 1);
+    assert.equal(first[0].type, 'day.boundary');
+    assert.equal(first[0].atWorldSeconds, SECONDS_PER_DAY);
+    assert.deepEqual(first[0].data, { dayEnded: 1, nextDay: 2 });
+
+    const second = provider({ nowWorldSeconds: SECONDS_PER_DAY, horizonWorldSeconds: 2 * SECONDS_PER_DAY });
+    assert.equal(second[0].atWorldSeconds, 2 * SECONDS_PER_DAY);
+    assert.deepEqual(second[0].data, { dayEnded: 2, nextDay: 3 });
+});
+
+test('default end-of-day policy stops exactly at midnight and pauses for review', () => {
+    const state = createInitialState();
+    state.worldTime.totalSeconds = SECONDS_PER_DAY - 10;
+    ensureDayCycleState(state);
+
+    const result = advanceSimulationWithDayPolicy(state, 100);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.code, 'day.end-paused');
+    assert.equal(result.data.secondsAdvanced, 10);
+    assert.equal(result.data.remainingSeconds, 90);
+    assert.equal(state.worldTime.totalSeconds, SECONDS_PER_DAY);
+    assert.equal(state.simulation.paused, true);
+    assert.equal(result.data.summary.day, 1);
+    assert.equal(getLatestDaySummary(state).day, 1);
+    assert.equal(state.dayCycle.lastFinalizedDay, 1);
+});
+
+test('resuming after end-of-day review continues from the boundary without catch-up', () => {
+    const state = createInitialState();
+    state.worldTime.totalSeconds = SECONDS_PER_DAY - 1;
+    ensureDayCycleState(state);
+
+    const first = advanceSimulationWithDayPolicy(state, 60);
+    assert.equal(first.data.secondsAdvanced, 1);
+    assert.equal(state.simulation.paused, true);
+
+    resumeSimulation(state);
+    const second = advanceSimulationWithDayPolicy(state, 59);
+    assert.equal(second.code, 'day.advance-complete');
+    assert.equal(second.data.secondsAdvanced, 59);
+    assert.equal(state.worldTime.totalSeconds, SECONDS_PER_DAY + 59);
+});
+
+test('disabling end-of-day pause records summaries while allowing multi-day advancement', () => {
+    const state = createInitialState();
+    setEndOfDayPause(state, false);
+    ensureDayCycleState(state);
+
+    const result = advanceSimulationWithDayPolicy(state, (2 * SECONDS_PER_DAY) + 30);
+
+    assert.equal(result.code, 'day.advance-complete');
+    assert.equal(result.data.secondsAdvanced, (2 * SECONDS_PER_DAY) + 30);
+    assert.equal(state.simulation.paused, false);
+    assert.equal(state.dayCycle.lastFinalizedDay, 2);
+    assert.deepEqual(listDaySummaries(state).map((summary) => summary.day), [1, 2]);
+    assert.equal(state.worldTime.totalSeconds, (2 * SECONDS_PER_DAY) + 30);
+});
+
+test('day summaries aggregate structured semantic event types and categories without parsing prose', () => {
+    const state = createInitialState();
+    emitSemanticEvent(state, 'task.completed', { taskId: 'task-a' }, { source: 'test' });
+    state.worldTime.totalSeconds = 100;
+    emitSemanticEvent(state, 'travel.arrived', { to: 'west-ronfaure' }, { source: 'test' });
+    state.worldTime.totalSeconds = 200;
+    emitSemanticEvent(state, 'project.completed', { projectId: 'shed' }, { source: 'test' });
+
+    const summary = buildDaySummary(state, 1);
+
+    assert.equal(summary.eventCount, 3);
+    assert.deepEqual(summary.eventTypeCounts, {
+        'task.completed': 1,
+        'travel.arrived': 1,
+        'project.completed': 1,
+    });
+    assert.deepEqual(summary.categoryCounts, { work: 1, travel: 1, projects: 1 });
+    assert.deepEqual(summary.notableEvents.map((event) => event.type), [
+        'task.completed',
+        'travel.arrived',
+        'project.completed',
+    ]);
+});
+
+test('same-time higher-priority interrupt finalizes the day but remains the surfaced interrupt', () => {
+    const state = createInitialState();
+    state.worldTime.totalSeconds = SECONDS_PER_DAY - 5;
+    ensureDayCycleState(state);
+
+    const result = advanceSimulationWithDayPolicy(state, 20, {
+        candidates: [{
+            id: 'midnight-ambush',
+            type: 'combat.encounter',
+            atWorldSeconds: SECONDS_PER_DAY,
+            data: { enemyId: 'orc' },
+        }],
+    });
+
+    assert.equal(result.code, 'day.interrupted');
+    assert.equal(result.data.interrupt.id, 'midnight-ambush');
+    assert.equal(result.data.secondsAdvanced, 5);
+    assert.equal(state.dayCycle.lastFinalizedDay, 1);
+    assert.equal(getLatestDaySummary(state).day, 1);
+    assert.equal(state.simulation.paused, false);
+});
+
+test('day transition emits structured day-ended and day-started events', () => {
+    const state = createInitialState();
+    setEndOfDayPause(state, false);
+    ensureDayCycleState(state);
+
+    advanceSimulationWithDayPolicy(state, SECONDS_PER_DAY);
+
+    const dayEvents = listSemanticEvents(state).filter((event) => event.type.startsWith('day.'));
+    assert.deepEqual(dayEvents.map((event) => event.type), ['day.ended', 'day.started']);
+    assert.equal(dayEvents[0].data.day, 1);
+    assert.equal(dayEvents[1].data.day, 2);
+});
+
+test('older saves initialize day-cycle bookkeeping at the current completed-day boundary', () => {
+    const state = createInitialState();
+    delete state.dayCycle;
+    state.worldTime.totalSeconds = (3 * SECONDS_PER_DAY) + 500;
+
+    const dayCycle = ensureDayCycleState(state);
+
+    assert.equal(dayCycle.lastFinalizedDay, 3);
+    assert.deepEqual(dayCycle.summaries, []);
+    assert.equal(state.version, 4);
+});

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -14,8 +14,8 @@ import {
 
 
 test('version manifest separates product package and persistence versions', () => {
-    assert.equal(PRODUCT_VERSION, '0.5.300.0');
-    assert.equal(PACKAGE_VERSION, '0.5.300');
+    assert.equal(PRODUCT_VERSION, '0.5.500.0');
+    assert.equal(PACKAGE_VERSION, '0.5.500');
     assert.equal(VERSION.product, PRODUCT_VERSION);
     assert.equal(VERSION.package, PACKAGE_VERSION);
     assert.equal(VERSION.app, PRODUCT_VERSION);
@@ -24,19 +24,21 @@ test('version manifest separates product package and persistence versions', () =
     assert.equal(VERSION.data, 13);
     assert.equal(VERSION.benchmark, 1);
     assert.equal(VERSION.save, VERSION.accountSave);
-    assert.match(describeVersion(), /Product: 0\.5\.300\.0/);
-    assert.match(describeVersion(), /Package: 0\.5\.300/);
+    assert.match(describeVersion(), /Product: 0\.5\.500\.0/);
+    assert.match(describeVersion(), /Package: 0\.5\.500/);
     assert.match(describeVersion(), /Account Save: 4/);
     assert.match(describeVersion(), /Game State: 4/);
-    assert.match(describeVersion(), /Codename: Canonical Timed Tasks/);
+    assert.match(describeVersion(), /Codename: Day Boundary Review/);
     assert.match(describeVersion(), /Compatibility: migrate-supported-save-versions/);
-    assert.match(describeSystemVersions(), /versionManifest: 0\.5\.300/);
+    assert.match(describeSystemVersions(), /versionManifest: 0\.5\.500/);
     assert.match(describeSystemVersions(), /saveMigrations: 0\.2\.0/);
     assert.match(describeSystemVersions(), /actionResults: 0\.1\.0/);
     assert.match(describeSystemVersions(), /semanticEvents: 0\.1\.0/);
     assert.match(describeSystemVersions(), /worldTime: 0\.2\.0/);
-    assert.match(describeSystemVersions(), /simulationControl: 0\.1\.0/);
+    assert.match(describeSystemVersions(), /simulationControl: 0\.3\.0/);
+    assert.match(describeSystemVersions(), /simulationInterrupts: 0\.1\.0/);
     assert.match(describeSystemVersions(), /timedTasks: 0\.1\.0/);
+    assert.match(describeSystemVersions(), /dayCycle: 0\.1\.0/);
     assert.match(describeSystemVersions(), /validation: 0\.7\.0/);
     assert.match(describeSystemVersions(), /travel: 0\.4\.2/);
     assert.match(describeSystemVersions(), /characterCreation/);

--- a/tests/simulationControlEngine.test.js
+++ b/tests/simulationControlEngine.test.js
@@ -5,18 +5,30 @@ import { createInitialState } from '../js/text/gameState.js';
 import { listSemanticEvents } from '../js/text/systems/semanticEventEngine.js';
 import {
     createSimulationAdvanceDriver,
+    ensureSimulationControlState,
     pauseSimulation,
     resumeSimulation,
+    setEndOfDayPause,
     setSimulationSpeed,
     validateSimulationControlState,
 } from '../js/text/systems/simulationControlEngine.js';
 
 
-test('new games start running at normal simulation speed', () => {
+test('new games start running at normal simulation speed with end-of-day review enabled', () => {
     const state = createInitialState();
 
-    assert.deepEqual(state.simulation, { paused: false, speedMultiplier: 1 });
+    assert.deepEqual(state.simulation, { paused: false, speedMultiplier: 1, endOfDayPause: true });
     assert.deepEqual(validateSimulationControlState(state.simulation), []);
+});
+
+test('older simulation-control state lazily acquires end-of-day preference', () => {
+    const state = createInitialState();
+    delete state.simulation.endOfDayPause;
+
+    const simulation = ensureSimulationControlState(state);
+
+    assert.equal(simulation.endOfDayPause, true);
+    assert.equal(state.version, 4);
 });
 
 test('pause and resume change simulation control without advancing world time', () => {
@@ -49,6 +61,18 @@ test('speed control accepts arbitrary whole-number multipliers within the engine
     assert.equal(state.simulation.speedMultiplier, 60);
     const [event] = listSemanticEvents(state, { type: 'simulation.speed-changed' });
     assert.deepEqual(event.data, { previousSpeed: 1, speedMultiplier: 60, paused: false });
+});
+
+test('end-of-day pause preference can be disabled and emits structured change event', () => {
+    const state = createInitialState();
+
+    const result = setEndOfDayPause(state, false);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.code, 'simulation.end-of-day-pause-changed');
+    assert.equal(state.simulation.endOfDayPause, false);
+    const [event] = listSemanticEvents(state, { type: 'simulation.end-of-day-pause-changed' });
+    assert.deepEqual(event.data, { previousEndOfDayPause: true, endOfDayPause: false });
 });
 
 test('scheduled advancement converts wall elapsed time into deterministic simulated seconds', () => {
@@ -107,4 +131,13 @@ test('invalid speed values are rejected without mutating simulation state', () =
         assert.equal(result.code, 'simulation.invalid-speed');
         assert.equal(state.simulation.speedMultiplier, 1);
     }
+});
+
+test('invalid end-of-day pause values are rejected without mutation', () => {
+    const state = createInitialState();
+
+    const result = setEndOfDayPause(state, 'no');
+
+    assert.equal(result.ok, false);
+    assert.equal(state.simulation.endOfDayPause, true);
 });


### PR DESCRIPTION
## Target

`0.5.500` — deterministic day boundaries and end-of-day review, rebuilt on the merged 0.5.400 interrupt foundation.

## Changes

- adds `dayCycleEngine` with deterministic midnight interrupt scheduling
- records bounded structured day summaries from semantic events
- emits `day.ended` / `day.started` events
- enables end-of-day pause by default and exposes a validated `setEndOfDayPause` preference
- lazily upgrades older Game State v4 simulation-control state without a save-version bump
- preserves higher-priority same-time interrupts while still finalizing the completed day
- advances manifest/package metadata to 0.5.500 and records interrupt/day-cycle system versions
- removes FFXI-specific language from the package description; broader world/content renaming follows before content-database expansion

## Why this replaces #307

#307 was opened before 0.5.400 merged and therefore tested without `simulationInterruptEngine`; it also referenced an end-of-day simulation preference that had not been implemented. This PR is based on current `main` and includes the missing preference implementation and compatibility tests.

## Tests

Adds day-boundary/EOD tests plus simulation-control preference and legacy-state coverage. Full repository tests and benchmark gate run in CI.

## Next

Before resource/ecology/content database expansion, perform the planned world-identity/canonical-nomenclature migration so new content is authored under original names and stable IDs rather than legacy FFXI terminology.