### PR TITLE
Rebaseline roadmap for original world and content-scale architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# FFXI Text RPG
+# Hearth & Horizon
 
-A text-first fantasy life RPG foundation inspired by the weight, preparation, dangerous travel, equipment, mastery, jobs/disciplines, and earned accomplishment of Final Fantasy XI.
+**Working title.** This repository is a text-first persistent fantasy life RPG about building one continuous character and life across a connected world of settlements, roads, wilderness, livelihoods, relationships, trade, exploration, and danger.
 
-This is **not** intended to become a text transcription of retail FFXI. The long-term game is a persistent life/adventure RPG built around simulated time, measurable mastery, livelihoods, projects, infrastructure, relationships, logical loadouts, exploration, and a continuous character who can develop across multiple disciplines.
+Earlier versions of the project grew from FFXI-derived experiments. Those files may remain temporarily as research, migration, or comparison material, but the canonical game is now an **original setting with original world identifiers, cultures, disciplines, creatures, NPCs, quests, and content databases**.
 
 Core progression law:
 
@@ -10,19 +10,17 @@ Core progression law:
 effort -> mastery -> efficiency -> capability -> larger ambition
 ```
 
-The browser UI is canvas-first and text-led. Restrained icons, tokens, meters, cards, and diagrams are welcome when they improve comprehension without turning the project into a full graphical-world production.
+The browser presentation is canvas-first and text-led. Prose and imagination render most of the world; restrained maps, icons, tokens, meters, cards, and diagrams can improve comprehension without turning the project into a full graphical-world production.
 
 ## Current version
 
-At the 0.4 foundation exit gate:
-
 ```text
-Product:      0.4.900.0
-Package:      0.4.900
+Product:      0.5.500.0
+Package:      0.5.500
 Account Save: 4
-Game State:   3
+Game State:   4
 Data:         13
-Codename:     Foundation Exit Gate
+Codename:     Day Boundary Review
 ```
 
 Product versions use:
@@ -38,14 +36,14 @@ MAJOR.PHASE.TRACK.REVISION
 ## Read these first
 
 1. `docs/DEVELOPMENT_DIRECTION.md` — design north star.
-2. `docs/VERSIONING_AND_RELEASE_ROADMAP.md` — version protocol and detailed route to 1.0.
-3. `docs/TRANSITIONAL_ARCHITECTURE.md` — temporary seams and migration constraints.
-4. `docs/ROADMAP.md` — current phase index.
-5. `docs/PHASE_0_4_EXIT_GATE.md` — evidence for closing the foundation phase.
-6. `docs/THREAD_HANDOFF.md` — current repo state and immediate sequence.
-7. `docs/ARCHITECTURE.md` — current runtime/module boundaries.
+2. `docs/WORLD_IDENTITY_AND_CONTENT_POLICY.md` — original-world naming, legacy-data boundaries, resource provenance, content scale, and content-pack rules.
+3. `docs/ROADMAP.md` — current phase and implementation sequence.
+4. `docs/VERSIONING_AND_RELEASE_ROADMAP.md` — detailed version/release gates.
+5. `docs/TRANSITIONAL_ARCHITECTURE.md` — temporary seams and migration constraints.
+6. `docs/ARCHITECTURE.md` — current runtime/module boundaries.
+7. `docs/THREAD_HANDOFF.md` — implementation handoff notes.
 
-`docs/planning/DEVELOPMENT_PIPELINE_AND_MILESTONES.md` is superseded historical planning from the earlier formula-first direction.
+Older planning documents may describe superseded FFXI-oriented or formula-first assumptions and should not override the authoritative files above.
 
 ## Running
 
@@ -86,39 +84,101 @@ GitHub Actions runs the test and benchmark gate for pull requests and pushes to 
 
 ## Product direction in brief
 
-### Continuous character, not magical job switching
+### One person, many disciplines
 
 Long-term rule:
 
 ```text
-Jobs describe.
+Disciplines describe.
 Capabilities enable.
-Loadouts constrain and enhance.
+Loadouts and preparation constrain and enhance.
 ```
 
-Jobs remain recognizable disciplines/training traditions, but changing equipment should not magically replace the character's identity or erase learned knowledge.
+The current job-switch scaffold is transitional. A learned technique, spell, recipe, or practical capability ultimately belongs to the character. Actual use depends on real prerequisites such as proficiency, equipment, focus, ammunition, tools, reagents, resources, injury/status, terrain/context, and formal advanced training where the fiction requires it.
 
-Capabilities may cross traditional job boundaries when their real prerequisites are met: proficiency, equipment, focus, ammunition, tools, reagents, resources, condition, preparation, context, and formal advanced training where logically required.
-
-The current `mainJob`/support-job/current-job code remains transitional compatibility scaffolding until the 0.6 migration. See `docs/TRANSITIONAL_ARCHITECTURE.md` before expanding job-gated behavior.
-
-### Long fictional time without unnecessary real waiting
+### Long fictional time without needless real waiting
 
 Simulation time and wall-clock time are separate.
 
-The game may contain substantial fictional grind while still allowing pause, fast-forward, exact advancement, advance-to-completion, and advance-until-interrupt. End-of-day review should make cumulative progress legible.
+The game can contain substantial fictional grind while still allowing pause, fast-forward, exact deterministic advancement, timed tasks, advance-until-interrupt, and end-of-day review.
 
-The existing `tickEngine.js` is only a wall-clock scheduler/dispatcher. It is not the canonical game calendar.
+Current main includes:
 
-### Logical resource scaling
+- canonical deterministic world time;
+- pause and simulation speed control;
+- canonical timed tasks;
+- deterministic simulation interrupts;
+- structured day boundaries and end-of-day review.
 
-Repeated identical construction should not become exponentially more expensive merely because another copy already exists.
+### A home base, not a one-city game
 
-Resource demand should grow through physical scale, larger structures, upgrades, renovation, specialization, logistics, automation, capacity, transport, maintenance, quality, and ambitious regional/prestige projects.
+The player may establish a room, home, workshop, farm, camp, or other foothold. That base matters for storage, recovery, preparation, relationships, and production, but the world extends well beyond it.
 
-### Life and adventure are one loop
+The target world contains multiple major cities, smaller settlements, roads, wilderness, mines, ports, ruins, dungeons, caravans, ferries, mounts/pack logistics, trade routes, and regional economies.
 
-The first representative target is **A Week Beyond the West Gate**: a multi-day slice combining origin, home foothold, livelihood, local economy, project progress, preparation, travel, danger/combat, recovery, end-of-day review, and a permanent accomplishment.
+Internal data partitions support maps and simulation, but player-facing travel should usually read as continuous geography rather than artificial `ZONE LOADING` screens.
+
+### Maps are knowledge
+
+Maps can be owned, purchased, discovered, incomplete, or supplemented by exploration and NPC directions.
+
+The player should discover routes, landmarks, hazards, resources, services, and shortcuts rather than automatically possessing omniscient world navigation.
+
+### Resource provenance instead of reward confetti
+
+A defeated creature should not automatically manufacture finished crafting materials in inventory.
+
+Depending on context, rewards may require:
+
+- searching carried belongings;
+- skinning/butchering/plucking;
+- recovering bone, horn, shell, glands, venom, or other useful parts;
+- dismantling constructs;
+- mining/logging/foraging/fishing/trapping;
+- salvage;
+- crafting/processing;
+- commerce, wages, contracts, reputation, or quest rewards.
+
+Tools, time, proficiency, condition, carrying capacity, and player choice should matter.
+
+### Materials circulate through the economy
+
+```text
+world source
+  -> raw material
+  -> processing
+  -> component/ingredient
+  -> finished good
+  -> use/wear/consumption
+  -> repair/recycling/salvage or replacement
+```
+
+Items should have intentional sources and sinks. Gathering, crafting, cooking, shops, quests, construction, equipment, travel, and regional trade should consume the same material world.
+
+### Content breadth is an engineering requirement
+
+The intended game ultimately needs hundreds to thousands of interconnected records: places, NPCs, creatures, flora/resources, items, recipes, abilities, quests, relationships, shops, and transport routes.
+
+The project therefore does not treat content as a late decorative layer. Mechanics and representative content grow together, with regional content packs and cross-reference validation rather than a few toy records or giant unvalidated files.
+
+## Original setting migration
+
+The immediate next runtime track is:
+
+```text
+0.5.550 — Original-world identity and canonical nomenclature
+```
+
+Before high-volume content databases are expanded, current inherited world/race/job/currency/creature/NPC terminology and stable IDs will be migrated to the original setting described in `docs/WORLD_IDENTITY_AND_CONTENT_POLICY.md`.
+
+The initial world anchors are:
+
+- **Thornwall** and the **Elderwood** region;
+- **Brasshaven** and the **Redstone Reach**;
+- **Mistmere** and the **Starfen**;
+- future central trade hub **Waymeet**.
+
+These are starting anchors, not the whole world.
 
 ## Current architecture
 
@@ -151,73 +211,35 @@ tests/
 docs/
 ```
 
-## 0.4 foundation delivered
+## What is implemented versus what is still sparse
 
-The current foundation includes:
+The repository already has useful foundations for:
 
-- canvas-first text UI and command adapters;
-- account/character local saves;
-- four-part product versioning separated from package SemVer;
-- ordered persistence migrations;
+- account/character local saves and ordered migrations;
 - structured player/NPC/enemy entities;
-- places, San d'Oria coordinates, navigation, atlas, travel and aggro scaffolds;
-- POIs, shops, guild hooks and starter quest hooks;
+- places, maps, coordinates, navigation, travel, and aggro;
+- POIs, shops, guild/quest hooks;
 - inventory/storage/wardrobes;
-- item schema, equipment, inspection, buying and selling;
-- character-owned skills and deterministic representative skill-gain hooks;
-- battle/reward/EXP/loot/status/RNG scaffolds;
-- versioned `ActionResult` with travel-start pilot;
-- bounded semantic events with travel start/arrival pilot;
-- validation, tests, benchmarks, CI, database registry and system-version tracking;
-- explicit transitional architecture rules for world time and future capability work.
+- item schema, equipment, inspection, buying/selling;
+- character-owned skills and progression scaffolds;
+- battle/reward/EXP/status/RNG scaffolds;
+- `ActionResult` and semantic events;
+- canonical simulation time/tasks/interrupts/day review;
+- validation, tests, benchmarks, CI, database registry, and system-version tracking.
 
-This breadth is foundation code, not evidence that the product is near content completion.
+This is **foundation breadth, not content completion**. Current canonical monster, item, shop, quest, magic, relationship, companion, crafting, and regional catalogs are far below the intended scale and several still carry inherited naming that will be migrated before expansion.
+
+See `docs/SYSTEM_CATALOG.md` for a system-by-system status audit.
 
 ## Command compatibility
 
-The canvas input accepts bare gameplay commands plus leading-slash account/menu or compatible FFXI-style commands.
-
-Representative gameplay commands:
-
-```text
-look
-stats
-skills
-inventory
-equipment
-here
-move n
-travel West Ronfaure
-wait 60
-battle
-item Bronze Sword
-equip Bronze Sword
-shop Ashene
-buy Bronze Sword
-sell Bronze Sword
-validate
-save
-```
-
-Representative account/menu commands:
-
-```text
-/menu
-/commands
-/help
-/newcharacter
-/characters
-/load <name|number>
-/save
-/account
-/reset
-```
-
 Typed commands remain a powerful adapter/debug interface. Normal play should increasingly expose discoverable UI actions so command memorization is not required.
+
+Current examples may still contain inherited names until the 0.5.550 migration lands. After that track, examples and saved identifiers should use only canonical original-world vocabulary except inside explicit legacy adapters/migration tests.
 
 ## Save model
 
-Current localStorage keys:
+Current localStorage keys still use historical project identifiers and may be migrated later under an explicit compatibility plan:
 
 ```text
 ffxiTextRpgAccounts
@@ -232,44 +254,28 @@ base64-json-v1
 
 This is encoding, not cryptographic protection.
 
-Ordered migrations handle registered persistent-version transitions. `reviveGameState()` remains responsible for post-JSON reference repair such as relinking `player.inventory` to the Inventory container.
+Ordered migrations handle registered persistent-version transitions. `reviveGameState()` remains responsible for post-JSON reference repair such as relinking inventory container references.
 
-## New integration seams
+## Formula and research policy
 
-### ActionResult
+Formula confidence stays explicit:
 
-`js/text/systems/actionResult.js` separates semantic action outcome/code/data from display prose. Non-enumerable `.message` / `.reason` aliases exist only for transitional command compatibility.
-
-### Semantic events
-
-`js/text/systems/semanticEventEngine.js` provides bounded observational events with stable sequential IDs/types. Events are not event sourcing and are not authoritative state history.
-
-Travel currently emits:
-
-```text
-travel.started
-travel.arrived
-```
-
-Future objectives, achievements, day summaries, projects, and relationship reactions should consume structured event data rather than parse command-log prose.
-
-## Formula policy
-
-Formula confidence must remain explicit:
-
-- exact / sourced;
+- exact/sourced;
 - researched approximation;
 - intentional simplification;
 - placeholder.
 
-Formula refinement matters, but it does not lead the roadmap. Improve formulas when they materially improve a meaningful player-facing loop.
+Historical games may inform research, pacing, or structural comparisons, but they do not define canonical names, balance, or content. Formula refinement matters when it materially improves a real player-facing loop at representative data scale.
 
-## Immediate next implementation target
-
-After the 0.4.900 integration gate passes and merges:
+## Immediate implementation sequence
 
 ```text
-0.5.100 — Deterministic world clock
+0.5.550  Original-world names and stable-ID/save migration
+0.5.600  Resource provenance, body processing, persistent projects
+0.5.650  Ecology, gathering sources, spawn populations
+0.5.700  Timed routes and scheduled caravans/transport
+0.5.800  Regional content packs, normalization tools, cross-reference validation
+0.5.900  Simulation/content-substrate exit gate
 ```
 
-That pass should add canonical simulated time, exact deterministic advancement, derived day/time inspection, rollover tests, and **no dependency on `Date.now()` for canonical simulation state**.
+High-volume item/monster/quest/recipe generation starts only after the canonical identity migration is complete.

--- a/docs/DEVELOPMENT_DIRECTION.md
+++ b/docs/DEVELOPMENT_DIRECTION.md
@@ -1,26 +1,27 @@
 # Development Direction
 
-This document is the design north star for the project. It defines what the game is trying to become, the design laws that should survive implementation changes, and the architectural direction that future work should follow.
+This document is the design north star for the project. It defines the product laws that should survive implementation changes and the architectural direction that future work should follow.
 
-It supersedes the earlier assumption that the project roadmap should primarily be driven by reconstructing FFXI formulas or feature breadth. FFXI remains an important source of tone, weight, progression philosophy, jobs, equipment, travel danger, and long-form accomplishment, but the project is not intended to become a text transcription of retail FFXI.
+The project is an **original text-first persistent fantasy life RPG**, currently using the working title **Hearth & Horizon**. Earlier FFXI-derived code and data remain useful research/reference material, but inherited world identity, proper nouns, class terminology, and content catalogs are not the target product.
+
+`docs/WORLD_IDENTITY_AND_CONTENT_POLICY.md` is authoritative for original-setting nomenclature, legacy-data boundaries, content provenance, scale targets, and content-pack rules.
 
 ## Product identity
 
-The target is a long-form, text-first fantasy life RPG in which an ordinary character gradually builds a livelihood, home, skills, relationships, reputation, and material capability while venturing into an increasingly dangerous world.
+The player develops one continuous person and one persistent life across a connected fantasy world.
 
-The intended experience combines:
+The game combines:
 
-- the weight, preparation, danger, mastery, and earned accomplishment associated with older FFXI;
-- the incremental life-building structure of games such as Rune Factory and Fantasy Life;
-- the measurable long-horizon progress of incremental games without requiring real-world waiting;
-- tabletop-style presentation where prose and imagination do most of the rendering while icons, tokens, cards, meters, and diagrams communicate state;
-- a deterministic, testable simulation foundation that can support large amounts of authored content without tying game logic to the UI.
+- meaningful preparation, travel danger, mastery, equipment choice, and earned accomplishment;
+- life-building through livelihood, property, tools, relationships, reputation, and infrastructure;
+- long-horizon progress without requiring avoidable real-world waiting;
+- a sandbox world where cities, smaller settlements, roads, wilderness, dungeons, caravans, ferries, resources, creatures, and economies belong to the same simulation;
+- tabletop-style presentation where prose and imagination render most of the world while restrained maps, icons, cards, meters, tokens, and diagrams make state legible;
+- deterministic, testable systems capable of supporting thousands of cross-linked content records without tying game logic to the UI.
 
-The player should feel that they are developing one continuous person and one persistent life, not switching between disconnected game modes.
+The game should not feel like several disconnected minigames joined by menus. Hunting, gathering, work, crafting, trade, quests, relationships, travel, combat, and home-building should continually feed one another.
 
 ## Core progression law
-
-The primary progression loop is:
 
 ```text
 effort -> mastery -> efficiency -> capability -> larger ambition
@@ -29,329 +30,484 @@ effort -> mastery -> efficiency -> capability -> larger ambition
 Progression should not primarily be:
 
 ```text
-effort -> arbitrary larger denominator -> same activity again
+effort -> arbitrary larger denominator -> identical activity again
 ```
 
-Repeated work may take substantial simulated time and may require substantial resources, but it should leave measurable residue: improved proficiency, better tools, better infrastructure, new options, reduced labor, improved yield, safer travel, better preparation, or access to more ambitious work.
+Repeated work may consume substantial fictional time and resources, but it should leave residue:
 
-Earlier chores should eventually consume less player attention because the character has earned ways to perform them more efficiently.
+- improved proficiency;
+- learned capabilities;
+- better tools or equipment;
+- improved infrastructure;
+- stronger relationships/reputation;
+- better maps and route knowledge;
+- reduced labor or safer travel;
+- better yield/quality;
+- access to more ambitious projects, regions, services, or training.
+
+Earlier chores should eventually demand less player attention because the character has earned ways to perform them more efficiently.
 
 ## Long-duration play without real-time punishment
 
-The game should support long fictional timescales and meaningful grind while respecting real player time.
-
 Simulation time and wall-clock time are separate concepts.
 
-A four-hour fictional task should consume four hours of world time whether the player watches it at normal speed, fast-forwards, advances directly to completion, or advances until a meaningful interrupt occurs.
+A four-hour fictional task consumes four hours of world time whether the player watches it, fast-forwards, advances directly to completion, or advances until a meaningful interrupt occurs.
 
-The player pays with character time, resources, risk, preparation, and opportunity cost. They should not be forced to pay with avoidable real-world waiting.
+The player pays with character time, resources, risk, preparation, fatigue/opportunity cost, and world consequences. The player should not be forced to pay with needless real-world waiting.
 
-### Time controls
+The simulation should support:
 
-The intended simulation eventually supports:
-
-- normal-speed ticking;
+- normal-speed progression;
 - pause;
 - configurable fast-forward;
 - advance-to-task-completion;
 - advance-to-next-event;
-- end-of-day auto-pause;
-- meaningful interrupts such as combat, exhaustion, tool failure, project completion, major NPC events, dangerous weather, or important unlocks.
+- day-boundary review;
+- meaningful interrupts such as combat, exhaustion, tool failure, dangerous weather, project completion, NPC events, transport arrival, or important discoveries.
 
-Hardcore modes may restrict pauses, saving, injury tolerance, or event handling, but should not simply force slower real-world waiting.
+Hardcore modes may restrict saving, injury tolerance, pause behavior, or information, but should not simply turn fictional duration into mandatory wall-clock waiting.
 
 ## End-of-day review
 
-Standard play should default to an end-of-day decision pause.
+Standard play defaults to an end-of-day pause/review.
 
-The day summary should make progress legible without forcing the player to watch every low-value tick. Useful summary categories include:
+A useful day summary can include:
 
-- work completed;
-- resources gained or spent;
-- skill/proficiency changes;
+- work and travel completed;
+- resources acquired/spent/processed;
+- skill/proficiency/capability gains;
 - project progress;
-- notable encounters;
+- notable encounters/discoveries;
 - relationship/reputation changes;
-- injuries, fatigue, equipment wear, or shortages;
+- injuries, fatigue, tool/equipment wear, shortages, or failed work;
 - newly available opportunities;
-- reminders for tomorrow.
+- reminders or commitments for the next day.
 
-The player should be able to inspect state, plan, save/quit, or immediately continue.
+The player can inspect, plan, save/quit, or continue.
+
+## The world is larger than the home base
+
+The player may build a meaningful foothold, home, workshop, room, farm, camp, or property, but that location is not the entire game.
+
+The world should support:
+
+- multiple major cities and regional hubs;
+- smaller towns, villages, camps, forts, mines, ports, monasteries/colleges, farms, and roadside services;
+- wilderness routes and landmarks;
+- caves, ruins, dungeons, resource sites, and dangerous regions;
+- caravan roads and scheduled transport;
+- ferries and other waterways;
+- mounts, hired transport, pack animals, or equivalent logistics where appropriate;
+- trade and production differences that create real reasons to travel.
+
+A home base creates storage, preparation, social, production, and recovery advantages. Travel expands what the character can know, acquire, learn, sell, build, and become.
+
+## Internal world partitions are not mandatory player-facing zones
+
+The engine may partition geography into places, regions, route segments, cells, maps, encounter populations, or streaming/content units. These boundaries are implementation and navigation tools.
+
+Player-facing transitions should usually be expressed naturally through geography and prose rather than artificial level-loading language.
+
+Example:
+
+A paved road narrowing into forest track, a ridge opening onto dry uplands, or cultivated outskirts giving way to marsh can mark an internal dataset transition without announcing a gamey `ZONE CHANGE`.
+
+Hard boundaries remain appropriate where the fiction calls for them: gates, ferries, passes, locked doors, border controls, dungeon entrances, magical barriers, etc.
+
+## Maps are knowledge
+
+Maps are not merely menus containing automatically known coordinates.
+
+A character may:
+
+- own or borrow maps;
+- discover routes without owning a formal map;
+- buy incomplete regional maps;
+- learn landmarks from NPC directions;
+- reveal terrain/routes through exploration;
+- annotate resource sites, hazards, shortcuts, camps, ruins, and services;
+- know that a destination exists without knowing the safest/fastest route.
+
+Map knowledge should improve navigation, planning, route confidence, and transport decisions without requiring graphical terrain rendering.
+
+## Resource provenance is gameplay
+
+Rewards should normally have a physical, economic, or social explanation.
+
+Combat against a creature can create access to a body; it does not automatically manufacture finished crafting materials in inventory.
+
+Depending on creature and context, the player may need to:
+
+- search carried belongings;
+- skin or flay;
+- butcher/dress meat;
+- recover bone, horn, teeth, feathers, shell, glands, venom, organs, or other useful parts;
+- dismantle/salvage a construct;
+- spend tools and fictional time;
+- possess enough knowledge/proficiency to recover delicate material;
+- choose which outputs are worth weight, time, spoilage, or inventory space.
+
+Likewise, environmental resources come from places that support them:
+
+- plants/fungi through foraging/harvesting;
+- timber through logging;
+- ore/stone/clay through mining/quarrying/digging;
+- fish/shellfish through fishing/trapping/shore gathering;
+- salvage through ruins, machinery, containers, wrecks, and discarded equipment.
+
+Exceptional magical creation is allowed when the world explicitly supports it, but unexplained reward confetti should not be the default economy.
+
+## Materials circulate through the world
+
+The economy spine is transformation and use:
+
+```text
+world source
+  -> raw material
+  -> processing
+  -> component/ingredient
+  -> finished good
+  -> use/wear/consumption
+  -> repair/recycling/salvage or replacement
+```
+
+A raw resource should ideally participate in multiple decisions rather than one recipe.
+
+Example:
+
+```text
+small game carcass
+  -> meat -> meals/preservation/bait/contracts
+  -> hide -> tanning -> leather -> equipment/tools
+  -> bone -> craft components/glue/medicine/decorative goods
+```
+
+Items need sources and sinks. Regional economies need demand beyond vendors buying infinite junk.
+
+## Gathering and crafting are world systems, not menu checklists
+
+Gathering depends on:
+
+- geography/habitat;
+- tool suitability;
+- proficiency;
+- time;
+- resource condition/quality;
+- depletion/regeneration or population logic where useful;
+- danger/weather/time-of-day where meaningful;
+- storage/encumbrance/logistics.
+
+Crafting/processing depends on:
+
+- real ingredients/components;
+- tools/stations/facilities;
+- time and labor;
+- proficiency/knowledge;
+- recipe/process discovery or instruction where appropriate;
+- quality and byproducts where they create useful choices;
+- regional access to materials and services.
+
+Cooking, medicine/alchemy, smithing, woodworking, leatherwork, textiles, construction, repair, and other disciplines should exchange materials rather than live in isolated inventories.
 
 ## Construction and resource economy
 
-Construction costs should follow physical and economic logic, not arbitrary exponential repetition penalties.
+Construction costs follow physical/economic logic rather than arbitrary exponential repetition penalties.
 
-If one standard barn requires a particular amount of lumber, stone, fittings, and labor, a second identical barn under comparable conditions should cost approximately the same amount.
+A second comparable barn should cost approximately what a comparable barn physically requires. Costs legitimately change because of:
 
-Costs may legitimately change because of:
-
-- different size;
-- different materials;
-- difficult terrain;
+- size/design;
+- material choice;
+- terrain;
 - transport distance;
-- labor availability;
 - regional scarcity;
-- specialized machinery or magic;
+- labor availability;
+- specialized machinery/magic;
+- renovation constraints;
 - structural upgrades;
-- capacity expansion;
-- renovation complexity;
-- prestige or regional scale.
+- capacity and prestige requirements.
 
-The game should create long-term resource demand through expansion and sophistication rather than unexplained multipliers based only on how many copies the player has already built.
+Long-term resource sinks come from larger ambition:
 
-High-value resource sinks include:
+- more/larger buildings;
+- roads and bridges;
+- irrigation;
+- carts/wagons/boats;
+- workshops and specialized facilities;
+- storage and warehouses;
+- repairs and maintenance;
+- hired labor;
+- civic/regional projects;
+- prestige and high-complexity work.
 
-- larger structures;
-- renovations;
-- specialized facilities;
-- automation and labor-saving infrastructure;
-- storage and transport capacity;
-- roads, carts, warehouses, irrigation, and workshops;
-- equipment maintenance and replacement;
-- prestige projects;
-- civic or regional projects.
+## Disciplines are training traditions, not magical transformations
 
-## Jobs are disciplines, not magical transformations
+The final design does not treat a selected class/job as a magical state that rewrites the character.
 
-The project should retain recognizable jobs such as Warrior, White Mage, Black Mage, Red Mage, Thief, Ranger, Paladin, Dark Knight, Bard, and other fantasy disciplines, but a job is not a magical character state.
+A discipline is a recognized school, profession, guild tradition, martial method, magical curriculum, or social classification.
 
-A job is a recognized archetype, curriculum, training tradition, or classification of competencies.
-
-The character remains one continuous person. Equipping an axe does not transform the character into a Warrior. Equipping a staff does not transform the character into a Mage. Removing equipment does not cause learned knowledge to disappear.
-
-### Design vocabulary
+The character remains one person. Equipping a sword does not transform them into another identity; removing a focus does not erase learned magic.
 
 Use these concepts distinctly:
 
 | Term | Meaning |
 | --- | --- |
-| Discipline / Job | A recognized school, profession, archetype, or training tradition. |
-| Capability | A learned spell, technique, skill, trait, or other action the character knows. |
-| Proficiency | How practiced or competent the character is with a capability or skill domain. |
-| Loadout | The equipment and immediately prepared state that determines what the character can effectively do now. |
-| Preparation | Ammunition, reagents, focus items, stance, memorization/prepared actions, tools, mounts, supplies, or other contextual readiness. |
+| Discipline | Recognized training school/profession/archetype. |
+| Capability | Learned spell, technique, recipe knowledge, practical skill, trait, or action. |
+| Proficiency | Degree of practice/competence in a domain. |
+| Loadout | Equipment and immediately ready tools/supplies. |
+| Preparation | Ammunition, reagents, focus, stance, memorization, tools, mounts, provisions, companions, route plans, etc. |
 
-A useful rule is:
+Core rule:
 
 ```text
-Jobs describe.
+Disciplines describe.
 Capabilities enable.
-Loadouts constrain and enhance.
+Loadouts and preparation constrain and enhance.
 ```
 
-### Ability eligibility
-
-Ability use should eventually resolve from actual prerequisites rather than primarily from `currentJob`.
+### Capability eligibility
 
 A capability check may consider:
 
-- whether the character has learned the ability;
-- relevant proficiency or mastery;
-- required or preferred equipment;
-- required free hands, weapon family, shield, focus, ammunition, or tool;
-- MP, TP, stamina, charges, reagents, or other resources;
-- silence, injury, encumbrance, status effects, or environmental restrictions;
-- mounted, workshop, travel, terrain, or other context;
-- discipline-specific advanced training where instruction is genuinely required.
+- whether the character learned it;
+- proficiency/mastery;
+- hard equipment/tool requirements;
+- preferred/enhancing equipment;
+- free hands, weapon family, shield, focus, ammunition, reagent, station, mount, etc.;
+- MP/TP/stamina/charges/material resources;
+- silence, injury, fatigue, encumbrance, statuses;
+- terrain, workshop, travel, mounted, underwater, social, or other context;
+- formal certification/training when the fiction requires it.
 
-### Hard requirements, soft requirements, and enhancers
+### Hard, soft, and enhancing requirements
 
-Abilities should support three broad equipment/preparation relationships.
+**Hard requirement:** the action makes no sense without the prerequisite.
 
-**Hard requirement:** the action does not make sense without the prerequisite. Shield Bash requires a shield. Archery techniques require a bow and usable ammunition. Some rituals may require a focus.
+**Soft requirement:** the action is possible but inefficient, slower, weaker, riskier, or more expensive without preferred preparation.
 
-**Soft requirement:** the action is still possible, but the character is poorly prepared. A learned healing spell may be cast without a preferred wand or staff at increased resource cost, longer cast time, lower potency, or higher interruption risk.
+**Enhancer:** optional preparation improves the result without enabling the basic action.
 
-**Enhancer:** the item is not required but improves the action. A healing focus may improve potency or efficiency; specialist armor may improve interruption resistance.
-
-The exact penalties and bonuses should be data-driven, confidence-labeled, and balance-tested rather than hard-coded into command handlers.
+These relationships should be data-driven and testable.
 
 ### Cross-discipline use
 
-The design intentionally does not use FFXI's single support-job limitation as the primary capability gate.
+A character may combine capabilities associated with several disciplines if they know them and satisfy actual prerequisites.
 
-A character may use capabilities associated with several disciplines at the same time if they genuinely know those capabilities and satisfy their prerequisites.
+Balance comes from equipment slots, action economy, resources, encumbrance, preparation, proficiency, context, and opportunity cost—not from pretending learned knowledge disappears when a class toggle changes.
 
-The balancing constraint is that the character cannot optimally deploy everything simultaneously. Equipment, preparation, resources, encumbrance, action economy, proficiency, and context create the build boundaries.
+Advanced training can still require mentors, guild standing, certification, quests, reputation, prerequisite proficiencies, facilities, or difficult accomplishments.
 
-A heavily armored sword-and-shield character who studied restoration magic may still cast a basic heal, but may do so less efficiently than a character equipped and prepared as a dedicated healer.
+## Origins and starting circumstances
 
-### Discipline progression still matters
-
-Jobs remain meaningful because advanced techniques may require formal instruction, certification, guild standing, milestones, quests, mentors, or minimum proficiencies.
-
-A discipline can provide:
-
-- training paths;
-- advanced techniques;
-- specialist traits;
-- trainers and guilds;
-- titles and recognition;
-- access to equipment or facilities;
-- reputation and narrative identity;
-- shorthand for describing a loadout or play style.
-
-The important rule is that discipline identity should represent earned training, not a toggle that rewrites the character.
-
-## Origins and starting conditions
-
-Character creation should eventually move from a simple starting-job choice toward origin-based starting circumstances.
+Character creation should center on **where this person begins in life**, not merely a starting combat class.
 
 Origins may provide different:
 
-- starting tools;
-- equipment;
-- seeds or materials;
-- learned beginner capabilities;
-- local relationships;
-- debts, obligations, or reputation;
-- starting property or lodging;
+- lodging/property/camp context;
+- equipment and tools;
+- food/seeds/materials;
+- beginner capabilities;
+- relationships/contacts;
+- debts/obligations;
+- reputation;
 - starting proficiencies;
-- introductory objectives.
+- local maps/route knowledge;
+- introductory opportunities.
 
-Origins should not permanently lock later play. They change the opening and early constraints while allowing a character to learn other disciplines and livelihoods over time.
+Origins alter the opening without permanently locking later play.
 
-Examples include Homesteader, Guard, Apprentice, Hunter, Drifter, Craftsperson, or similar setting-appropriate backgrounds.
+## Preparation is gameplay
 
-## Preparation should be gameplay
+Before an expedition, workday, caravan trip, dungeon descent, hunting run, gathering route, delivery, or construction job, the player should decide what they are trying to accomplish.
 
-Before an expedition, the player should think about what they are trying to accomplish rather than selecting a magical class transformation.
+Different goals naturally favor different:
 
-A hunting trip, dungeon expedition, gathering run, escort mission, or construction supply trip should naturally favor different equipment and supplies.
-
-This gives long-term value to:
-
-- storage;
-- equipment collections;
+- equipment;
 - tools;
-- crafting;
-- mounts and pack animals;
-- carts;
-- homes and workshops;
-- consumables;
-- scouting and known routes;
-- relationships and local services.
+- food/water/medicine;
+- ammunition/reagents;
+- containers and carrying capacity;
+- maps and route knowledge;
+- companions;
+- transport;
+- weather/time planning;
+- spare equipment/repair supplies.
 
-Preparation should create meaningful tradeoffs without becoming inventory busywork.
+This creates value for homes, storage, workshops, equipment collections, crafting, mounts, pack animals, caravans, local services, and relationships without turning preparation into pointless inventory micromanagement.
+
+## NPCs are persistent world participants
+
+Important NPCs should eventually have some combination of:
+
+- home/work locations;
+- schedules/availability;
+- profession/services;
+- relationships/faction ties;
+- goals/needs;
+- dialogue state;
+- quest/contract involvement;
+- reputation reactions;
+- companion/romance eligibility where appropriate.
+
+The world needs broad service populations and a smaller set of deeply authored social characters.
+
+## Relationships and romance
+
+Social progression should not collapse every person into one universal affection meter.
+
+Possible dimensions include trust, respect, familiarity, attraction, rivalry, gratitude, fear, obligation, shared history, or faction/community standing when useful.
+
+Romance-capable characters should:
+
+- have goals and routines outside the player;
+- have boundaries and preferences;
+- react to meaningful choices and shared experiences;
+- not require identical gift-spam loops;
+- remain useful/interesting characters even if romance is never pursued.
+
+## AI party systems
+
+Companions are persistent characters, not summoned combat vending machines.
+
+A party member can have:
+
+- tactical role/preferences;
+- learned capabilities/proficiency;
+- equipment and consumables;
+- resource management;
+- injury/KO/recovery;
+- relationship state;
+- personal goals/quests;
+- willingness/availability constraints;
+- progression and changing behavior.
+
+Combat AI and relationship state should be separate systems that interact deliberately.
+
+## Content scale is part of architecture
+
+The target game requires hundreds to thousands of interconnected records. A subsystem validated only against five toy records is not necessarily validated for the product.
+
+Mechanics and content therefore grow together.
+
+Examples:
+
+- a crafting engine is tested against enough recipes to reveal categorization, lookup, dependency, and balance problems;
+- an ecology engine is tested against multiple families/habitats/variants rather than two starter enemies;
+- quest validation is tested across real cross-region objectives;
+- shops and regional economies are tested with meaningful inventories and resource chains;
+- relationship and companion systems are tested with multiple distinct behavior/personality patterns.
+
+See `WORLD_IDENTITY_AND_CONTENT_POLICY.md` for planning-scale ranges.
+
+## Content-pack architecture
+
+Author dense regional content packs that cross-link:
+
+- geography/routes/maps;
+- NPCs/services/shops;
+- ecology/resources;
+- items/recipes;
+- quests/contracts/rewards;
+- relationships/companions;
+- lore/descriptive text;
+- transport/economy.
+
+Do not build one enormous global hand-edited file for each category if regional ownership and validation can keep data more comprehensible.
+
+## Original setting and legacy research
+
+Canonical runtime content is original.
+
+Historical FFXI-derived data may remain temporarily for research, migration, formula comparison, or candidate-data normalization, but:
+
+- new canonical stable IDs must not be inherited FFXI proper nouns;
+- player-facing content must not present the world as FFXI;
+- imported structures require original names/context and review;
+- legacy modules must be clearly bounded from canonical data sources.
+
+The identity/stable-ID migration is intentionally scheduled before high-volume content expansion so this separation does not become prohibitively expensive later.
 
 ## Visual presentation policy
 
 The game remains text-first and imagination-led.
 
-Limited visual polish is encouraged when it improves comprehension or identity without creating a full graphical-world burden.
+Useful restrained visuals include:
 
-Appropriate visual elements include:
-
-- icons;
-- tokens;
-- status meters;
+- icons/tokens;
+- status/resource meters;
 - equipment silhouettes;
 - cards;
-- simple node diagrams;
-- maps represented as schematic/coordinate information;
-- project progress indicators;
+- node/route diagrams;
+- schematic/cartographic maps;
+- project progress;
 - day/time indicators;
-- relationship or reputation markers.
+- relationship/reputation markers;
+- simple party/tactics displays.
 
-The project should not pivot into sprite animation, full graphical terrain, cinematic rendering, or a large asset-production pipeline unless explicitly reconsidered later.
-
-## First lovable vertical slice
-
-The first substantial playable target should prove the life/adventure intersection rather than only combat or only farming.
-
-Working concept: **A Week Beyond the West Gate**.
-
-The slice should include:
-
-1. a small set of origins with different starting circumstances;
-2. a modest home base, room, plot, workshop access, or equivalent foothold;
-3. one simple livelihood/gathering loop;
-4. a local shop/economy loop;
-5. a persistent project that accumulates materials and labor;
-6. simulated days with end-of-day review;
-7. one meaningful expedition outside the city/gate;
-8. travel risk and at least one dangerous combat encounter;
-9. measurable proficiency or capability growth;
-10. return-home recovery and preparation;
-11. completion of something permanent that did not exist when the character began;
-12. a resulting unlock that opens the next layer of play.
-
-The first slice should make the player feel that a week of fictional life produced a materially different character and world state.
+The project does not require full graphical terrain, sprite animation, cinematic rendering, or a large art-asset pipeline to deliver its core promise.
 
 ## Architecture direction
 
-The current separation of data, state, systems, and UI remains appropriate. Do not rewrite the project simply to pursue the new direction.
+The separation of data, state, systems, and UI remains appropriate. Continue evolutionary change rather than another broad rewrite.
 
-Evolutionary priorities:
+Priorities:
 
-- add explicit ordered save migrations before persistent systems proliferate;
-- separate deterministic simulation time from wall-clock timer delivery;
-- define a canonical time-consuming action/task model used by travel, work, crafting, construction, farming, and other systems;
-- move toward structured action results instead of prose-only return values;
-- add lightweight semantic game events so quests, summaries, tests, achievements, and UI can react to meaning rather than parsing strings;
-- keep command input and UI controls as adapters into the same gameplay actions;
-- keep content data-driven and stable-ID based;
-- author dense regional content packs rather than broad shallow map coverage;
-- preserve formula confidence labels: exact/sourced, researched approximation, intentional simplification, placeholder;
-- avoid full event sourcing unless a later requirement justifies its complexity.
+- ordered save migrations before persistent state proliferates;
+- deterministic canonical world time;
+- common timed-action/task/project contracts;
+- structured action results and semantic events;
+- stable canonical IDs;
+- content-pack boundaries and cross-reference validation;
+- resource provenance and item source/sink validation;
+- ecology/population data separated from encounter instances;
+- UI/command input as adapters into shared gameplay actions;
+- formulas/values carrying confidence/provenance metadata when uncertain;
+- avoid full event sourcing unless a later requirement demonstrates its necessity.
 
-## Current transitional systems
+## Transitional systems
 
-Several current systems are useful foundations but should not be mistaken for final design commitments.
+Current systems that should not be mistaken for final commitments include:
 
-In particular:
+- legacy FFXI world/place/race/job/currency terminology;
+- `mainJobId` and job-switch assumptions;
+- current sparse job skill-cap tables;
+- placeholder combat magic/weapon-skill behavior;
+- automatic battle loot behavior that predates provenance/body-processing design;
+- wall-clock tick scheduling as distinct from canonical simulation time;
+- small starter item/shop/monster catalogs;
+- legacy `data/` modules and recovered FFXI reference datasets.
 
-- `mainJobId`, support-job assumptions, job-specific current-state checks, and current job switching are transitional;
-- job level data may later become discipline training/mastery data;
-- capability eligibility should gradually migrate away from a single current-job gate;
-- the existing wall-clock tick engine is a scaffold, not the final world-time model;
-- current formulas are executable scaffolds, not a requirement to reproduce retail FFXI exactly;
-- current San d'Oria content is a foundation for a dense region, not a mandate to reproduce every FFXI zone before the core game loop is fun.
+Replace these incrementally behind tested interfaces and explicit migrations.
 
-Do not rip these systems out in one broad rewrite. Replace assumptions incrementally behind tested interfaces.
+## Current priority order
 
-## Priority order
+1. complete deterministic time/tasks/interrupt/day-boundary foundation;
+2. migrate canonical runtime identity/stable IDs to the original setting;
+3. add provenance/projects/body processing;
+4. add ecology/gathering/spawn substrate;
+5. integrate timed routes and scheduled caravans/transport;
+6. establish regional content packs, import-normalization tools, and validators;
+7. complete character stats/proficiencies/disciplines/capabilities;
+8. build magic/ability and Combat 2.0;
+9. expand item/tool/equipment and production systems at meaningful data scale;
+10. add AI party/companions;
+11. expand into multiple connected regions/cities with real NPC populations/economies;
+12. add systemic quests/contracts/reputation;
+13. deepen relationships and romance;
+14. expand infrastructure/life systems and late adventure depth;
+15. release hardening at thousands-of-record scale.
 
-The broad priority order from the present repo is:
+## Decision test for substantial features
 
-1. lock development direction and version protocol;
-2. persistence/migration foundation;
-3. deterministic world time, pause, advance, and day boundaries;
-4. canonical tasks/projects and semantic action/event contracts;
-5. capability/discipline/loadout model and origins;
-6. first livelihood plus first-week vertical slice;
-7. infrastructure, construction, tools, farming/gathering depth, crafting, relationships, taming, and logistics;
-8. deeper adventure systems, magic, combat, objectives, and regional expansion;
-9. formula refinement where it materially improves an already-compelling game loop;
-10. release hardening and 1.0 content completeness.
+Before adding a major feature or content family, ask:
 
-The detailed release sequence and version-number protocol live in `docs/VERSIONING_AND_RELEASE_ROADMAP.md`.
+1. Does it help the player build persistent life, capability, relationships, knowledge, or infrastructure?
+2. Does it create a meaningful decision, risk, preparation need, tradeoff, or long-term ambition?
+3. Does mastery make repeated use more efficient, expressive, reliable, or valuable?
+4. Does it connect to at least one other world system?
+5. Does it fit a text-first UI without requiring a graphical-engine pivot?
+6. Can its state/behavior be tested deterministically?
+7. Can it scale to the content volume the final game needs?
+8. Does it belong to this original world rather than merely reproduce another game's proper nouns/content?
 
-## Non-goals for the near term
-
-Do not let the following become the roadmap spine before the first complete loop is proven:
-
-- exact retail FFXI formula reconstruction;
-- complete FFXI job/ability/spell coverage;
-- complete FFXI item database migration;
-- full auction-house/economy simulation;
-- broad map reproduction with low interaction density;
-- full graphical world rendering;
-- massive creature or recipe catalogs before one representative instance is fun;
-- arbitrary exponential construction costs;
-- real-world idle timers as a substitute for simulation depth.
-
-## Decision test for new features
-
-Before adding a substantial feature, ask:
-
-1. Does this help the player build a persistent life or capability?
-2. Does it create a meaningful decision, risk, preparation need, or long-term ambition?
-3. Does repeated use become more efficient or more expressive through mastery?
-4. Does it integrate with at least one other system rather than exist as an isolated checklist item?
-5. Can it be represented clearly in the text-first UI without demanding a graphical-engine pivot?
-6. Can its state and behavior be tested deterministically?
-7. Is the implementation appropriately scoped for the current release milestone?
-
-If the answer to most of these is no, the feature probably belongs later or should be redesigned.
+If the answer to several is no, redesign or defer it.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,30 +1,27 @@
 # Roadmap
 
-This is the current implementation summary and phase index for the text-first fantasy life RPG.
+This is the authoritative implementation summary and phase index for the original text-first persistent fantasy life RPG currently using the working title **Hearth & Horizon**.
 
 Authoritative companion documents:
 
 - `docs/DEVELOPMENT_DIRECTION.md` — design north star.
-- `docs/VERSIONING_AND_RELEASE_ROADMAP.md` — detailed version protocol and path to 1.0.
+- `docs/WORLD_IDENTITY_AND_CONTENT_POLICY.md` — original-setting, naming, content-provenance, scale, and import rules.
+- `docs/VERSIONING_AND_RELEASE_ROADMAP.md` — detailed version protocol and release gates.
 - `docs/TRANSITIONAL_ARCHITECTURE.md` — temporary seams that must not harden into final design.
-- `docs/PHASE_0_4_EXIT_GATE.md` — evidence for closing the foundation phase.
-- `docs/THREAD_HANDOFF.md` — current implementation handoff.
 - `docs/ARCHITECTURE.md` — current runtime/module boundaries.
 
 ## Current baseline
 
-Current 0.5 timed-task target:
-
 ```text
-Product:      0.5.300.0
-Package:      0.5.300
+Product:      0.5.500.0
+Package:      0.5.500
 Account Save: 4
 Game State:   4
 Data:         13
-Codename:     Canonical Timed Tasks
+Codename:     Day Boundary Review
 ```
 
-This remains pre-alpha product development. The version is a milestone identity, not a completion percentage.
+This remains pre-alpha product development. A milestone number identifies the active development contract; it is not a completion percentage.
 
 ## Product direction
 
@@ -34,200 +31,340 @@ Core progression law:
 effort -> mastery -> efficiency -> capability -> larger ambition
 ```
 
-The intended game is a persistent, long-form fantasy life RPG where work, infrastructure, relationships, preparation, travel, danger, combat, and exploration belong to one connected simulation.
+The intended game is one connected simulation of life, work, exploration, relationships, logistics, preparation, danger, combat, and long-term ambition.
 
 Key rules:
 
-- simulation time and real-world waiting are separate concepts;
-- identical construction does not receive arbitrary exponential cost multipliers;
-- mastered chores should eventually demand less player attention;
-- jobs remain recognizable disciplines, but do not magically replace the character's identity;
-- learned capabilities may cross discipline boundaries when equipment/preparation/proficiency/resource/context requirements are met;
-- text and imagination do most rendering while restrained icons/tokens/meters/diagrams may improve comprehension;
-- FFXI contributes weight, danger, preparation, equipment, mastery, and accomplishment, but retail feature/formula replication is not the roadmap spine.
+- fictional simulation time and real-world waiting are separate concepts;
+- the player controls one continuous person rather than switching magical class identities;
+- disciplines describe training traditions, capabilities enable actions, and loadouts/preparation constrain effective use;
+- settlements are social/economic/logistical places rather than isolated menus;
+- a home base may matter greatly, but the world is not confined to one city;
+- roads, wilderness, smaller settlements, caravans, ferries, mounts, and other transport connect a larger sandbox;
+- player-facing hard zone transitions are minimized; internal world partitions exist for simulation, navigation, maps, and data management;
+- maps represent acquired geographic knowledge and can be incomplete;
+- creatures, flora, minerals, shops, recipes, quests, NPCs, and transport exist as interconnected data rather than one-off encounter text;
+- animal/construct/environmental rewards have physical provenance through searching, skinning, butchering, gathering, mining, salvage, fishing, processing, or other appropriate work;
+- high-volume content production is a first-class engineering concern and grows continuously with mechanics;
+- legacy FFXI-derived material is reference/research only and must not define canonical names or new content databases.
 
-## Product phases
+## Phase summary
 
 | Phase | Theme | Exit promise |
 | --- | --- | --- |
-| `0.4` | Foundation and direction lock | Architecture can accept deterministic simulation/capability work without another reset. |
-| `0.5` | World time, tasks, projects | Multi-hour/day fictional work can advance, pause, interrupt, summarize, and complete without real-time waiting. |
-| `0.6` | Capabilities, disciplines, origins, livelihood | One continuous character can logically mix learned disciplines through preparation/loadout and pursue a livelihood. |
-| `0.7` | First complete game loop | A representative first week combines work, preparation, travel, danger, recovery, and permanent progress. |
-| `0.8` | Life/infrastructure expansion | Buildings, tools, farming/gathering, crafting, taming, relationships, and logistics materially transform earlier work. |
-| `0.9` | Adventure depth and release hardening | Combat/magic/content/balance/UI/persistence reach release-candidate quality. |
-| `1.0` | Live Foundation | The core product promise is coherent, stable, migratable, and playable as a persistent long-form RPG. |
+| `0.4` | Foundation and direction lock | Architecture can evolve without another broad reset. |
+| `0.5` | Simulation + original-world/content substrate | Time, interrupts, day review, canonical naming, provenance, ecology, transport, projects, and scalable content validation exist. |
+| `0.6` | Integrated character/mechanics content | Stats, skills, disciplines, magic, combat, items, gathering/crafting, ecology, and AI party play form a substantial connected mechanics layer. |
+| `0.7` | Multi-region playable alpha | Multiple cities/regions, transport, NPC populations, quests, relationships, regional economies, and substantial authored content support a real sandbox campaign. |
+| `0.8` | Life and infrastructure expansion | Property, farming, construction, taming/husbandry, logistics, relationships, production chains, and labor-saving infrastructure deepen long-form play. |
+| `0.9` | Adventure depth and release hardening | Advanced combat/magic/content/balance/UI/persistence reach release-candidate quality at meaningful scale. |
+| `1.0` | Live foundation | The central persistent-life/adventure promise is coherent, stable, migratable, and content-complete enough for release. |
 
-## 0.4 — Foundation — complete
+---
 
-- [x] `0.4.100` Direction and version-roadmap lock.
-- [x] `0.4.200` Four-part product version separated from package SemVer; CI test/benchmark gate added.
-- [x] `0.4.300` Ordered persistence migration mechanism with deterministic unsupported-version handling.
-- [x] `0.4.400` Structured `ActionResult` contract; travel-start pilot.
-- [x] `0.4.500` Bounded semantic-event foundation; travel start/arrival pilot.
-- [x] `0.4.600` Foundation stabilization/readiness tests and transitional architecture rules.
-- [x] `0.4.900` Foundation exit-gate certification.
+# 0.4 — Foundation — complete
 
-## 0.5 — World Time, Tasks, and Projects — active
+- [x] `0.4.100` Development direction and version protocol.
+- [x] `0.4.200` Four-part product version and package-version separation.
+- [x] `0.4.300` Ordered persistence migrations.
+- [x] `0.4.400` Structured `ActionResult` contract.
+- [x] `0.4.500` Bounded semantic-event foundation.
+- [x] `0.4.600` Foundation stabilization and transitional architecture rules.
+- [x] `0.4.900` Foundation exit certification.
 
-### 0.5.100 Deterministic world clock — complete
+---
 
-- [x] Canonical simulated seconds stored in Game State v4.
-- [x] Exact deterministic advancement independent of `Date.now()`.
-- [x] Derived day/hour/minute/second inspection and formatting.
-- [x] Deterministic minute/hour/day/multi-day rollover tests.
-- [x] `time.advanced` semantic event records structured advancement observations.
-- [x] Ordered Game State v3 -> v4 migration adds canonical world time.
-- [x] Wall-clock `tickEngine` remains only a scheduler/dispatcher and does not mutate canonical world time by itself.
+# 0.5 — Simulation and Content Substrate — active
 
-### 0.5.200 Pause and speed control — complete
+## 0.5.100 — Deterministic world clock — complete
 
-- [x] Simulation pause/resume state and semantic events.
-- [x] Engine accepts whole-number simulation-speed multipliers from 1x through 3600x without hard-coding UI presets.
-- [x] Scheduler adapter converts supplied wall-clock milliseconds into exact simulated seconds.
-- [x] Sub-second simulated remainder is retained deterministically rather than discarded.
-- [x] Wall-clock time observed while paused is discarded and cannot become a burst of simulation time after resume.
-- [x] Fast-forward advances the canonical world clock rather than merely changing render timing.
-- [x] Scheduler conversion does not call `Date.now()`.
-- [x] New games initialize simulation control at running/1x while older Game State v4 saves can lazily acquire control state.
+- [x] Canonical simulated seconds in Game State v4.
+- [x] Deterministic advancement independent of wall-clock reads.
+- [x] Derived day/hour/minute/second formatting.
+- [x] Persistence migration and deterministic rollover tests.
 
-### 0.5.300 Canonical timed task model — current
+## 0.5.200 — Pause and speed control — complete
 
-- [x] Versioned task registry with stable task IDs.
-- [x] Tasks use canonical start/completion world-time boundaries and positive whole-second durations.
-- [x] Start semantics return structured ActionResult data and emit `task.started`.
-- [x] Progress is derived from canonical world time instead of maintaining a second competing task clock.
-- [x] Reconciliation completes due tasks deterministically and emits `task.completed`.
-- [x] Cancellation freezes progress at cancellation time and emits `task.cancelled`.
-- [x] Overshoot preserves the scheduled completion time while the completion event records when the simulation observed it.
-- [x] Multiple channels may coexist; concurrency/exclusivity policy is intentionally deferred to activity-specific systems.
-- [x] New games initialize an empty task registry while older Game State v4 saves can lazily acquire one without a schema migration.
+- [x] Pause/resume semantics.
+- [x] Whole-number speed multipliers up to the engine limit.
+- [x] Scheduler-to-simulation conversion with sub-second remainder.
+- [x] Paused wall time is discarded rather than banked.
 
-The timed-task engine does not own time advancement. It observes `worldTime.totalSeconds`. This keeps task semantics reusable for work, crafting, travel, construction, recovery, and later systems without making travel the universal implementation template.
+## 0.5.300 — Canonical timed tasks — complete
 
-### 0.5.400 Interrupt model — next
+- [x] Versioned task registry and stable IDs.
+- [x] Start/progress/complete/cancel semantics.
+- [x] Canonical world-time deadlines and deterministic reconciliation.
+- [x] Multiple task channels without prematurely hard-coded concurrency policy.
 
-- [ ] Advance-until-event.
-- [ ] Deterministic interrupt priority.
-- [ ] Combat/exhaustion/tool failure/project completion hooks or placeholders.
+## 0.5.400 — Simulation interrupt model — complete
 
-### 0.5.500 Day boundary and end-of-day review
+- [x] Advance-until-event semantics.
+- [x] Deterministic time/priority/tie ordering.
+- [x] Built-in task-completion interrupts.
+- [x] Generic providers for combat, exhaustion, tool failure, projects, day boundaries, and later systems.
+- [x] Accelerated scheduler advancement stops cleanly at meaningful interrupts.
 
-- [ ] Day transition.
-- [ ] Configurable EoD auto-pause.
-- [ ] Structured daily summary data.
-- [ ] Review/continue/save/inspect flow.
+## 0.5.500 — Day boundary and end-of-day review — complete
 
-### 0.5.600 Persistent projects
+- [x] Deterministic midnight boundary provider.
+- [x] Structured day summaries built from semantic events.
+- [x] Configurable end-of-day auto-pause, enabled by default.
+- [x] Higher-priority same-time interrupts remain visible while completed days still finalize.
+- [x] Older Game State v4 records acquire day/simulation bookkeeping lazily.
 
-- [ ] Material requirements.
-- [ ] Accumulated labor/time.
-- [ ] Visible progress.
-- [ ] Completion events.
-- [ ] No arbitrary duplicate-building exponential multiplier.
+## 0.5.550 — Original-world identity and canonical nomenclature — next
 
-### 0.5.700 Time-cost integration pilot
+This track must finish **before high-volume canonical content databases are expanded**.
 
-- [ ] Travel on canonical time.
-- [ ] At least one non-travel work activity on canonical time.
-- [ ] Energy/fatigue hooks where appropriate.
-- [ ] Fast-forward through low-information periods without missing meaningful interrupts.
+- [ ] Replace inherited world, nation, region, place, map, ancestry, discipline, currency, transport, storage, companion, creature, NPC, shop, and institutional terminology in canonical runtime data.
+- [ ] Migrate stable IDs rather than changing only display strings.
+- [ ] Add bounded legacy-to-canonical aliases at migration/input boundaries.
+- [ ] Add ordered save migration for persisted renamed identifiers where needed.
+- [ ] Quarantine historical FFXI-derived modules as legacy/reference sources rather than canonical gameplay data.
+- [ ] Update player-facing copy, tests, examples, and package/project language.
+- [ ] Establish the first original regional naming/cultural patterns described in `WORLD_IDENTITY_AND_CONTENT_POLICY.md`.
 
-### 0.5.900 Exit gate
+### 0.5.550 exit gate
 
-0.5 closes when multi-hour/multi-day fictional activities can be advanced safely, reach day boundaries, produce readable progress, and complete persistent projects without depending on real-world waiting.
+No newly authored canonical gameplay record should require an FFXI proper noun or stable identifier. Existing legacy references may remain only behind documented compatibility/research boundaries.
 
-## 0.6 — Character Capability, Disciplines, Origins, Livelihood
+## 0.5.600 — Resource provenance and persistent projects
 
-- [ ] `0.6.100` Learned capability/proficiency model independent of current equipment.
-- [ ] `0.6.200` Jobs represented as disciplines/classifications rather than magical active states.
-- [ ] `0.6.300` Hard/soft/enhancing equipment and preparation requirements.
-- [ ] `0.6.400` Cross-discipline ability access when actual prerequisites are satisfied.
-- [ ] `0.6.500` Origin-based starting circumstances/loadouts.
-- [ ] `0.6.600` First complete livelihood loop.
-- [ ] `0.6.700` Loadout/capability UX.
-- [ ] `0.6.900` Capability/livelihood exit gate.
+- [ ] Persistent projects with material, labor, time, progress, and completion events.
+- [ ] World-resource provenance schema: carried goods, carcass/body outputs, plants, minerals, fishing, salvage, crafting, trade, contracts, and exceptional magical sources.
+- [ ] Body/resource opportunities created by combat rather than automatic finished-item confetti.
+- [ ] Search/skin/butcher/pluck/extract/salvage action substrate with tools, time, condition, and proficiency hooks.
+- [ ] Item source/sink metadata foundation.
 
-Transitional rule until this phase lands:
+## 0.5.650 — Ecology, gathering, and spawn substrate
 
-```text
-Jobs describe.
-Capabilities enable.
-Loadouts constrain and enhance.
-```
+- [ ] Species/family definitions separated from individual encounter instances.
+- [ ] Habitat, time, weather/season hooks where useful, population density, aggression, senses, linking/social behavior, and rarity.
+- [ ] Flora/mineral/fishing/gathering-source definitions with location and yield rules.
+- [ ] Respawn/regeneration model compatible with deterministic simulation.
+- [ ] Rare/named spawn hooks without magical arbitrary appearance rules.
 
-Do not deepen the current `mainJob` scaffold into the final ability-lock model.
+## 0.5.700 — Travel and scheduled transport substrate
 
-## 0.7 — First Complete Representative Game
+- [ ] Walking/local travel consumes canonical simulation time.
+- [ ] Route/road records independent of artificial player-facing zone screens.
+- [ ] Scheduled caravan service with stops, fare, cargo allowance, travel time, and interruption hooks.
+- [ ] Generic transport contract suitable for ferries, hired wagons, mounts, and later air travel.
+- [ ] Map/route knowledge and discovery hooks.
+- [ ] At least one non-travel work activity integrated with canonical time.
 
-Working slice: **A Week Beyond the West Gate**.
+## 0.5.800 — Content-pack schema, import normalization, and validation
 
-The slice should combine:
+- [ ] Regional content-pack contract for places, routes, NPCs, shops, ecology, resources, items, recipes, quests, relationships, and transport.
+- [ ] Legacy-data ingestion tools produce candidate normalized records, never direct canonical imports.
+- [ ] Cross-reference validation for IDs, sources/sinks, spawns, recipes, shops, quests/rewards, routes, maps, and companions.
+- [ ] Explicit originality/provenance metadata where imported research materially informs a canonical record.
+- [ ] Data-generation workflow designed for hundreds/thousands of records rather than giant manually edited monoliths.
 
-- multiple origins;
-- a modest foothold/home-base context;
-- one livelihood/gathering/economy loop;
-- one persistent material/labor project;
-- simulated days and EoD review;
-- preparation/loadout decisions;
-- one meaningful West Gate expedition;
-- travel danger and combat;
-- recovery/return-home loop;
-- measurable capability growth;
-- one permanent end-of-week accomplishment/unlock;
-- UI/action discoverability without requiring command memorization.
+## 0.5.900 — Simulation/content-substrate exit gate
 
-0.7 should be judged primarily by whether this connected loop is compelling enough to continue playing.
+0.5 closes when:
 
-## 0.8 — Long-form Life Expansion
+- long fictional activities advance safely with deterministic interrupts and day review;
+- the original-world naming/stable-ID migration is complete;
+- persistent projects and resource provenance exist;
+- ecology/gathering/spawn definitions can populate the world;
+- scheduled transport can connect multiple settlements/regions;
+- regional content packs and validators can safely support large-scale data production;
+- no new content pipeline depends on inherited FFXI naming.
+
+---
+
+# 0.6 — Integrated Character and Mechanics Content
+
+## 0.6.100 — Character stat and progression model
+
+- [ ] Complete primary/resource/derived stat contracts.
+- [ ] Character-owned progression independent of temporary loadout classification.
+- [ ] EXP/advancement or replacement progression law integrated with origins, training, work, and combat.
+- [ ] Confidence-labeled balance formulas with deterministic tests.
+
+## 0.6.200 — Skills, proficiency, disciplines, and capabilities
+
+- [ ] Full canonical skill/proficiency registry across martial, magical, gathering, crafting, social, and practical domains.
+- [ ] Original discipline registry and training paths.
+- [ ] Learned capabilities stored on the character.
+- [ ] Hard, soft, and enhancing preparation/equipment prerequisites.
+- [ ] Cross-discipline capability use where real requirements are met.
+
+## 0.6.300 — Magic and active ability engine
+
+- [ ] Canonical spell/technique records with cost, cast/use time, recast, target rules, tags, effects, and training/unlock provenance.
+- [ ] Casting/channel/interruption/recast engine.
+- [ ] First substantial original spell/technique catalog rather than placeholder Cure/generic damage logic.
+
+## 0.6.400 — Combat 2.0
+
+- [ ] Tactical enemy AI and family abilities.
+- [ ] Status effects, resistance/mitigation, threat/attention, positioning/range where meaningful in text.
+- [ ] Weapon techniques and party interactions.
+- [ ] KO/injury/recovery and battle cleanup.
+- [ ] Combat consumes simulation time and interacts with interrupts/ecology.
+
+## 0.6.500 — Canonical item, equipment, tool, and direct-use expansion
+
+- [ ] Hundreds-scale item catalog using source/sink validation.
+- [ ] Equipment tiers and meaningful tradeoffs.
+- [ ] Consumables, tools, containers, maps, reagents, ammunition, food, medicine, keys/permissions, and quest objects.
+- [ ] Wear/maintenance/repair hooks where they create useful economic decisions.
+
+## 0.6.600 — Gathering, hunting, processing, crafting, cooking, and salvage
+
+- [ ] Mining, logging, harvesting/foraging, fishing/trapping, and hunting loops.
+- [ ] Carcass processing and quality/yield decisions.
+- [ ] Recipe/process engine with stations, tools, time, proficiency, quality, and byproducts.
+- [ ] Cooking, medicine/alchemy, smithing, woodworking, leatherwork, textiles, and other useful production branches.
+- [ ] Regional materials circulate through multiple production chains.
+
+## 0.6.700 — Ecology and regional creature/resource content
+
+- [ ] At least 40–60 meaningful creature/fauna definitions.
+- [ ] At least 40 environmental resource/flora definitions.
+- [ ] Multiple families, variants, behaviors, rare encounters, and habitat differences.
+- [ ] Ecology connects to gathering, recipes, quests, economy, and travel danger.
+
+## 0.6.800 — AI party and companion foundation
+
+- [ ] Persistent recruitable companion entities.
+- [ ] Role/tactics preferences, equipment, progression, resource use, KO/recovery, and party targeting.
+- [ ] Relationship/affinity hooks separated from tactical AI.
+- [ ] At least 4–6 distinct companions proving multiple combat/support personalities.
+
+## 0.6.900 — Mechanics integration exit gate
+
+0.6 closes when one continuous character can train across original disciplines, acquire and use a substantial catalog of skills/magic/items, gather and transform natural resources, fight tactically with or without companions, improve through multiple activities, and participate in a functioning material economy.
+
+---
+
+# 0.7 — Multi-Region Playable Alpha
+
+## 0.7.100 — Multi-region sandbox graph
+
+- [ ] Multiple major cities/hubs plus smaller settlements and wilderness connectors.
+- [ ] At least 30–50 meaningful places/localities by alpha exit.
+- [ ] Internal partitions serve simulation/navigation without gamey mandatory player-facing zone loading.
+- [ ] Exploration, landmark, and cartography progression.
+
+## 0.7.200 — Caravans, ferries, mounts, and regional logistics
+
+- [ ] Scheduled transport network connecting major routes.
+- [ ] Freight/cargo, fares, route safety, delays/interrupts, and reputation/service variation.
+- [ ] Travel encounters and escort opportunities.
+- [ ] Mount/pack-animal or equivalent mobility layer where appropriate.
+
+## 0.7.300 — NPC populations, shops, guilds, and regional economies
+
+- [ ] Hundreds-scale named NPC population target by alpha exit.
+- [ ] NPC schedules/availability and contextual dialogue.
+- [ ] Regional shops/services with buy/sell/service behavior and meaningful stock.
+- [ ] Production/trade differences among regions create reasons to travel.
+
+## 0.7.400 — Quest, contract, mission, reward, and reputation engine
+
+- [ ] Journal/objective state driven by semantic events rather than log parsing.
+- [ ] Talk/search/gather/process/craft/travel/explore/combat/escort/deliver/project/social objective types.
+- [ ] Branching/prerequisite/repeatability/failure/reputation hooks where needed.
+- [ ] Rewards use real items, services, training, relationships, property, reputation, currency, or world changes.
+- [ ] 150–250 quests/contracts is the alpha-scale planning range, not a launch-day mandate for one track.
+
+## 0.7.500 — Relationships and romance
+
+- [ ] Persistent relationship state, affinity/trust/respect dimensions where useful, memory of meaningful events, and schedule/location integration.
+- [ ] Friendship, rivalry, mentorship, family/community, and romance are not reduced to one universal affection bar.
+- [ ] Romance candidates have independent goals, boundaries, preferences, and lives outside the player.
+- [ ] At least 8–12 deep romance-capable NPCs is the alpha-scale planning range.
+
+## 0.7.600 — Regional ecology and world-content packs
+
+- [ ] Distinct flora, fauna, monster families, gatherables, weather/terrain hooks, landmarks, dungeons, settlements, and local conflicts.
+- [ ] Regional packs do not copy the same template with renamed nouns.
+
+## 0.7.700 — Item, recipe, spell, technique, and economy content packs
+
+- [ ] Alpha-scale hundreds/thousand item target approached through validated generation/import workflows.
+- [ ] Regional ingredients and production chains create cross-region demand.
+- [ ] Skills/magic/gear progression supports multiple viable preparations and livelihoods.
+
+## 0.7.800 — First complete multi-city campaign layer
+
+The earlier **A Week Beyond the West Gate** concept becomes one polished introductory arc rather than the definition of the whole game.
+
+A new player should be able to:
+
+- begin from an origin with a concrete foothold;
+- explore a real settlement and surrounding routes;
+- acquire maps and route knowledge;
+- gather/hunt/fight and recover resources naturally;
+- process, craft, cook, sell, buy, and equip useful goods;
+- meet/recruit companions and build relationships;
+- take quests/contracts that interact with the same world systems;
+- travel to other settlements by road or scheduled transport;
+- return to or improve a home base without being trapped there;
+- end a substantial opening period with persistent skills, property/resources, relationships, reputation, and expanded geographic reach.
+
+## 0.7.900 — Playable-alpha exit gate
+
+0.7 closes when the above experience is coherent enough to play as a sandbox campaign rather than a systems demonstration.
+
+---
+
+# 0.8 — Life and Infrastructure Expansion
 
 Planned focus:
 
-- construction/renovation/capacity/efficiency upgrades;
-- farming and gathering depth;
-- crafting, tools and facilities;
-- taming/husbandry with practical value;
-- relationships and reputation;
-- logistics and labor-saving infrastructure;
-- additional discipline/livelihood interactions;
-- resource/economy sink balancing based on scale and ambition rather than arbitrary multipliers.
+- property acquisition, renovation, construction, workshops, storage, roads, carts, warehouses, irrigation, and other useful infrastructure;
+- farming, orchards, gardens, animal husbandry/taming, breeding where appropriate, and seasonal production;
+- hired labor and automation earned through mastery/investment rather than arbitrary idle timers;
+- deeper crafting facilities and regional production chains;
+- social institutions, households, civic reputation, faction consequences, and relationship depth;
+- logistics that allow earlier chores to consume less player attention as capability grows;
+- larger persistent projects and civic/regional ambitions.
 
-## 0.9 — Adventure Depth and Release Hardening
+---
+
+# 0.9 — Adventure Depth and Release Hardening
 
 Planned focus:
 
-- deeper enemy/combat behavior;
-- structured magic/advanced capabilities consistent with the loadout model;
-- second dense region proving scalable content architecture;
-- long-form progression/economy balance;
-- UI/accessibility/readability hardening;
+- advanced enemy/ecology behavior, bosses/rare threats, dungeons, expedition systems, and dangerous-region traversal;
+- advanced magic, techniques, companion tactics, status interactions, equipment build depth, and balance;
+- late-game professions, regional projects, reputation/faction arcs, and relationship conclusions/continuations;
+- content breadth approaching 1.0 scale targets;
+- economy/resource-source/sink balancing over long simulations;
+- UI/accessibility/readability and discoverability hardening;
 - save migration/compatibility hardening;
-- deterministic simulation/content validation/performance;
+- deterministic validation/performance at thousands-of-record scale;
 - content-complete beta and release-candidate freeze.
 
-## 1.0 — Live Foundation
+---
 
-1.0 is a compatibility/product promise, not an assertion that all possible content is finished.
+# 1.0 — Live Foundation
 
-A 1.0 player should be able to establish a persistent character, learn across disciplines, prepare logical loadouts, live through simulated days, pursue livelihoods and projects, build useful infrastructure, travel and fight, form meaningful relationships/reputation, experience representative creature/taming systems if retained, explore at least two dense regions, and save/load under an explicit migration contract.
+1.0 is a compatibility and product promise, not an assertion that no future content can be added.
+
+A 1.0 player should be able to build one persistent life across a connected original fantasy world: establish and improve a foothold, travel among multiple regions/cities, learn across disciplines, prepare equipment and supplies for different goals, pursue livelihoods and crafting chains, gather/hunt/fight and recover resources naturally, form meaningful relationships and parties, undertake substantial quests/contracts, build useful infrastructure, participate in regional economies, and save/load under an explicit migration contract.
 
 ## Formula policy
 
 Formula confidence categories remain:
 
-- exact / sourced;
+- exact/sourced where the project owns or can justify an exact rule;
 - researched approximation;
 - intentional simplification;
 - placeholder.
 
-Refine formulas when they materially improve a meaningful player-facing loop. Do not block simulation time, capabilities, livelihoods, projects, objectives, or the representative slice merely to chase retail-exact math.
+Historical game formulas may inform research, but canonical balance is chosen for this game's own simulation and player experience.
 
 ## Immediate next pass
 
-After the 0.5.300 timed-task PR is green and merged:
-
 ```text
-0.5.400 — Interrupt model
+0.5.550 — Original-world identity and canonical nomenclature
 ```
 
-The interrupt layer should coordinate advancement stopping points and priorities without moving combat, project, or tool-specific policy into the world clock itself.
+Do not start high-volume item/monster/quest/recipe generation before that migration is complete.

--- a/docs/SYSTEM_CATALOG.md
+++ b/docs/SYSTEM_CATALOG.md
@@ -1,104 +1,202 @@
 # System Catalog
 
-This catalog assigns every known major system to a roadmap phase and version target.
+This catalog tracks major systems against the current roadmap. It distinguishes **schema existence** from **real player-facing breadth** so a toy dataset is not mistaken for a completed subsystem.
 
-## Legend
+## Status legend
 
 | Status | Meaning |
 | --- | --- |
-| planned | Known need, no runtime implementation. |
-| seeded | Schema or seed definitions exist. |
-| integrated | Runtime can read/use the system. |
-| playable | Player-facing command/gameplay exists. |
-| balanced | Tested, benchmarked, and tuned. |
+| `planned` | Known requirement, no canonical runtime implementation. |
+| `seeded` | Schema or small seed dataset exists. |
+| `integrated` | Runtime reads/uses the system. |
+| `playable` | A player can meaningfully interact with it end-to-end. |
+| `scaled` | Proven against representative content volume and cross-system references. |
+| `balanced` | Tuned through sustained gameplay/benchmarking at intended scale. |
 
-## Core foundation
+## Core simulation and architecture
 
-| System | Status | Target | Notes |
+| System | Status | Roadmap | Notes |
 | --- | --- | --- | --- |
-| Text command shell | integrated | 0.2.0 | Active runtime. |
-| Command parser | integrated | 0.2.0 | Positional and named args. |
-| Validation | integrated | 0.2.0 | Save and state validation baseline. |
-| Version tracking | integrated | 0.2.0 | App/save/data/benchmark versions. |
-| Benchmark harness | seeded | 0.2.0 | Combat profile, attack, tick dispatch. |
-| Live tick engine | seeded | 0.2.0 | Needs runtime integration. |
+| Text command shell/parser | integrated | complete foundation | Active command adapter. |
+| Canvas/UI intent layer | integrated | ongoing | UI and command paths should call shared gameplay actions. |
+| Structured action results | integrated | 0.4 complete | Semantic outcomes separated from prose. |
+| Semantic events | integrated | 0.4 complete | Bounded structured event history. |
+| Ordered save migrations | integrated | 0.4 complete | Required for upcoming stable-ID migration. |
+| Validation framework | integrated | ongoing | Must expand into cross-content validation. |
+| Benchmark harness | seeded | ongoing | Needs broader simulation/content benchmarks. |
+| Canonical world time | integrated | 0.5.100 complete | Deterministic simulation seconds. |
+| Pause/speed control | integrated | 0.5.200 complete | Includes end-of-day preference after 0.5.500. |
+| Canonical timed tasks | integrated | 0.5.300 complete | Generic timed activity substrate. |
+| Simulation interrupts | integrated | 0.5.400 complete | Deterministic advance-until-event foundation. |
+| Day cycle/review | integrated | 0.5.500 complete | Structured day summaries and default auto-pause. |
+| Persistent projects | planned | 0.5.600 | Materials + labor + time + progress + completion. |
 
-## World and travel
+## World identity, geography, maps, and travel
 
-| System | Status | Target | Notes |
+| System | Status | Roadmap | Notes |
 | --- | --- | --- | --- |
-| Places database | planned | 0.3.0 | Cities, zones, dungeons, interiors. |
-| Zone connections | planned | 0.3.0 | Directed graph with restrictions. |
-| Travel restrictions | planned | 0.3.0 | Level, key item, nation, quest, mount, time. |
-| Travel command | planned | 0.3.0 | Tick-based travel progress. |
-| Zone discovery | planned | 0.3.0 | Maps, home points, survival guides later. |
+| Original-world canonical IDs/names | planned | 0.5.550 | Must land before high-volume content expansion. |
+| Legacy ID/save migration | planned | 0.5.550 | Replace inherited place/nation/ancestry/discipline IDs safely. |
+| Places database | integrated | 0.5.550 migration then 0.7 scale | Several starter city/wilderness/dungeon records exist but use legacy identity. |
+| Place/route connections | integrated | 0.5.700 expansion | Directed graph exists; should evolve toward roads/routes and natural transitions. |
+| Coordinate/topology movement | integrated | ongoing | Supports grid/topology movement and exits. |
+| Map definitions | integrated | 0.5.550 migration | Map ownership/discovery needs deeper cartography gameplay. |
+| Cartography/map knowledge | seeded | 0.5.700 / 0.7.100 | Discovery exists; partial maps/route confidence/annotations still needed. |
+| Local travel | playable scaffold | 0.5.700 | Existing travel/movement does not yet fully consume canonical time through one route model. |
+| Scheduled caravans | planned | 0.5.700 | Stops, schedules, fares, cargo, risk, interruption. |
+| Ferry/hired transport contract | planned | 0.5.700+ | Reuse generic transport model. |
+| Mount/pack-animal transport | planned | 0.7.200 / 0.8 | Original species/terminology required. |
+| Multi-region sandbox | seeded | 0.7.100 | Three starter clusters exist, but broad inter-regional graph and dense content are missing. |
 
-## Character progression
+## Character identity and progression
 
-| System | Status | Target | Notes |
+| System | Status | Roadmap | Notes |
 | --- | --- | --- | --- |
-| Player identity | seeded | 0.2.0 | Race, sex, nation, title, job. |
-| Jobs | seeded | 0.2.0 | All standard jobs listed. |
-| Support jobs | planned | 0.4.0 | Unlocks, half-level behavior, restrictions. |
-| EXP and leveling | planned | 0.4.0 | Level curves and caps. |
-| Skills and caps | planned | 0.5.0 | Combat/magic/crafting skill growth. |
-| Merits/job points | planned | later | Advanced progression. |
+| Player entity | integrated | ongoing | Identity/resources/equipment/progression present. |
+| Ancestries | seeded legacy | 0.5.550 | Mechanical slots exist; canonical names/identity migrate next. |
+| Origins/backgrounds | planned | 0.6 / 0.7 opening | Starting circumstances should replace class-only opening emphasis. |
+| Transitional job scaffold | integrated legacy | 0.5.550 then 0.6.200 | Must become original disciplines and later cease being universal ability gate. |
+| EXP/level progression | playable scaffold | 0.6.100 | Current system works but remains transitional. |
+| Character-owned skills | playable scaffold | 0.6.200 | Learned skill storage exists. |
+| Skill caps/ranks | seeded | 0.6.200 | Sparse starter table with placeholder rank math. |
+| Full skill/proficiency registry | planned | 0.6.200 | Must include combat, magic, gathering, crafting, practical/social domains. |
+| Learned capability registry | planned | 0.6.200 | Spells/techniques/recipes/traits/actions owned by character. |
+| Training/mentor/certification | planned | 0.6.200+ | Advanced instruction and recognition. |
+| Advanced long-horizon progression | planned | 0.9+ | Add only after core advancement is compelling. |
 
-## Combat and magic
+## Stats, combat, magic, and abilities
 
-| System | Status | Target | Notes |
+| System | Status | Roadmap | Notes |
 | --- | --- | --- | --- |
-| Stat engine | seeded | 0.2.0 | Conservative placeholders. |
-| Battle state | seeded | 0.2.0 | Basic attack flow. |
-| Enemy AI | planned | 0.5.0 | Tick/subturn based. |
-| Magic database | planned | 0.5.0 | Spells, costs, recasts, elements. |
-| Casting engine | planned | 0.5.0 | Cast time, interruption, recast. |
-| Abilities and traits | planned | 0.5.0 | Job abilities, traits, enemy abilities. |
-| Enmity | planned | 0.6.0 | Needed for trusts/party play. |
-| Weapon skills | planned | 0.6.0 | TP spenders. |
-| Skillchains | planned | 0.7.0 | Requires weapon skills. |
-| Magic bursts | planned | 0.7.0 | Requires magic + skillchains. |
+| Primary/resource/derived stat engine | integrated scaffold | 0.6.100 | Mix of researched and simplified values; needs canonical balance pass. |
+| Basic battle state | playable scaffold | 0.6.400 | Hit/damage/TP and victory/defeat exist. |
+| Basic attack | playable | 0.6.400 hardening | Deterministic tests exist. |
+| Weapon techniques | seeded placeholder | 0.6.300–0.6.400 | Current weapon-skill action is simplified and not a full ability catalog. |
+| Magic action | seeded placeholder | 0.6.300 | Current Cure/generic-damage split is intentionally temporary. |
+| Canonical magic database | planned | 0.6.300 | Legacy spell data is reference only; author original spell catalog. |
+| Casting/recast/interruption | planned | 0.6.300 | Time-aware spell action engine. |
+| Capability prerequisites | planned | 0.6.200–0.6.300 | Hard/soft/enhancing equipment/preparation/context checks. |
+| Enemy tactical AI | planned | 0.6.400 | Current enemies auto-basic-attack only. |
+| Enemy family abilities | planned | 0.6.400 | Requires canonical creature ability records. |
+| Status/resistance system | seeded | 0.6.400 | Status structure exists; broad combat integration incomplete. |
+| Threat/attention | planned | 0.6.400 | Needed for party tactics. |
+| KO/injury/recovery | planned | 0.6.400 | Persistent consequences/recovery. |
+| Party combat | planned | 0.6.800 | Companion-aware targets/tactics/resources. |
 
-## Data and economy
+## Creatures, ecology, spawns, and natural resources
 
-| System | Status | Target | Notes |
+| System | Status | Roadmap | Notes |
 | --- | --- | --- | --- |
-| Items database | planned | 0.4.0 | Equipment, consumables, materials. |
-| Key items | planned | 0.4.0 | Unlocks, maps, travel permissions, quest flags. |
-| Inventory | seeded | 0.2.0 | Minimal list only. |
-| Equipment | seeded | 0.2.0 | Slots exist; validation pending. |
-| Loot tables | planned | 0.5.0 | Drop rates, quest drops, currency. |
-| Vendors | planned | 0.5.0 | Shops, guilds, conquest rewards. |
-| Crafting | planned | 0.8.0 | Recipes, crystals, ingredients, HQ tiers. |
+| Enemy entity schema | integrated | ongoing | Runtime enemy entities exist. |
+| Starter spawn rules | seeded | 0.5.650 | Small place-level populations exist. |
+| Species/family database | planned | 0.5.650 | Separate species ecology from encounter instances. |
+| Habitat/population model | planned | 0.5.650 | Density, rarity, aggression, senses, social behavior, time/environment hooks. |
+| Respawn/regeneration | planned | 0.5.650 | Deterministic population/resource recovery. |
+| Rare/named spawns | legacy seed only | 0.5.650 / 0.6.700 | Rebuild under original world/content rules. |
+| Flora/fungi resources | planned | 0.5.650 | Location/yield/regeneration/use data. |
+| Mineral/clay/stone resources | planned | 0.5.650 | Geology/location/yield/tool hooks. |
+| Fishing/shore resources | planned | 0.5.650 / 0.6.600 | Waters/habitat/tackle/time hooks. |
+| Hunting/trapping | planned | 0.6.600 | Integrates ecology and provenance. |
+| Carcass/body processing | planned | 0.5.600 / 0.6.600 | Skin, butcher, pluck, bone, gland, venom, salvage. |
+| Construct salvage | planned | 0.5.600 / 0.6.600 | Dismantle rather than magical drops. |
 
-## Quests and achievements
+## Items, inventory, equipment, and economy
 
-| System | Status | Target | Notes |
+| System | Status | Roadmap | Notes |
 | --- | --- | --- | --- |
-| Quest database | planned | 0.6.0 | Prereqs, objectives, rewards, flags. |
-| Quest engine | planned | 0.6.0 | Objective evaluation and turn-in flow. |
-| Achievements | planned | 0.7.0 | Milestones, titles, unlocks. |
-| Mission/rank progression | planned | 0.7.0 | Nation rank and story gates. |
-| Reputation/fame | planned | 0.7.0 | Zone/nation fame. |
+| Canonical item schema | integrated | 0.5.800 validation / 0.6.500 scale | Structured requirements/effects/modifiers/metadata exist. |
+| Inventory containers | playable scaffold | ongoing | Portable/home/storage rules exist. |
+| Item stacking/transfers | playable | ongoing | Capacity/access/stack behavior tested. |
+| Equipment eligibility | playable scaffold | 0.6.200 evolution | Currently tied partly to legacy job scaffold. |
+| Equipment catalog | seeded | 0.6.500 | Very small starter catalog only. |
+| Direct-use consumables/tools | seeded | 0.6.500 | Item behavior contract exists; broad actions/content missing. |
+| Item source/sink metadata | planned | 0.5.600 | Required before high-volume item database. |
+| Physical provenance | planned | 0.5.600 | Body/environment/commerce/craft/quest origin categories. |
+| Loot/search carried inventory | seeded legacy behavior | 0.5.600 | Automatic battle rewards must distinguish carried goods from recoverable body resources. |
+| Shops/buy/sell | playable scaffold | 0.7.300 scale | Transactions work; catalogs are tiny. |
+| Regional economy | planned | 0.7.300 | Stock, services, regional inputs/outputs, trade incentives. |
+| Currency vocabulary | legacy | 0.5.550 | Replace inherited currency/reward terminology. |
+| Repair/maintenance | planned | 0.6.500 / 0.8 | Add where it creates useful sinks/decisions. |
 
-## Companions and movement extras
+## Gathering, processing, crafting, and cooking
 
-| System | Status | Target | Notes |
+| System | Status | Roadmap | Notes |
 | --- | --- | --- | --- |
-| Trust database | planned | 0.6.0 | AI companions and unlock records. |
-| Trust AI | planned | 0.6.0 | Role profiles and action choices. |
-| Mount database | planned | 0.8.0 | Mount unlocks and travel modifiers. |
-| Mount restrictions | planned | 0.8.0 | Zone and state restrictions. |
+| Gathering categories | legacy seed only | 0.6.600 | Names exist in old data, not a canonical gathering engine. |
+| Gathering actions/nodes | planned | 0.5.650 / 0.6.600 | Actual world sources, tools, time, yields, proficiency. |
+| Craft disciplines | legacy seed only | 0.6.600 | Old list is not a recipe/process system. |
+| Recipe/process schema | planned | 0.5.800 / 0.6.600 | Inputs, outputs, tools, stations, time, skill, quality, byproducts. |
+| Cooking | planned | 0.6.600 | Food effects + ingredient chains. |
+| Medicine/alchemy | planned | 0.6.600 | Herbs, extracts, reagents, tools, medicines. |
+| Smithing/metalwork | planned | 0.6.600 | Ore -> processed metal -> components/equipment/tools. |
+| Woodworking | planned | 0.6.600 | Timber -> lumber/components/tools/construction. |
+| Leatherwork | planned | 0.6.600 | Hide -> tanning -> leather/components/equipment. |
+| Textiles | planned | 0.6.600 | Fiber/wool/etc. -> cloth -> clothing/equipment. |
+| Salvage/recycling | planned | 0.5.600 / 0.6.600 | Recover materials from constructed goods/ruins. |
+| Quality/HQ behavior | planned | 0.6.600 | Original quality model; do not assume inherited MMO tiers. |
 
-## Implementation priority
+## NPCs, services, quests, reputation, and social systems
 
-1. Places and zone connections.
-2. Travel restrictions and tick-based travel.
-3. Item/key item schemas.
-4. Leveling and EXP.
-5. Combat loop with enemy turns.
-6. Magic/casting/recasts.
-7. Loot and drops.
-8. Quests and achievements.
-9. Trust AI companions.
-10. Crafting and mounts.
+| System | Status | Roadmap | Notes |
+| --- | --- | --- | --- |
+| NPC entity schema | integrated | ongoing | Only a few runtime seed entities currently exist. |
+| POI/NPC location records | seeded | 0.5.550 migration / 0.7.300 scale | Many current POIs still use inherited names. |
+| NPC schedules/availability | planned | 0.7.300 | Work/home/service routines. |
+| Shop/service attachment | playable scaffold | 0.7.300 | Small catalogs/services exist. |
+| Quest hooks | seeded only | 0.7.400 | No full objective/journal state yet. |
+| Quest/contract engine | planned | 0.7.400 | Semantic objectives, prereqs, branches, rewards, repeatability. |
+| Reputation/faction | planned | 0.7.400+ | Regional/social consequences and service access. |
+| Relationship state | planned | 0.7.500 | Friendship/rivalry/mentorship/community/romance. |
+| Romance | planned | 0.7.500 | Deep authored candidates with goals/boundaries/schedules. |
+| Achievements/titles | planned | 0.7+ | Milestones, recognition, unlocks; not a priority over core quests. |
+
+## Party and companions
+
+| System | Status | Roadmap | Notes |
+| --- | --- | --- | --- |
+| Companion database | planned | 0.6.800 | Original persistent companion entities replace inherited `Trust` terminology. |
+| Companion tactics AI | planned | 0.6.800 | Roles/preferences/action selection/resources. |
+| Companion equipment/progression | planned | 0.6.800 | Persistent capability/loadout growth. |
+| Companion KO/recovery | planned | 0.6.800 | Integrate party and injury/recovery systems. |
+| Companion relationships | planned | 0.7.500 | Tactical AI remains separate from social state. |
+| Personal companion quests | planned | 0.7.400–0.7.500 | Goals and narrative/state changes. |
+
+## Home, livelihood, infrastructure, and logistics
+
+| System | Status | Roadmap | Notes |
+| --- | --- | --- | --- |
+| Home/storage foothold | seeded legacy | 0.7 opening / 0.8 | Current storage concept needs original terminology and deeper property context. |
+| Origins/backgrounds | planned | 0.6/0.7 | Determine opening property/tools/relationships/obligations. |
+| Livelihood loops | planned | 0.6.600 | Work must connect time, resources, skill, economy, and mastery. |
+| Persistent construction projects | planned | 0.5.600 | Shared project substrate first. |
+| Property/buildings | planned | 0.8 | Acquisition, renovation, capacity, workshops. |
+| Farming/gardening | planned | 0.8 | Crop/soil/season/work/infrastructure systems. |
+| Husbandry/taming | planned | 0.8 | Practical animals, care, production, transport where useful. |
+| Logistics/carts/warehouses | planned | 0.7.200 / 0.8 | Carrying capacity and regional trade/infrastructure. |
+| Hired labor/earned automation | planned | 0.8 | Reduce chore attention through investment/mastery. |
+
+## Data-production infrastructure
+
+| System | Status | Roadmap | Notes |
+| --- | --- | --- | --- |
+| Regional content-pack contract | planned | 0.5.800 | Geography, NPC, ecology, items, recipes, quests, social, transport. |
+| Cross-reference validator | seeded baseline | 0.5.800 | Expand dramatically before large data generation. |
+| Legacy normalization/import tools | planned | 0.5.800 | Produce candidate original records; never direct canonical copying. |
+| Source/sink validator | planned | 0.5.600 / 0.5.800 | Detect items with no source/use unless exempt. |
+| Quest reachability/content validator | planned | 0.5.800 / 0.7.400 | Detect impossible objectives/rewards. |
+| Scale/performance validation | planned | 0.5.800 onward | Test hundreds/thousands of records rather than only tiny seeds. |
+
+## Current implementation priority
+
+1. **0.5.550** — original-world naming and stable-ID/save migration.
+2. **0.5.600** — persistent projects + resource provenance/body processing.
+3. **0.5.650** — ecology, gathering sources, spawn populations, regeneration.
+4. **0.5.700** — canonical timed travel + scheduled caravans/transport.
+5. **0.5.800** — regional content packs, import normalization, cross-reference validation.
+6. **0.6.100–0.6.400** — stats/progression, skills/disciplines/capabilities, magic/abilities, Combat 2.0.
+7. **0.6.500–0.6.800** — item breadth, gathering/crafting/cooking/salvage, ecology content, AI party.
+8. **0.7** — multi-region world, transport network, NPC populations/economies, quests, relationships/romance, broad content packs.
+9. **0.8** — infrastructure/life expansion.
+10. **0.9** — adventure depth, high-volume balance, release hardening.
+
+The project must no longer treat content as a late decorative layer. Systems and real cross-linked data advance together.

--- a/docs/THREAD_HANDOFF.md
+++ b/docs/THREAD_HANDOFF.md
@@ -1,23 +1,28 @@
 # Thread Handoff
 
-This is the first document a new ChatGPT/Codex thread should read before continuing repository work.
+Read this before continuing implementation in a new ChatGPT/Codex thread.
 
 ## Read order
 
 1. `docs/DEVELOPMENT_DIRECTION.md` — authoritative design north star.
-2. `docs/VERSIONING_AND_RELEASE_ROADMAP.md` — authoritative product-version protocol and release gates.
-3. `docs/TRANSITIONAL_ARCHITECTURE.md` — temporary seams that must not be mistaken for final design.
-4. `docs/ROADMAP.md` — implementation summary and phase index.
-5. `docs/ARCHITECTURE.md` — current module/runtime boundaries.
-6. `js/text/version.js` — authoritative runtime/system version state.
+2. `docs/WORLD_IDENTITY_AND_CONTENT_POLICY.md` — original-setting, naming, legacy-data, provenance, scale, and content-pack policy.
+3. `docs/ROADMAP.md` — current implementation status and immediate sequence.
+4. `docs/VERSIONING_AND_RELEASE_ROADMAP.md` — product-version protocol and detailed release gates.
+5. `docs/TRANSITIONAL_ARCHITECTURE.md` — temporary seams that must not harden into final design.
+6. `docs/ARCHITECTURE.md` — module/runtime boundaries.
+7. `js/text/version.js` — runtime/system version manifest.
 
-`docs/planning/DEVELOPMENT_PIPELINE_AND_MILESTONES.md` is superseded historical planning from the earlier formula-first direction.
+Older planning documents may preserve useful history but do not override these files.
 
 ## Product identity
 
-The project is a long-form, text-first fantasy life RPG with FFXI-inspired weight, preparation, dangerous travel, jobs/disciplines, equipment, mastery, and earned accomplishment.
+Working title: **Hearth & Horizon**.
 
-It is not intended to become a text transcription of retail FFXI.
+This is an original text-first persistent fantasy life RPG about one continuous character building livelihood, skills, relationships, reputation, material capability, home/infrastructure, and geographic reach across a connected fantasy world.
+
+Earlier code/data contains extensive FFXI-derived experiments. Those are now **legacy research/reference/migration material**, not canonical world content.
+
+Do not author new canonical databases using inherited FFXI place, nation, race, class, currency, creature, NPC, or item proper nouns.
 
 Core progression law:
 
@@ -25,253 +30,184 @@ Core progression law:
 effort -> mastery -> efficiency -> capability -> larger ambition
 ```
 
-Repeated identical work should not receive arbitrary exponential resource multipliers. Higher resource demand should come from physical scale, upgrades, specialization, logistics, infrastructure, quality, and more ambitious projects.
-
-Simulation time and wall-clock time are separate. Fictional work may take hours, days, seasons, or years while the player can pause, accelerate, advance to completion, or advance to a meaningful interrupt.
-
-## Jobs/disciplines direction
-
-The current `mainJob`/support-job/current-job model is transitional compatibility scaffolding.
-
-Long-term rule:
+Core capability law:
 
 ```text
-Jobs describe.
+Disciplines describe.
 Capabilities enable.
-Loadouts constrain and enhance.
+Loadouts and preparation constrain and enhance.
 ```
 
-Jobs remain recognizable disciplines/training traditions. Equipment does not magically transform the character into another job, and changing loadout should not erase learned knowledge.
-
-Ability eligibility should eventually derive from learned capability, proficiency, equipment, hard/soft requirements, preparation, resources, condition, context, and formal advanced training where logically required. Characters may combine capabilities associated with several disciplines when the actual prerequisites are satisfied.
-
-Do not broadly remove the existing job state before the 0.6 capability migration. Also do not deepen it into a permanent magical class-lock model.
-
-See `docs/TRANSITIONAL_ARCHITECTURE.md` for implementation constraints.
-
-## Current version state
-
-Target state for the current stabilization branch:
+## Current merged baseline
 
 ```text
-Product:      0.4.600.0
-Package:      0.4.600
+Product:      0.5.500.0
+Package:      0.5.500
 Account Save: 4
-Game State:   3
+Game State:   4
 Data:         13
-Codename:     Foundation Stabilization
+Codename:     Day Boundary Review
 ```
 
-Product version format:
+Completed:
+
+- `0.4` foundation: versioning, migrations, ActionResult, semantic events, architecture stabilization;
+- `0.5.100` deterministic world clock;
+- `0.5.200` pause/speed control;
+- `0.5.300` canonical timed tasks;
+- `0.5.400` deterministic simulation interrupt model;
+- `0.5.500` day boundaries, structured day summaries, configurable end-of-day pause.
+
+The 0.5.500 merge is the point at which the roadmap was deliberately re-baselined to recognize that content breadth and data-production infrastructure are first-class engineering requirements.
+
+## Immediate target
 
 ```text
-MAJOR.PHASE.TRACK.REVISION
+0.5.550 — Original-world identity and canonical nomenclature
 ```
 
-`package.json.version` remains valid three-part SemVer and normally mirrors `MAJOR.PHASE.TRACK`.
+This runtime migration happens **before high-volume item/monster/quest/recipe database expansion**.
 
-### Completed foundation tracks
+### Initial original-world anchors
 
-- `0.4.100` — direction and version-roadmap lock.
-- `0.4.200` — product/package version separation and repository CI gate.
-- `0.4.300` — ordered Account Save/Game State migration mechanism.
-- `0.4.400` — versioned `ActionResult` contract; travel-start pilot.
-- `0.4.500` — bounded semantic event foundation; travel start/arrival pilot.
-- `0.4.600` — stabilization/readiness pass and transitional architecture documentation.
+- **Thornwall** — western crown realm/capital context;
+- **Elderwood** — surrounding western forest region;
+- **Brasshaven** — industrial/mercantile forge republic;
+- **Redstone Reach** — its mineral-rich hinterland;
+- **Mistmere** — scholastic canal city;
+- **Starfen** — surrounding wetland/grassland region;
+- **Waymeet** — future neutral central trade/transport hub.
 
-After this track is green, `0.4.900` is the 0.4 exit-gate certification. The next implementation phase is 0.5 deterministic world time.
+### Initial ancestry migration
 
-## New foundation contracts
+- Hume -> Human
+- Elvaan -> Lethari
+- Tarutaru -> Miri
+- Mithra -> Veyra
+- Galka -> Korren
 
-### Ordered persistence migrations
+Mechanical stat behavior can remain temporarily equivalent while the canonical identity changes.
 
-Files:
+### Initial discipline migration
+
+The transitional job scaffold should migrate to original player-facing names before capability database expansion:
+
+- Warrior -> Vanguard
+- Monk -> Pugilist
+- White Mage -> Lifewarden
+- Black Mage -> Elementalist
+- Red Mage -> Spellblade
+- Thief -> Shadowhand
+- Paladin -> Oathguard
+- Dark Knight -> Duskblade
+- Beastmaster -> Wildbinder
+- Bard -> Cantor
+- Ranger -> Wayfinder
+- Samurai -> Blade Adept
+- Ninja -> Veilrunner
+- Dragoon -> Sky Lancer
+- Summoner -> Eidolist
+- Blue Mage -> Echo Sage
+- Corsair -> Free Captain
+- Puppetmaster -> Artificer
+- Dancer -> Rhythmblade
+- Scholar -> Savant
+- Geomancer -> Leykeeper
+- Rune Fencer -> Wardsword
+
+These remain disciplines/training traditions, not permanent magical class locks.
+
+## 0.5.550 implementation expectations
+
+The migration should update more than display strings.
+
+1. Introduce canonical stable IDs for powers/regions/places/maps/ancestries/disciplines and other renamed runtime records.
+2. Add a bounded legacy-to-canonical identifier map at save/input boundaries.
+3. Use the ordered migration engine for persisted renamed identifiers; a Game State version bump is expected if saved state uses those IDs.
+4. Update world connections, map records, POIs, shop catalogs, enemy/spawn references, starting-state definitions, command examples, tests, and validation atomically.
+5. Rename current player-facing NPC/shop/creature/landmark content into the original setting rather than leaving a mixed canon.
+6. Keep historical FFXI research modules behind explicit legacy/reference naming/boundaries.
+7. New saves and canonical runtime records should not emit legacy FFXI stable IDs after the migration.
+
+Do not solve this by maintaining two permanent full schemas.
+
+## Following 0.5 tracks
 
 ```text
-js/text/systems/migrationEngine.js
-js/text/systems/saveMigrations.js
-js/text/save.js
+0.5.600  Persistent projects + resource provenance/body processing
+0.5.650  Ecology, gathering sources, spawn populations/regeneration
+0.5.700  Canonical timed routes + scheduled caravans/transport
+0.5.800  Regional content packs + normalization tools + cross-reference validation
+0.5.900  Simulation/content-substrate exit gate
 ```
 
-Registered migrations are applied sequentially. Unsupported old/future versions fail deterministically rather than being silently interpreted as current.
+Then 0.6 integrates substantial character stats/progression, skills/proficiencies/disciplines/capabilities, original magic/abilities, Combat 2.0, item/tool breadth, gathering/crafting/cooking/salvage, ecology content, and AI companions.
 
-`reviveGameState()` still repairs JSON-broken object references such as `player.inventory`, but it is not the migration system.
+0.7 is the first multi-region playable-alpha phase: multiple cities/settlements, transport networks, hundreds-scale NPC population, regional economies, systemic quests/contracts/rewards/reputation, relationships/romance, and substantial regional content packs.
 
-### ActionResult
+## Resource/economy design law
 
-File:
+Rewards should have physical, economic, or social provenance.
+
+A defeated animal normally creates access to a body; it does not automatically produce a finished pelt in inventory.
+
+Desired acquisition paths include:
+
+- search carried belongings;
+- skin/butcher/pluck/extract;
+- gather/forage/log/mine/dig/fish/trap;
+- dismantle/salvage;
+- craft/process/cook;
+- buy/barter/earn wages;
+- quest/contract/reputation/social rewards;
+- deliberate exceptional magic when the fiction explicitly supports it.
+
+Item chains should create meaningful source/sink graphs such as:
 
 ```text
-js/text/systems/actionResult.js
+creature/body -> raw materials -> processing -> ingredients/components -> recipes -> usable goods -> consumption/wear/repair/salvage
 ```
 
-Representative semantic shape:
+## World/navigation law
 
-```text
-contract
-version
-ok
-action
-code
-outcome
-data
-display
-```
+A home base is useful but is not the whole game.
 
-Engine consumers should use semantic fields instead of parsing prose. Non-enumerable `.message` / `.reason` aliases exist only as transitional command compatibility adapters.
+The target supports multiple cities, smaller settlements, roads, wilderness, dungeons, caravans, ferries, mounts/pack logistics, and regional trade.
 
-Travel start is the first migrated path.
+Internal `place`/map/content partitions may remain for simulation and navigation. Avoid making those boundaries mandatory gamey player-facing loading transitions unless a physical/fantastical boundary actually exists.
 
-### Semantic events
+Maps represent knowledge. Exploration, NPC directions, purchases, landmarks, and discovered routes should matter.
 
-File:
+## Data-scale law
 
-```text
-js/text/systems/semanticEventEngine.js
-```
+Do not confuse a schema with a complete system.
 
-Events have stable sequential IDs, typed names, source, optional observed world-time seconds, and structured data. They are bounded observational history, not event sourcing and not the authoritative source of game state.
+The intended product eventually contains hundreds/thousands of cross-linked places, NPCs, creatures, resources, items, recipes, techniques/spells, quests, relationships, shops/services, and transport routes.
 
-Travel currently emits:
+Mechanics and representative content must grow together. Regional content packs and validation are required before large-scale data generation.
 
-```text
-travel.started
-travel.arrived
-```
+## Current transitional technical debt
 
-Objective/quest/achievement/end-of-day consumers should eventually use event types/data rather than parsing command-log prose.
+Treat these as temporary:
 
-## World-time insertion point
+- FFXI-derived world/place/nation/race/job/currency naming;
+- `mainJobId` as a universal ability gate;
+- sparse placeholder skill-rank math;
+- placeholder spell/weapon-skill combat actions;
+- automatic generic battle loot where provenance/body processing should replace it;
+- tiny starter equipment/shop/enemy catalogs;
+- legacy `data/` modules and `ffxi*` research tables;
+- historical localStorage key names.
 
-The current `tickEngine.js` uses wall-clock timing and is only a scheduling/dispatch scaffold.
+Replace them incrementally behind migrations and tested interfaces rather than through an unbounded rewrite.
 
-It must not become the canonical game calendar.
+## CI rule
 
-0.5 should introduce deterministic world-time state and exact advancement independently of `Date.now()`. The desired boundary is:
-
-```text
-optional wall-clock scheduler
-        -> requests simulation advancement
-        -> deterministic world clock
-        -> tasks/travel/projects/status/events
-```
-
-Tests and commands must be able to advance simulation without sleeping or waiting for real time.
-
-## Current browser/UI architecture
-
-```text
-index.html
-  -> js/main.js
-      -> createCanvasApp(canvas)
-          -> loadActiveCharacter() or createInitialState()
-          -> createCommandRouter(state)
-          -> createSlashCommandRouter(state)
-          -> canvas render/input loop
-```
-
-The active UI is canvas-first and text-focused. Limited icons, tokens, meters, diagrams, cards, or similar state aids are welcome; do not rebuild a fully graphical world unless explicitly requested.
-
-Logic must remain independent of rendering.
-
-## Existing foundations to preserve
-
-### World and interaction
-
-- starter cities/wilderness/dungeon hooks;
-- San d'Oria alphanumeric topology;
-- coordinate movement and atlas discovery;
-- zone graph and travel restrictions;
-- foot-travel aggro scaffold;
-- POI discovery/actions and same-zone travel.
-
-### Inventory/equipment/economy
-
-- Inventory plus Mog/storage/portable/wardrobe containers;
-- capacity/access/stack rules;
-- item normalization/schema;
-- equipment eligibility/equip/unequip;
-- item inspection;
-- shop buying/selling;
-- metadata-only latent/enchantment/charge/ranged-ammo behavior.
-
-### Progression/combat
-
-- character-owned `player.progression.skills[skillId]` values;
-- sparse skill-cap scaffolds;
-- deterministic representative skill-gain hooks;
-- EXP, leveling, reward and loot scaffolds;
-- battle state and deterministic RNG injection;
-- placeholder attacks/weapon skills/casts;
-- status lifecycle.
-
-Current FFXI formulas/caps are scaffold data unless explicitly confidence-labeled otherwise.
-
-## Save/account rules
-
-Current local keys:
-
-```text
-ffxiTextRpgAccounts
-ffxiTextRpgAccountSession
-```
-
-Encoding:
-
-```text
-base64-json-v1
-```
-
-This is encoding, not cryptographic protection.
-
-Important compatibility reference:
-
-```text
-player.inventory
-```
-
-must reference:
-
-```text
-player.inventoryState.containers.inventory.items
-```
-
-after load/revive.
-
-Persistent incompatible state changes require an ordered migration or an explicit reset decision.
-
-## Development gate
-
-Use Node 20+.
+Before merging runtime work:
 
 ```bash
 npm test
 npm run benchmark
-npm run check
 ```
 
-GitHub Actions runs the test and benchmark gate for pull requests and pushes to `main`.
-
-New runtime tracks should merge only after the gate is green.
-
-## Immediate sequence after 0.4 stabilization
-
-1. `0.4.900` — certify the 0.4 exit gates and synchronize authoritative docs.
-2. `0.5.100` — deterministic world clock.
-3. `0.5.200` — pause/simulation speed boundary.
-4. `0.5.300` — canonical timed task model.
-5. `0.5.400` — interrupt model.
-6. `0.5.500` — day boundary and end-of-day review.
-7. `0.5.600` — persistent project model.
-8. `0.5.700` — integrate travel plus one non-travel activity with canonical time.
-9. `0.5.900` — 0.5 exit gate.
-
-Then 0.6 begins capability/disciplines/origins/livelihood work.
-
-## First representative gameplay target
-
-0.7 working slice: **A Week Beyond the West Gate**.
-
-It should combine origins, a modest foothold, one livelihood loop, local economy, one persistent material/labor project, simulated days/EoD review, preparation, one meaningful expedition, travel danger/combat, return/recovery, measurable capability growth, and one permanent end-of-week accomplishment.
-
-The purpose is to prove that life-building and adventure are one connected game rather than separate minigames.
+GitHub Actions must be green unless a failure is explicitly understood, fixed, and rerun.

--- a/docs/VERSIONING_AND_RELEASE_ROADMAP.md
+++ b/docs/VERSIONING_AND_RELEASE_ROADMAP.md
@@ -1,24 +1,27 @@
 # Versioning and Release Roadmap
 
-This document defines the product-version protocol and the planned release path from the current rough foundation to a coherent 1.0 release.
+This document defines the product-version protocol and the milestone gates from the current pre-alpha foundation to 1.0.
 
-The roadmap is intentionally milestone-driven rather than calendar-driven. A version changes because its exit criteria are met, not because a date arrived or a large number of commits accumulated.
+The roadmap is milestone-driven rather than calendar-driven. A version changes because its exit criteria are met, not because a date arrived or because a large number of commits accumulated.
 
-`docs/DEVELOPMENT_DIRECTION.md` is the design north star. This document translates that direction into version gates.
+Authoritative companions:
 
-## Current baseline and transition
+- `docs/DEVELOPMENT_DIRECTION.md` — product/design north star.
+- `docs/WORLD_IDENTITY_AND_CONTENT_POLICY.md` — original-setting, naming, provenance, content scale, and import policy.
+- `docs/ROADMAP.md` — concise implementation status and phase index.
 
-The current repository uses a legacy three-part application/package version:
+## Current baseline
 
 ```text
-0.4.4
+Product:      0.5.500.0
+Package:      0.5.500
+Account Save: 4
+Game State:   4
+Data:         13
+Codename:     Day Boundary Review
 ```
 
-That number describes a very early foundation build. It should not be read as “44% complete” or as a promise that 0.5 is nearly production-ready.
-
-The existing project is architecturally useful but still pre-alpha in product terms: it has many system scaffolds and relatively little complete game experience.
-
-The new protocol should not retroactively renumber historical releases. `0.4.4` remains the historical baseline. The four-part product-version format begins when the version manifest is deliberately migrated in a runtime PR.
+The repository is pre-alpha. It has a useful deterministic simulation foundation and several gameplay scaffolds, but content breadth and many integrated mechanics remain far below the intended game.
 
 ## Product version format
 
@@ -31,835 +34,448 @@ MAJOR.PHASE.TRACK.REVISION
 Example:
 
 ```text
-0.5.300.4
+0.5.550.3
 ```
-
-Meaning:
 
 | Segment | Meaning |
 | --- | --- |
-| `MAJOR` | Product stability/compatibility generation. `0` means pre-1.0 development; `1` begins the live compatibility contract. |
-| `PHASE` | Major pre-release milestone or, after 1.0, the live feature line. Examples: `0.5`, `0.7`, `0.9`. |
-| `TRACK` | Three-digit scoped sub-milestone within the phase. Planned tracks normally advance by 100: `100`, `200`, `300`, etc. |
-| `REVISION` | Incremental integration counter inside the active track. It starts at `0` and increments for merged runtime changes that advance or repair that track. |
+| `MAJOR` | Stability/compatibility generation. `0` is pre-1.0; `1` begins the live compatibility contract. |
+| `PHASE` | Major development milestone, such as `0.5`, `0.6`, or `0.7`. |
+| `TRACK` | Three-digit scoped milestone within the phase. Planned tracks normally use `100`, `200`, etc.; inserted tracks such as `550` are allowed. |
+| `REVISION` | Runtime-affecting integration counter inside the active track. |
 
-### Why the track is three digits
-
-Using `100`, `200`, `300` leaves room to insert unforeseen work without renumbering the entire roadmap.
-
-For example:
-
-```text
-0.6.200.x  discipline classification
-0.6.250.x  inserted prerequisite refactor
-0.6.300.x  equipment/preparation eligibility
-```
-
-The roadmap numbers are therefore stable labels, not estimates of effort.
-
-## Revision handling
-
-The fourth segment is deliberately simple.
-
-Within one track:
-
-```text
-0.5.200.0
-0.5.200.1
-0.5.200.2
-0.5.200.3
-```
-
-A revision increment means a merged runtime-affecting change has advanced, fixed, or hardened the current track.
-
-When the track exit gate is met, move to the next track and reset the revision:
-
-```text
-0.5.200.7 -> 0.5.300.0
-```
-
-When the phase exit gate is met, move to the next phase:
-
-```text
-0.5.900.x -> 0.6.100.0
-```
-
-Do not bump the fourth segment for README wording, comments, planning notes, or other docs-only edits unless a release artifact itself is being corrected and the project explicitly chooses to version documentation releases.
+The track numbering is a stable planning label, not an estimate of percentage complete or amount of work.
 
 ## Product version versus package version
 
-The project currently treats `VERSION.app` and `package.json.version` as the same value. That cannot continue unchanged because npm package versions use standard three-part SemVer while the product protocol uses four numeric segments.
-
-At protocol adoption, separate these concepts.
-
-Recommended model:
-
-```text
-Product/game version: 0.5.300.4
-Package/tooling version: 0.5.300
-```
-
 The four-part product version is authoritative for game-development milestones.
 
-`package.json.version` remains valid SemVer and normally mirrors `MAJOR.PHASE.TRACK`, omitting the fourth revision. Because the package is private, it does not need to change for every product revision unless tooling or package identity actually requires it.
-
-If an exact build identity is later needed in package metadata, use valid SemVer prerelease/build metadata rather than a fourth numeric segment.
+`package.json.version` remains valid three-part SemVer and normally mirrors `MAJOR.PHASE.TRACK` while omitting the product revision.
 
 Example:
 
 ```text
-0.5.300+rev.4
+Product: 0.5.550.4
+Package: 0.5.550
 ```
 
-Do not place `0.5.300.4` directly into `package.json.version`.
+Do not put a four-part numeric product version directly into `package.json.version`.
 
-## Other version counters
+## Independent schema/system versions
 
-The existing independent counters remain useful and should not be collapsed into the product version.
+Do not collapse these into the product version:
 
-Examples:
+- Account Save;
+- Game State;
+- Data;
+- Benchmark;
+- individual system versions.
 
-- Account Save
-- Game State
-- Data
-- Benchmark
-- individual system versions
+The product version answers **what development milestone does this build represent?**
 
-These answer different questions.
+Persistence versions answer **can saved data be read, migrated, or rejected safely?**
 
-### Product version
+The Data version answers **has the canonical data contract changed in a way consumers/migrations must distinguish?**
 
-Answers:
+System versions answer **what revision of one subsystem contract is present?**
 
-> What coherent development milestone does this build represent?
-
-### Game State / Account Save
-
-Answers:
-
-> Can persisted player data be safely read, migrated, or rejected?
-
-Increment these only when the persisted schema/contract changes.
-
-### Data version
-
-Answers:
-
-> Has the authoritative data schema/content contract changed in a way that consumers or migrations need to distinguish?
-
-Do not bump it for every content entry.
-
-### System versions
-
-Answers:
-
-> What revision of an individual subsystem's behavior or public contract is present?
-
-System versions may continue to use ordinary three-part SemVer-like values. They do not have to match the product milestone.
-
-## Version bump protocol
+## Runtime version-bump protocol
 
 Every runtime PR should declare:
 
 1. target product phase/track;
-2. whether it increments product revision or completes a track;
+2. previous and resulting product version or whether the PR does not yet complete the track;
 3. affected system versions;
-4. whether Game State, Account Save, or Data versions change;
+4. Game State / Account Save / Data version impact;
 5. migration/reset implications;
-6. tests and benchmark results;
-7. known limitations.
+6. tests and benchmark status;
+7. known limitations and intentionally deferred work.
 
-### Normal runtime change inside a track
+A runtime change inside an active track normally increments the fourth segment. Completing a track advances the three-digit track and resets revision to zero only when the prior gate is actually satisfied.
 
-Example:
+Docs-only planning changes normally do **not** bump product version.
 
-```text
-Before: 0.5.200.3
-After:  0.5.200.4
-```
-
-Use when the change advances or fixes the same scoped goal.
-
-### Track completion
-
-Example:
-
-```text
-Before: 0.5.200.7
-After:  0.5.300.0
-```
-
-Use only when the prior track's exit gate is satisfied and the codebase is ready to begin the next scoped objective.
-
-### Phase completion
-
-Example:
-
-```text
-Before: 0.6.900.5
-After:  0.7.100.0
-```
-
-Do not enter the next phase just because planned features exist on branches. The merged `main` branch must satisfy the phase exit gate.
-
-### Bug fixes
-
-A bug fix that belongs to the active track increments the revision.
-
-A critical bug discovered after the team has begun a later track should normally be fixed on the current line and documented as a regression fix. Avoid reopening historical numbering unless an actual release branch/hotfix policy exists.
-
-### Docs-only planning
-
-No product-version bump.
-
-### Save-shape change
-
-A product-version bump does not substitute for a Game State/Account Save migration decision. If persistence shape changes, bump the relevant schema counter and provide an explicit migration or deliberate reset policy.
-
-## Milestone philosophy
-
-Pre-1.0 versions are product-completeness gates, not marketing labels.
-
-Each phase should leave the game materially more playable than the prior phase.
-
-A phase is not complete because its modules exist. It is complete when the player-facing loop associated with that phase works end-to-end and is covered by tests/validation appropriate to the system.
+A product-version bump never substitutes for a persistence migration. If stable IDs or persisted schema change, bump and migrate the relevant persistence version explicitly.
 
 ---
 
-# 0.4 — Foundation Closeout and Direction Lock
+# Historical milestone record
 
-## Purpose
+## 0.4 — Foundation closeout — complete
 
-Convert the existing broad scaffold into a stable launch point for the new game direction without attempting another rewrite.
-
-The historical baseline is `0.4.4`. The first four-part release should be made deliberately during this phase when the version manifest/protocol is implemented.
-
-## 0.4.100 — Direction and version protocol
-
-Planning/design deliverables:
+### 0.4.100 Direction and version protocol
 
 - development north star;
 - version protocol;
-- updated authoritative roadmap/handoff references;
-- explicit declaration that formula reconstruction is no longer the primary roadmap spine;
-- jobs/discipline/capability/loadout design recorded.
+- explicit move away from formula-reconstruction as roadmap spine.
 
-This track may be documentation-only and therefore does not itself require changing the historical `0.4.4` runtime string.
+### 0.4.200 Version manifest separation
 
-## 0.4.200 — Version manifest separation
+- four-part product version;
+- package/product version separation;
+- CI version tests.
 
-Runtime/tooling deliverables:
+### 0.4.300 Ordered persistence migrations
 
-- introduce authoritative four-part product version field;
-- decouple product version from `package.json.version`;
-- update version-display tests;
-- document package/product version behavior;
-- retain compatibility aliases only where genuinely useful.
+- ordered Game State migration engine;
+- deterministic handling of unsupported/future state.
 
-Suggested first four-part product version:
+### 0.4.400 Structured action contract
 
-```text
-0.4.200.0
-```
+- `ActionResult`-style semantic outcome contract;
+- display prose separated from engine meaning.
 
-## 0.4.300 — Ordered persistence migrations
+### 0.4.500 Semantic event foundation
 
-Deliverables:
-
-- explicit ordered Game State migration mechanism;
-- explicit Account Save migration path where needed;
-- deterministic handling of unsupported old state;
-- tests for migration order and failure behavior;
-- remove reliance on ad-hoc revive logic as the only compatibility strategy.
-
-## 0.4.400 — Structured action contract
-
-Deliverables:
-
-- define a small `ActionResult`-style contract for engine-facing actions;
-- separate semantic outcome data from display prose;
-- migrate one representative action path first;
-- preserve command compatibility as an adapter.
-
-## 0.4.500 — Lightweight semantic event foundation
-
-Deliverables:
-
-- structured events for important game outcomes;
 - stable event IDs/types;
-- tests proving consumers do not parse log prose to understand game state;
-- no full event-sourcing architecture.
+- bounded structured event history;
+- consumers do not need to parse log prose.
 
-## 0.4.600 — Current-system stabilization
+### 0.4.600 / 0.4.900 stabilization and exit
 
-Deliverables:
-
-- preserve current inventory/equipment/travel/combat foundations;
-- fix blocking regressions exposed by the new contracts;
-- document transitional job/main-job assumptions;
-- validate that the architecture can accept world-time and capability work without a rewrite.
-
-## 0.4.900 — 0.4 exit gate
-
-0.4 is complete when:
-
-- the new direction and version protocol are authoritative;
-- product/package version concepts are separated;
-- ordered persistence migration exists;
-- a structured action/event seam exists;
-- current systems remain functional and tested;
-- the next phase can build deterministic world time without depending on wall-clock behavior.
+- existing travel/inventory/combat foundations preserved;
+- architecture certified ready for deterministic world time.
 
 ---
 
-# 0.5 — World Time, Tasks, and Projects
+# 0.5 — Simulation and Content Substrate — active
 
 ## Purpose
 
-Establish the simulation substrate for long-duration play without real-world waiting.
+Finish the deterministic long-duration simulation foundation **and** establish the original-world/content infrastructure required before thousands of gameplay records are authored.
 
-## 0.5.100 — Deterministic world clock
+The phase was re-baselined after 0.5.500 because the earlier plan materially underestimated the data scale required for a sandbox life/adventure RPG.
 
-Deliverables:
+## 0.5.100 — Deterministic world clock — complete
 
-- canonical world date/time state;
-- deterministic time advancement independent of `Date.now()`;
-- world-time formatting and inspection;
-- tests for exact advancement.
+Deliverables met:
 
-## 0.5.200 — Pause and speed control
+- canonical simulation seconds;
+- exact deterministic advancement;
+- persistence migration;
+- day/hour/minute derivation;
+- no dependency on `Date.now()` for simulation truth.
 
-Deliverables:
+## 0.5.200 — Pause and speed control — complete
 
-- pause/resume semantics;
-- simulation speed control;
-- fast-forward that advances simulation rather than merely changing renderer timing;
-- clean boundary between wall-clock scheduling and world-time calculation.
+Deliverables met:
 
-## 0.5.300 — Canonical timed task model
+- pause/resume;
+- configurable deterministic speed multiplier;
+- wall-clock scheduler adapter;
+- sub-second remainder;
+- no catch-up burst after pause.
 
-Deliverables:
+## 0.5.300 — Canonical timed tasks — complete
 
-- common task/action duration representation;
-- start/progress/complete/cancel semantics where appropriate;
-- deterministic task completion;
-- travel adapted as one consumer without forcing every system into travel-specific logic.
+Deliverables met:
 
-## 0.5.400 — Interrupt model
+- versioned task registry;
+- stable task IDs;
+- canonical start/completion boundaries;
+- deterministic progress, completion, cancellation, and reconciliation.
 
-Deliverables:
+## 0.5.400 — Interrupt model — complete
+
+Deliverables met:
 
 - advance-until-event;
-- meaningful interrupt priority;
-- combat/exhaustion/tool failure/project completion hooks or placeholders;
-- tests for deterministic interrupt ordering.
+- deterministic interrupt ordering;
+- task-completion source;
+- generic provider seam for combat, exhaustion, project completion, tool failure, day boundaries, and later systems;
+- interrupt-aware accelerated scheduler.
 
-## 0.5.500 — Day boundary and end-of-day review
+## 0.5.500 — Day boundary and end-of-day review — complete
 
-Deliverables:
+Deliverables met:
 
-- day transition;
-- configurable end-of-day auto-pause;
-- structured daily summary data;
-- review UI/text output;
-- continue/save/inspect flow.
+- deterministic midnight boundaries;
+- structured daily summaries;
+- end-of-day auto-pause preference;
+- day start/end semantic events;
+- priority-safe simultaneous interrupts;
+- lazy compatibility for older Game State v4 records.
 
-## 0.5.600 — Persistent project model
+## 0.5.550 — Original-world identity and stable-ID migration — next
 
-Deliverables:
+### Purpose
 
-- projects with material requirements;
-- accumulated labor/time;
-- progress visibility;
-- completion events;
-- no arbitrary exponential duplicate-building multiplier.
+Remove inherited FFXI world identity before large content generation multiplies migration cost.
 
-## 0.5.700 — Time-cost integration pilot
+### Deliverables
 
-Deliverables:
+- canonical original world/power/region/place/map identifiers and display names;
+- canonical ancestry terminology;
+- canonical discipline terminology for the transitional job scaffold;
+- canonical currency, storage, travel, companion, faction, and other player-facing system vocabulary where inherited terminology exists;
+- current creature, NPC, shop, POI, and landmark names originalised;
+- bounded legacy-to-canonical alias/migration table;
+- ordered persistence migration for renamed identifiers carried by saves;
+- tests proving old saves resolve to canonical IDs and new saves do not emit legacy IDs;
+- legacy FFXI-derived files clearly quarantined as research/reference data;
+- package/readme/player-facing copy no longer presents the project as an FFXI world implementation.
 
-- integrate at least travel plus one non-travel work activity with the canonical time model;
-- resource/energy or fatigue hooks where appropriate;
-- fast-forward through low-information periods without skipping meaningful events.
+### Persistence expectation
 
-## 0.5.900 — 0.5 exit gate
+Stable place/nation/ancestry/discipline identifiers are already persisted. This track is expected to require a Game State schema migration unless implementation proves all persisted references can be safely migrated at an already-versioned boundary. Prefer an explicit Game State version bump over indefinite dual schemas.
 
-0.5 is complete when the player can perform multi-hour/multi-day fictional activities, fast-forward safely, reach a day boundary, review meaningful progress, and advance a persistent project without the design depending on real-world waiting.
+### Exit gate
 
----
+New canonical content can be authored without FFXI proper nouns or stable IDs. Compatibility aliases are isolated to migration/input boundaries.
 
-# 0.6 — Character Capability, Disciplines, Origins, and Livelihood
+## 0.5.600 — Resource provenance and persistent projects
 
-## Purpose
+### Deliverables
 
-Replace magical job-switch assumptions with a continuous-character capability model and give the character a meaningful starting life.
+- persistent project model with materials, labor, canonical time, progress, and completion events;
+- acquisition-source schema for carried goods, body processing, flora, minerals, fishing, salvage, crafting, commerce, contracts, and exceptional magic;
+- post-combat bodies/resource opportunities rather than automatic finished-item drops for creatures where that fiction does not make sense;
+- search/skin/butcher/pluck/extract/salvage action foundation;
+- item source/sink metadata and validation hooks.
 
-## 0.6.100 — Capability and proficiency model
+## 0.5.650 — Ecology, gathering, and spawn substrate
 
-Deliverables:
+### Deliverables
 
-- learned capabilities stored independently from current equipment;
-- proficiency/mastery representation;
-- capability inspection;
-- migration strategy from existing character-owned skills.
+- species/family records separate from encounter instances;
+- habitat, population density, rarity, aggression, senses, social/link behavior, and environmental hooks;
+- flora/mineral/fishing/gathering-source definitions;
+- deterministic regeneration/respawn rules;
+- rare/named spawn foundation;
+- environment/resource outputs reference canonical items rather than free-form strings.
 
-## 0.6.200 — Jobs as disciplines/classifications
+## 0.5.700 — Canonical travel and scheduled transport
 
-Deliverables:
+### Deliverables
 
-- jobs represented as training traditions/archetypes rather than magical active states;
-- discipline metadata for training, recognition, and advanced instruction;
-- clear distinction between discipline identity and immediate ability eligibility;
-- transitional compatibility for current job data.
+- walking/local travel consumes canonical simulation time;
+- route/road representation independent of artificial player-facing zone screens;
+- scheduled caravan implementation with stops, fares, cargo, travel time, and interrupt hooks;
+- shared transport contract suitable for ferries, wagons, mounts, and later air transport;
+- map/route-knowledge discovery hooks;
+- at least one non-travel work activity uses the same time system.
 
-## 0.6.300 — Equipment/preparation prerequisites
+## 0.5.800 — Regional content packs, import normalization, and validation
 
-Deliverables:
+### Deliverables
 
-- hard requirements;
-- soft requirements with data-driven penalties;
-- enhancers;
-- equipment, focus, ammunition, tool, reagent, stance, and context checks where relevant.
+- content-pack schema for places/routes/maps/NPCs/shops/ecology/resources/items/recipes/quests/relationships/transport;
+- cross-reference validation across those record families;
+- tools that transform legacy/reference data into reviewable candidate records rather than direct canonical imports;
+- validation of item sources/sinks, recipe references, reachable quest objectives, transport topology, maps, and companion/NPC references;
+- data workflow tested at realistic hundreds-of-record scale.
 
-## 0.6.400 — Cross-discipline ability access
+## 0.5.900 — Phase exit gate
 
-Deliverables:
+0.5 closes when:
 
-- capabilities from multiple disciplines can coexist;
-- no single support-job slot as the universal gate;
-- loadout/resource/preparation tradeoffs prevent unrestricted optimal use of everything at once;
-- tests for valid hybrid behavior.
-
-## 0.6.500 — Origin system
-
-Deliverables:
-
-- multiple starting backgrounds;
-- different starting loadouts/resources/relationships/proficiencies;
-- origins do not permanently lock later disciplines;
-- character creation revised around starting circumstances rather than only a starting job toggle.
-
-## 0.6.600 — First livelihood loop
-
-Deliverables:
-
-- one complete gathering/farming/crafting-oriented work loop;
-- time, energy/resource cost, yield, proficiency growth, and sale/use of output;
-- measurable improvement with mastery.
-
-## 0.6.700 — Preparation/loadout UX
-
-Deliverables:
-
-- clear presentation of what the current loadout enables, weakens, or blocks;
-- recognizable archetype classification may be shown as descriptive shorthand;
-- the UI must not imply that equipment literally transforms the character into another person/job.
-
-## 0.6.900 — 0.6 exit gate
-
-0.6 is complete when one character can learn capabilities across disciplines, change effective play style through logical equipment/preparation, begin from different origins, and participate in at least one livelihood loop without magical job transformation.
+- multi-hour/day simulation can safely fast-forward, interrupt, and summarize;
+- original-world canonical naming and stable IDs are established;
+- provenance/projects/ecology/gathering/transport substrate exists;
+- content packs and validators can support high-volume original content generation;
+- the engine has demonstrated that broad data can be added without giant monolithic files or another naming reset.
 
 ---
 
-# 0.7 — First Complete Game Loop
+# 0.6 — Integrated Character and Mechanics Content
 
 ## Purpose
 
-Deliver the first genuinely representative game experience: life building plus preparation plus adventure plus permanent progress.
+Turn the substrate into a substantial playable mechanics layer. Mechanics and content are developed together; no subsystem is considered validated from a toy catalog alone.
 
-Working slice: **A Week Beyond the West Gate**.
+## 0.6.100 Character stats and progression
 
-## 0.7.100 — Objective/quest state foundation
+- complete primary/resource/derived stat contracts;
+- character-owned advancement;
+- balance/progression rules used by work, training, exploration, and combat;
+- confidence-labeled formulas and deterministic tests.
 
-Deliverables:
+## 0.6.200 Skills, proficiencies, disciplines, capabilities
 
-- lightweight objective state machine;
-- semantic event-driven progress;
-- talk/collect/travel/kill/work/project objective types as needed by the slice;
-- rewards and unlocks.
+- full canonical skill registry;
+- original discipline/training traditions;
+- learned capabilities independent of current equipment;
+- hard/soft/enhancing requirements;
+- cross-discipline access based on actual prerequisites.
 
-## 0.7.200 — Home-base foothold
+## 0.6.300 Magic and active ability engine
 
-Deliverables:
+- canonical spell/technique schema;
+- cost, cast/use time, recast, target, effect, unlock/training provenance;
+- casting/interruption/recast behavior;
+- substantial original spell/ability catalog.
 
-- a real starting foothold appropriate to origin;
-- storage/recovery/preparation context;
-- one permanent project tied to establishing or improving the foothold.
+## 0.6.400 Combat 2.0
 
-## 0.7.300 — West Gate expedition loop
+- tactical enemy AI;
+- family abilities;
+- statuses and resistance/mitigation;
+- attention/threat;
+- weapon techniques and party interactions;
+- KO/injury/recovery;
+- simulation-time integration.
 
-Deliverables:
+## 0.6.500 Items, equipment, tools, maps, consumables
 
-- prepare;
-- leave the safe area;
-- travel through a meaningful route;
-- encounter risk;
-- complete an objective;
-- return with materials/rewards/state changes.
+- hundreds-scale validated canonical item catalog;
+- equipment and direct-use behavior;
+- tools, containers, maps, reagents, ammunition, food, medicine, permissions, and quest objects;
+- repair/maintenance where economically useful.
 
-## 0.7.400 — Combat/recovery hardening for the slice
+## 0.6.600 Gathering, hunting, processing, crafting, cooking, salvage
 
-Deliverables:
+- complete loops for major gathering modes;
+- body processing and yield/quality decisions;
+- recipe/process engine with tools/stations/time/proficiency/quality/byproducts;
+- multiple craft and cooking/medicine branches;
+- regional material chains.
 
-- reliable target handling;
-- enemy turn/AI adequate for the slice;
-- KO/injury/recovery behavior;
-- clear battle end cleanup;
-- combat advancement compatible with world time.
+## 0.6.700 Ecology/content integration
 
-## 0.7.500 — First-week progression integration
+Planning-scale target for phase exit:
 
-Deliverables:
+- 40–60 meaningful creature/fauna definitions;
+- 40+ environmental resource/flora definitions;
+- multiple families, variants, habitats, rare encounters, and economic/quest uses.
 
-- multiple simulated days;
-- end-of-day summaries;
-- livelihood and expedition interdependence;
-- proficiency/capability gains;
-- project progression;
-- a permanent end-of-week accomplishment.
+## 0.6.800 AI party/companion foundation
 
-## 0.7.600 — Slice UX and onboarding
+- recruitable persistent companions;
+- tactical role/preferences/equipment/progression;
+- resource use and KO/recovery;
+- relationship hooks separate from combat AI;
+- at least 4–6 distinct companions proving different behavior profiles.
 
-Deliverables:
+## 0.6.900 Phase exit gate
 
-- player can discover actions without knowing command internals;
-- origin-specific opening guidance;
-- icons/tokens/meters used where helpful;
-- no full graphical-world requirement.
-
-## 0.7.700 — Replay and alternate-origin pass
-
-Deliverables:
-
-- at least two meaningfully different openings into the same systemic slice;
-- common systems remain reusable rather than scripting separate games per origin.
-
-## 0.7.900 — 0.7 exit gate
-
-0.7 is complete when a new player can start a character, live through a meaningful first week, work, prepare, travel, fight, return, build something permanent, and end the slice with materially expanded capability and future options.
-
-This is the first milestone that should be judged primarily by “is this fun enough to keep playing?” rather than “does the architecture exist?”
+One continuous character can train across disciplines, use substantial skill/magic/item catalogs, gather and transform world resources, fight tactically with or without companions, and improve through multiple interconnected activities.
 
 ---
 
-# 0.8 — Life, Infrastructure, and Systemic Expansion
+# 0.7 — Multi-Region Playable Alpha
 
 ## Purpose
 
-Turn the first slice into a durable long-form life RPG by expanding the systems that make accumulated resources and mastery change how the player lives.
+Deliver an actual sandbox campaign rather than a vertical systems demonstration.
 
-## 0.8.100 — Construction and renovation depth
+## 0.7.100 Multi-region world graph and exploration
 
-Deliverables:
+- multiple major cities/hubs and smaller settlements;
+- 30–50 meaningful places/localities by phase exit;
+- roads/wilderness/landmarks/maps/discovery;
+- internal partitions are not mandatory gamey player-facing zone screens.
 
-- reusable building instances;
-- upgrades/renovations;
-- capacity/efficiency improvements;
-- physically/economically justified costs;
-- project labor and logistics.
+## 0.7.200 Regional transport and logistics
 
-## 0.8.200 — Gathering and farming depth
+- caravans, ferries, hired transport, mounts/pack animals where appropriate;
+- schedules, stops, cargo, fares, risk, delays, escorts, and route reputation;
+- approximately 20–30 scheduled routes is the alpha-scale planning range.
 
-Deliverables:
+## 0.7.300 NPC populations and regional economies
 
-- multiple materials/crops or equivalent production lines;
-- quality/yield/season/environment hooks where useful;
-- better tools and infrastructure reduce labor or increase output;
-- avoid repetitive click expansion.
+- approximately 250–400 named NPCs by phase exit;
+- schedules/locations/services/dialogue;
+- 60–100 functional shops/services;
+- regional supply/demand and production differences create reasons to travel.
 
-## 0.8.300 — Crafting and tools
+## 0.7.400 Quest/contract/reward/reputation engine and content
 
-Deliverables:
+- semantic objective state;
+- broad objective vocabulary across social, exploration, gathering, work, crafting, transport, combat, delivery, escort, and projects;
+- real canonical rewards and world changes;
+- approximately 150–250 quests/contracts is the alpha-scale planning range.
 
-- structured recipe catalog;
-- tool requirements;
-- facilities;
-- skill/proficiency checks;
-- quality/failure rules appropriate to the game;
-- crafted goods feed other loops.
+## 0.7.500 Relationships and romance
 
-## 0.8.400 — Taming and husbandry
+- persistent multidimensional relationship state where useful;
+- friendship/rivalry/mentorship/community/romance;
+- candidates have schedules, goals, boundaries, and lives outside the player;
+- approximately 8–12 deep romance-capable NPCs is the alpha-scale planning range.
 
-Deliverables:
+## 0.7.600 Regional ecology/content packs
 
-- at least one tamable creature family;
-- relationship/care requirements;
-- housing/facility needs;
-- product, transport, labor, or companion value;
-- creature ownership should change capability, not just create another timer.
+- distinct biomes, resources, creature families, landmarks, settlements, dungeons, and local conflicts;
+- avoid copy-pasted region templates.
 
-## 0.8.500 — Relationships and local reputation
+## 0.7.700 Item/recipe/spell/technique/economy breadth
 
-Deliverables:
+Alpha-scale planning ranges:
 
-- persistent NPC relationships;
-- local/guild reputation or standing;
-- relationships unlock information, training, services, opportunities, or assistance;
-- avoid affection bars with no systemic consequence.
+- 800–1,500 canonical items;
+- 300–500 recipes/processes;
+- 250–400 spells/abilities/techniques;
+- 120–180 creature/fauna definitions;
+- 100–150 flora/resource definitions.
 
-## 0.8.600 — Logistics and labor-saving infrastructure
+These are scale targets across the phase, not requirements for one PR.
 
-Deliverables:
+## 0.7.800 Complete multi-city opening campaign layer
 
-- carts/pack capacity/storage networks/roads/irrigation/helpers or equivalent;
-- mature characters spend less attention on mastered low-level chores;
-- long-term resource sinks come from capability expansion rather than arbitrary multipliers.
+A new player can establish a foothold, explore and acquire maps/route knowledge, gather/hunt/fight, recover resources naturally, process/craft/cook/trade, recruit companions, form relationships, undertake systemic quests, use scheduled transport, reach other cities, and return/improve their home base.
 
-## 0.8.700 — Discipline and livelihood expansion
+The earlier **A Week Beyond the West Gate** concept may survive as one polished introductory arc, but is not the boundary of the game.
 
-Deliverables:
+## 0.7.900 Playable-alpha exit gate
 
-- additional disciplines/capabilities chosen for systemic value;
-- additional livelihood interactions;
-- hybrid play tested beyond the first slice.
-
-## 0.8.800 — Economy and project balancing
-
-Deliverables:
-
-- resource faucets/sinks reviewed across systems;
-- repeated identical construction remains logically priced;
-- upgrades/logistics/prestige create meaningful advanced demand;
-- no single livelihood trivially dominates all others.
-
-## 0.8.900 — 0.8 exit gate
-
-0.8 is complete when the player can pursue a sustained multi-week or multi-season life in which buildings, tools, creatures, relationships, and infrastructure measurably change how earlier work is performed.
+The project is coherent enough to play as a substantial multi-region sandbox campaign rather than a framework demonstration.
 
 ---
 
-# 0.9 — Adventure Depth, Content Expansion, and Release Hardening
+# 0.8 — Life and Infrastructure Expansion
 
-## Purpose
+Primary tracks will deepen:
 
-Bring adventure, magic, region content, balance, persistence, and UX to a release-candidate standard without losing the life-simulation identity proven in earlier phases.
+- property/home/land acquisition and renovation;
+- construction and persistent large projects;
+- farming/gardening/orchards;
+- husbandry/taming and practical animal systems;
+- workshops and specialist facilities;
+- logistics, carts, warehouses, roads, irrigation, hired labor, and earned automation;
+- relationships, households, civic institutions, and reputation;
+- production chains, maintenance, transport capacity, and regional ambition.
 
-## 0.9.100 — Adventure/combat depth
+The core progression law remains:
 
-Deliverables:
+```text
+effort -> mastery -> efficiency -> capability -> larger ambition
+```
 
-- stronger enemy behavior;
-- encounter variety;
-- tactical action choices;
-- status/recovery/death consequences;
-- preparation matters materially.
+Earlier chores should become easier to manage because the character has earned tools, knowledge, infrastructure, labor, and relationships—not because identical tasks receive arbitrary exponential costs.
 
-## 0.9.200 — Magic and advanced capabilities
+---
 
-Deliverables:
+# 0.9 — Adventure Depth and Release Hardening
 
-- structured spell/capability catalog;
-- cast/recast/resource behavior;
-- equipment/focus/preparation relationships;
-- hybrid access consistent with the discipline model;
-- formula confidence documented.
+Primary tracks will deepen:
 
-## 0.9.300 — Second dense region
-
-Deliverables:
-
-- prove the content architecture scales beyond the initial San d'Oria/Ronfaure-centered slice;
-- new local economy/resources/NPCs/objectives;
-- travel and discovery remain meaningful;
-- do not expand map count merely for breadth.
-
-## 0.9.400 — Long-form progression and economy balance
-
-Deliverables:
-
-- progression pacing across days/weeks/seasons reviewed;
-- grind produces measurable gains;
-- fast-forward does not trivialize decisions;
-- resource economy remains stable enough for extended play;
-- advanced sinks are logical and useful.
-
-## 0.9.500 — UI, accessibility, and readability
-
-Deliverables:
-
-- keyboard/mouse interaction stable;
-- action discovery and context panels clear;
-- text scaling/readability/accessibility improvements;
-- icons/tokens/meters used consistently;
-- no required command memorization for normal play.
-
-## 0.9.600 — Save compatibility and migration hardening
-
-Deliverables:
-
-- supported migration policy for late-beta saves;
-- corruption/failure handling;
-- backup/export/import strategy if appropriate;
-- 1.0 compatibility expectations documented.
-
-## 0.9.700 — Validation, performance, and deterministic test hardening
-
-Deliverables:
-
-- full standard test/check gate;
-- deterministic simulation tests;
-- benchmark targets;
-- content/schema validation;
-- no known blocker-class save, progression, or simulation defects.
-
-## 0.9.800 — Content complete beta
-
-Deliverables:
-
-- 1.0-critical content present;
-- no major 1.0 system still represented only by a placeholder;
-- tuning, writing, bug fixing, and polish may continue.
-
-## 0.9.900 — Release candidate freeze
-
-Deliverables:
-
-- feature freeze for 1.0-critical systems;
-- only release-blocking fixes, balancing, content corrections, migration work, and polish;
-- version/migration documentation finalized;
-- release checklist passes.
-
-## 0.9 exit gate
-
-0.9 is complete when `main` is suitable to promote to 1.0 without adding another foundational subsystem.
+- advanced combat and party tactics;
+- high-level magic/techniques;
+- bosses, rare threats, dungeons, expeditions, and dangerous-region traversal;
+- high-tier equipment/crafting and professions;
+- regional/faction/relationship arcs;
+- long-simulation economy and resource-source/sink balance;
+- UI/accessibility/readability/discoverability;
+- save migration compatibility;
+- validation/performance at thousands-of-record scale;
+- content-complete beta and release-candidate freeze.
 
 ---
 
 # 1.0 — Live Foundation
 
-Suggested initial product version:
+1.0 begins the explicit compatibility/product promise.
 
-```text
-1.0.000.0
-```
+The release must support one persistent character living across a connected original fantasy world with meaningful home/infrastructure, multiple cities/regions, livelihoods, preparation, exploration, natural resource acquisition, crafting/production, combat, companions, relationships, quests/contracts, regional economy, transport, and stable save migrations.
 
-`1.0` does not mean the game is finished forever. It means the core product promise is coherent, playable, stable enough to support persistent players, and governed by an explicit compatibility policy.
+Content can continue after 1.0, but 1.0 cannot depend on the promise that missing core breadth will be filled in later.
 
-## 1.0 minimum product promise
+## Formula policy
 
-A 1.0 player should be able to:
+Formula confidence labels remain:
 
-- create a character from meaningful starting circumstances;
-- develop one persistent character across multiple disciplines without magical job transformations;
-- use equipment/preparation to shape available and effective capabilities;
-- live through a deterministic day/time simulation with pause and fast-forward;
-- work at livelihoods and improve through measurable mastery;
-- own/use a persistent foothold and improve infrastructure;
-- undertake material projects with logical resource/labor costs;
-- travel into dangerous areas and prepare for expeditions;
-- fight, recover, and gain useful capability from adventure;
-- participate in an economy where work, crafting, gathering, and adventure interconnect;
-- build relationships/reputation that affect available opportunities;
-- tame/use at least representative creature systems if retained in the 1.0 scope;
-- progress through at least two dense regional content spaces;
-- experience end-of-day review and long-duration fictional progression without mandatory real-world waiting;
-- save/load through an explicit supported compatibility/migration contract;
-- play normal game flows without command-line expertise;
-- understand important state through text-first presentation plus limited visual polish.
+- exact/sourced;
+- researched approximation;
+- intentional simplification;
+- placeholder.
 
-## 1.0 quality gate
-
-Before promotion to 1.0:
-
-- no known data-loss blocker;
-- supported 0.9 save migration path is tested;
-- normal new-game-to-established-character loop is tested end-to-end;
-- first-region critical path and second-region access are complete;
-- economy has no obvious infinite or catastrophic early-game exploit in normal play;
-- fast-forward cannot silently skip blocker-class interrupts;
-- game logic remains renderer-independent;
-- validation/check/benchmark suite passes;
-- release notes and known limitations are explicit;
-- version manifest and all schema counters are correct;
-- project documentation points to current, non-superseded direction documents.
-
-## After 1.0
-
-Post-1.0 versions can continue using the same four-part product scheme:
-
-```text
-1.MINOR.TRACK.REVISION
-```
-
-Example:
-
-```text
-1.1.200.3
-```
-
-At that point `MINOR` represents a live feature line rather than a pre-release completeness phase.
-
-Breaking save or gameplay-contract changes after 1.0 require explicit migration/deprecation policy and should not be hidden inside an ordinary revision bump.
-
-A future `2.x` line should be reserved for a genuinely incompatible product-generation change, not ordinary content expansion.
-
----
-
-# Release management rules
-
-## Branch/PR targeting
-
-Every implementation branch should identify its intended target in the PR body, for example:
-
-```text
-Target: 0.5.300.x — Canonical timed task model
-```
-
-Do not mix unrelated tracks merely to increase version numbers faster.
-
-## Milestone completion evidence
-
-A track or phase exit should be based on merged evidence:
-
-- implemented behavior;
-- tests;
-- validation;
-- relevant benchmark/check results;
-- docs updated to the new state;
-- known limitations recorded.
-
-## Codenames
-
-Codenames are optional human-readable labels for meaningful product points. They must never replace numeric versions and should not be changed for every revision.
-
-Good use:
-
-```text
-0.7.900.x — First Week
-0.9.800.x — Content Complete Beta
-1.0.000.0 — Live Foundation
-```
-
-## Changelog policy
-
-`CHANGELOG.md` should record player-visible/runtime-significant changes grouped by product track or release.
-
-Do not flood the changelog with every internal refactor unless it affects behavior, compatibility, migration, testing guarantees, or developer-operational requirements.
-
-## Roadmap maintenance
-
-When reality changes, insert or revise future tracks rather than pretending the original plan was exact.
-
-Rules:
-
-- completed version labels are immutable history;
-- active track scope may be clarified but should not be silently broadened into a new phase;
-- new necessary work can use inserted track numbers such as `250` or `350`;
-- moving a feature later is preferable to declaring a milestone complete with placeholder behavior;
-- version numbers represent achieved gates, not aspirational branch names.
-
-## Current recommended sequence
-
-From the present `0.4.4` baseline:
-
-1. merge the direction/version planning docs without pretending they are runtime progress;
-2. implement `0.4.200` version-manifest separation;
-3. implement ordered persistence migrations;
-4. add structured action/event seams;
-5. close 0.4;
-6. build deterministic world time and task/project simulation in 0.5;
-7. build continuous-character capability/disciplines/origins in 0.6;
-8. prove the complete life/adventure loop in 0.7;
-9. deepen life/infrastructure systems in 0.8;
-10. deepen adventure, add a second region, balance, and harden in 0.9;
-11. promote the tested release candidate to `1.0.000.0`.
+Research from other games may inform design choices but does not define canonical balance or naming. Refine formulas when doing so materially improves a real player-facing loop at representative data scale.

--- a/docs/WORLD_IDENTITY_AND_CONTENT_POLICY.md
+++ b/docs/WORLD_IDENTITY_AND_CONTENT_POLICY.md
@@ -1,0 +1,258 @@
+# World Identity and Content Policy
+
+This document is authoritative for setting identity, content provenance, naming, and the order in which new gameplay data is authored.
+
+## Product identity
+
+The project is an original text-first persistent fantasy life RPG. Its working product identity is **Hearth & Horizon** until a later title review deliberately replaces it.
+
+The game may learn from the design tenets of older MMORPGs, life RPGs, tabletop games, survival games, and simulation games, but canonical content must not be a transcription of another game's world, proper nouns, factions, races, classes, currencies, maps, quests, monsters, NPCs, or item catalogs.
+
+The design inheritance we want to preserve is systemic rather than nominal:
+
+- dangerous travel and preparation matter;
+- progress is earned through use, training, work, exploration, and relationships;
+- one persistent character can learn across disciplines;
+- equipment and preparation create practical build limits;
+- the world contains regional economies and material chains;
+- gathering, hunting, crafting, cooking, trade, combat, and quests share the same resources;
+- settlements are social, economic, and logistical hubs rather than menu screens;
+- the player can establish a home base without being confined to one city;
+- roads, wilderness, caravans, ferries, mounts, and other transport connect a larger sandbox world;
+- maps represent knowledge and navigation rather than artificial player-facing level boundaries;
+- rewards should have physical or social provenance rather than appearing from nowhere.
+
+## Legacy material policy
+
+Existing FFXI-derived files and terminology are **legacy research/source material**, not canonical world content.
+
+Legacy material may be used to study:
+
+- pacing and progression curves;
+- equipment and stat relationships;
+- broad monster/ecology patterns;
+- spell and ability taxonomies;
+- gathering/crafting/economy structures;
+- travel-network density;
+- content-volume expectations;
+- historical formulas where they provide useful reference points.
+
+Legacy material must not be copied into new canonical databases as-is. Any imported structure must pass through an explicit normalization/originalization step.
+
+### Allowed legacy artifacts
+
+Legacy modules may remain temporarily when they are useful for regression comparison, migration, or research. They must be clearly named or documented as legacy/reference data and must not become the source of truth for new content.
+
+Examples include historical stat-grade tables, recovered legacy datasets, old spell/item files, or command adapters retained for compatibility.
+
+## Canonical naming rule
+
+Before large content-database expansion, canonical runtime/player-facing names and stable IDs must move to the original setting.
+
+This includes, where applicable:
+
+- world, regions, cities, districts, roads, dungeons, landmarks, and transport routes;
+- nations/factions and civic institutions;
+- ancestries/species;
+- disciplines and advanced training traditions;
+- currencies and reputation resources;
+- monsters, creature families, and named rare spawns;
+- NPCs, shops, guilds, and services;
+- mounts, companions, storage concepts, map terminology, and travel infrastructure;
+- items, spells, abilities, recipes, quests, and achievements as those databases are expanded.
+
+Generic fantasy or real-world vocabulary such as `sword`, `inn`, `goblin`, `caravan`, `iron`, `bread`, or `alchemy` may be used when it is the clearest language. The goal is not forced thesaurus renaming. The goal is to remove inherited proprietary identity and give regions, cultures, creatures, institutions, and histories their own character.
+
+## Stable ID migration policy
+
+Display-name replacement alone is not sufficient if canonical stable IDs still encode legacy setting names.
+
+The runtime migration will therefore:
+
+1. introduce canonical original IDs;
+2. provide an explicit legacy-to-canonical alias table at migration/input boundaries;
+3. migrate persisted Game State fields that contain renamed IDs;
+4. update maps, place connections, POIs, shops, spawns, nation records, and tests atomically;
+5. keep compatibility aliases bounded and documented rather than allowing them to become permanent second schemas.
+
+If persisted state changes shape or identifier vocabulary, the relevant save schema version must be bumped and migrated using the existing ordered migration mechanism.
+
+## Initial setting vocabulary
+
+The first original-world pass uses the following working canon. These names are canonical once the runtime migration lands; changing them later requires a deliberate content migration rather than casual churn.
+
+### Starting powers and regions
+
+| Role | Canonical name | Character |
+| --- | --- | --- |
+| Western crown realm | **Thornwall** | Old forest capital shaped by oath, timber, hunting, stone keeps, and court politics. |
+| Western wild region | **Elderwood** | Managed royal forest giving way to old growth, logging tracks, forgotten shrines, and raider territory. |
+| Forge republic | **Brasshaven** | Dense mercantile-industrial city built around mines, foundries, engineering, labor, and civic competition. |
+| Forge hinterland | **Redstone Reach** | Dry uplands, exposed ore, quarry roads, mines, wind-scoured ridges, and caravan routes. |
+| Scholastic canal city | **Mistmere** | Wetland city of colleges, gardens, observatories, canals, herbalists, and practical magic. |
+| Eastern wild region | **Starfen** | Bright marsh-grassland mosaic containing reed villages, ruins, herb beds, shallow waterways, and old magical works. |
+| Central future trade hub | **Waymeet** | Neutral crossroads city intended to become a major caravan, ferry, guild, and long-distance travel interchange. |
+
+These are starting anchors, not the complete world. New regions should develop their own naming patterns, economies, history, ecology, and social conflicts rather than repeating the three starter templates.
+
+### Starting ancestry migration
+
+The current five mechanical ancestry slots migrate to original identities while preserving existing stat behavior until a later balance pass:
+
+| Legacy slot | Canonical ancestry | Direction |
+| --- | --- | --- |
+| Hume | **Human** | Broadly adaptable populations found across the major powers. |
+| Elvaan | **Lethari** | Tall long-lived woodland and highland people with strong martial and oath traditions. |
+| Tarutaru | **Miri** | Small-bodied people with strong traditions of scholarship, craft, and practical magic. |
+| Mithra | **Veyra** | Agile clan-based people with strong hunting, scouting, trade, and travel traditions. |
+| Galka | **Korren** | Large resilient people with deep mining, masonry, engineering, and diasporic traditions. |
+
+These descriptions are starting cultural directions, not biological destiny. Origins, upbringing, training, relationships, and individual choices should matter more than ancestry stereotypes.
+
+### Discipline migration
+
+The current job scaffold remains mechanically transitional, but player-facing/canonical discipline names will migrate away from Final Fantasy-specific labels before capability database expansion.
+
+| Legacy scaffold | Canonical discipline |
+| --- | --- |
+| Warrior | Vanguard |
+| Monk | Pugilist |
+| White Mage | Lifewarden |
+| Black Mage | Elementalist |
+| Red Mage | Spellblade |
+| Thief | Shadowhand |
+| Paladin | Oathguard |
+| Dark Knight | Duskblade |
+| Beastmaster | Wildbinder |
+| Bard | Cantor |
+| Ranger | Wayfinder |
+| Samurai | Blade Adept |
+| Ninja | Veilrunner |
+| Dragoon | Sky Lancer |
+| Summoner | Eidolist |
+| Blue Mage | Echo Sage |
+| Corsair | Free Captain |
+| Puppetmaster | Artificer |
+| Dancer | Rhythmblade |
+| Scholar | Savant |
+| Geomancer | Leykeeper |
+| Rune Fencer | Wardsword |
+
+The later capability system is not required to reproduce one-to-one class restrictions. Disciplines describe schools and training traditions; capabilities enable actions; loadouts and preparation constrain effective use.
+
+## Content provenance model
+
+The content model must support a physical/social origin for rewards.
+
+Canonical acquisition categories include:
+
+- carried inventory searched from defeated or surrendered humanoids;
+- carcass/body processing such as skinning, butchering, plucking, bone recovery, gland extraction, or salvage;
+- gathering from plants, fungi, trees, mineral deposits, clay, water, shoreline, nests, and similar world sources;
+- fishing, trapping, hunting, and husbandry;
+- salvage or dismantling of constructs, tools, equipment, ruins, and containers;
+- crafting and processing transformations;
+- purchase, barter, wages, contracts, gifts, reputation rewards, and quest rewards;
+- deliberate exceptional magical creation where the fiction and mechanics explicitly justify it.
+
+A defeated animal should not automatically materialize a finished pelt in inventory. Combat can create access to a body/resource opportunity; recovery actions, tools, time, condition, skill, and player choice determine what is obtained.
+
+## Content graph requirement
+
+Major content records should participate in a connected graph rather than isolated lists.
+
+Examples:
+
+`creature -> carcass/resource outputs -> processing -> ingredients/components -> recipes -> usable goods -> shops/contracts/quests`
+
+`region -> habitats -> spawns/gathering nodes -> travel routes -> settlements -> services -> economy -> objectives`
+
+`NPC -> schedule/location -> relationship -> services/dialogue -> quests/contracts -> faction/reputation`
+
+Every canonical item should eventually have at least one intentional source and at least one meaningful sink/use, unless explicitly marked as decorative, collectible, quest-only, or transitional.
+
+## Content-pack architecture
+
+New world content should be authored in regional content packs rather than a single giant hand-maintained file.
+
+A mature regional pack may contain:
+
+- places and internal localities;
+- route/connection data;
+- map/cartography knowledge;
+- landmarks and discoveries;
+- NPC population records and schedules;
+- shops, services, lodging, guilds, trainers, and transport;
+- creature/ecology records and spawn populations;
+- flora, minerals, fishing waters, and other gatherables;
+- item/resource definitions introduced by the region;
+- recipes and processing chains;
+- quests, contracts, events, rewards, and reputation hooks;
+- relationships and companion candidates;
+- lore and descriptive text.
+
+The runtime must validate cross-references between these records.
+
+## Required content validation
+
+Before large-scale data generation, validation must be able to detect at minimum:
+
+- missing stable IDs and duplicate IDs;
+- references to nonexistent places, items, creatures, NPCs, recipes, quests, shops, or transport routes;
+- spawn definitions with no valid habitat/place;
+- harvest outputs with no item definition;
+- recipe ingredients/products that do not exist;
+- items with no source or no use unless intentionally exempted;
+- shops stocking nonexistent goods;
+- quests whose objectives cannot be completed in reachable world data;
+- rewards referencing nonexistent content;
+- transport routes with missing stops or impossible topology;
+- maps referencing nonexistent places;
+- relationship/companion records referencing nonexistent NPCs;
+- legacy identifiers leaking into canonical packs without an explicit adapter.
+
+## Scale policy
+
+Content volume is a first-class engineering requirement. Engine milestones must ship with enough real interconnected content to expose scaling problems.
+
+Planning ranges are not hard quotas, but the order of magnitude matters:
+
+| Content | Mechanics integration target | Playable-alpha target | 1.0-scale target |
+| --- | ---: | ---: | ---: |
+| Connected regions/localities | 10–15 | 30–50 | 75–125+ |
+| Named NPCs | 50+ | 250–400 | 700–1,200 |
+| Functional shops/services | 20+ | 60–100 | 150+ |
+| Creature/fauna definitions | 40–60 | 120–180 | 300–500 |
+| Flora/resource definitions | 40+ | 100–150 | 250+ |
+| Canonical items | 200–300 | 800–1,500 | 2,500–5,000 |
+| Recipes/processes | 75–125 | 300–500 | 800–1,500 |
+| Spells/abilities/techniques | 100+ | 250–400 | 500+ |
+| Quests/contracts | 30–50 | 150–250 | 500+ |
+| Recruitable companions | 4–6 | 12–20 | 25–40 |
+| Deep romance-capable NPCs | 2–4 | 8–12 | 15–25 |
+| Scheduled transport routes | 5+ | 20–30 | 50+ |
+
+## Development ordering rule
+
+From 0.5.500 forward:
+
+1. finish the original-world naming/stable-ID migration;
+2. establish resource provenance, ecology/spawn, transport, and content-pack validation substrates;
+3. only then begin high-volume canonical content generation/import normalization;
+4. grow mechanics and content together so each system is tested against realistic data breadth.
+
+Do not expand hundreds of records under legacy FFXI names and plan to rename them later.
+
+## Content originality test
+
+Before a new content pack is accepted, ask:
+
+1. Is the identity understandable without knowledge of another game?
+2. Do names and institutions fit this region's own culture/history?
+3. Does the content connect to the material economy and world simulation?
+4. Are rewards physically, economically, or socially explainable?
+5. Does the region offer more than a reskinned version of another starter region?
+6. Are monsters, flora, routes, shops, NPCs, quests, and recipes cross-linked rather than isolated lists?
+7. Can the content be validated automatically and migrated through stable IDs?
+
+If the answer to several of these is no, the content is not ready to become canonical.


### PR DESCRIPTION
## Purpose

Lock the post-0.5.500 direction before the repository begins high-volume content generation.

## Changes

- adds `WORLD_IDENTITY_AND_CONTENT_POLICY.md`
- establishes the original working identity **Hearth & Horizon**
- makes legacy FFXI-derived material research/reference only rather than canonical content
- introduces original starting anchors: Thornwall/Elderwood, Brasshaven/Redstone Reach, Mistmere/Starfen, future Waymeet
- defines initial ancestry and discipline migrations
- makes stable-ID/save migration a requirement rather than display-only renaming
- adds resource-provenance and source/sink design laws
- defines regional content-pack and cross-reference validation requirements
- adds realistic planning-scale ranges for NPCs, creatures, resources, items, recipes, abilities, quests, companions, romance candidates, and transport routes
- rebaselines 0.5 around identity/provenance/ecology/transport/content infrastructure
- rebaselines 0.6 around integrated mechanics/content and 0.7 around a genuine multi-region playable alpha
- refreshes README, system catalog, and thread handoff to current 0.5.500 state

## Version

Docs/policy only. Product remains `0.5.500.0` per the versioning protocol.

## Immediate runtime follow-up

`0.5.550` — migrate canonical runtime/player-facing names and stable IDs to the original setting, with ordered persistence migration, before expanding content databases.