### PR TITLE
Enforce complete current-schema persistence

### DIFF
--- a/js/text/save.js
+++ b/js/text/save.js
@@ -1,3 +1,4 @@
+import { validateCurrentGameStateStructure } from './systems/currentGameStateSchema.js';
 import { isValidGameState, validateGameState } from './systems/validation.js';
 import { VERSION } from './version.js';
 
@@ -42,6 +43,12 @@ export function loadCharacter(characterSelector) {
         return null;
     }
 
+    const structureIssues = validateCurrentGameStateStructure(state, { requireMeta: true });
+    if (structureIssues.length) {
+        console.warn('Ignoring incomplete current-schema character save.', structureIssues);
+        return null;
+    }
+
     const revived = reviveGameState(state, record.id);
     if (!isValidGameState(revived)) {
         console.warn('Ignoring incompatible character save.', validateGameState(revived));
@@ -66,7 +73,10 @@ export function saveGame(state) {
             return false;
         }
         const revived = reviveGameState(state, state?.meta?.characterId);
-        const issues = validateGameState(revived);
+        const issues = [
+            ...validateCurrentGameStateStructure(revived, { requireMeta: true }),
+            ...validateGameState(revived),
+        ];
         if (issues.length) {
             console.warn('Refusing to save invalid game state.', issues);
             return false;

--- a/js/text/systems/currentGameStateSchema.js
+++ b/js/text/systems/currentGameStateSchema.js
@@ -28,7 +28,6 @@ const REQUIRED_PLAYER_OBJECT_FIELDS = Object.freeze([
     'wallet',
     'equipment',
     'inventoryState',
-    'capabilities',
     'combat',
     'resources',
     'flags',
@@ -63,6 +62,9 @@ export function validateCurrentGameStateStructure(state, options = {}) {
         }
         for (const field of REQUIRED_PLAYER_ARRAY_FIELDS) {
             if (!Array.isArray(state.player[field])) issues.push(`player.${field} must be a persisted array.`);
+        }
+        if (isObject(state.player.progression) && !isObject(state.player.progression.capabilities)) {
+            issues.push('player.progression.capabilities must be a persisted object.');
         }
     }
 

--- a/js/text/systems/currentGameStateSchema.js
+++ b/js/text/systems/currentGameStateSchema.js
@@ -1,0 +1,83 @@
+import { VERSION } from '../version.js';
+
+const REQUIRED_OBJECT_FIELDS = Object.freeze([
+    'worldTime',
+    'simulation',
+    'tasks',
+    'abilities',
+    'party',
+    'projects',
+    'commitments',
+    'relationships',
+    'resourceOpportunities',
+    'ecology',
+    'position',
+    'atlas',
+    'discoveredPois',
+    'player',
+    'flags',
+    'events',
+]);
+
+const REQUIRED_ARRAY_FIELDS = Object.freeze(['npcs', 'enemies', 'log']);
+
+const REQUIRED_PLAYER_OBJECT_FIELDS = Object.freeze([
+    'identity',
+    'jobs',
+    'progression',
+    'wallet',
+    'equipment',
+    'inventoryState',
+    'capabilities',
+    'combat',
+    'resources',
+    'flags',
+]);
+
+const REQUIRED_PLAYER_ARRAY_FIELDS = Object.freeze(['inventory', 'keyItems', 'statuses']);
+
+export function validateCurrentGameStateStructure(state, options = {}) {
+    const issues = [];
+    if (!isObject(state)) return ['state must be an object.'];
+
+    if (state.version !== VERSION.gameState) {
+        issues.push(`version must be current Game State ${VERSION.gameState}.`);
+    }
+
+    for (const field of REQUIRED_OBJECT_FIELDS) {
+        if (!isObject(state[field])) issues.push(`${field} must be a persisted object.`);
+    }
+    for (const field of REQUIRED_ARRAY_FIELDS) {
+        if (!Array.isArray(state[field])) issues.push(`${field} must be a persisted array.`);
+    }
+
+    if (typeof state.currentPlaceId !== 'string' || !state.currentPlaceId.trim()) issues.push('currentPlaceId must be a persisted non-empty string.');
+    if (typeof state.location !== 'string' || !state.location.trim()) issues.push('location must be a persisted non-empty string.');
+    if (state.travel !== null && !isObject(state.travel)) issues.push('travel must be persisted as null or an object.');
+    if (!Number.isInteger(state.combatSequence) || state.combatSequence < 0) issues.push('combatSequence must be a persisted non-negative integer.');
+    if (state.activeBattle !== null && !isObject(state.activeBattle)) issues.push('activeBattle must be persisted as null or an object.');
+
+    if (isObject(state.player)) {
+        for (const field of REQUIRED_PLAYER_OBJECT_FIELDS) {
+            if (!isObject(state.player[field])) issues.push(`player.${field} must be a persisted object.`);
+        }
+        for (const field of REQUIRED_PLAYER_ARRAY_FIELDS) {
+            if (!Array.isArray(state.player[field])) issues.push(`player.${field} must be a persisted array.`);
+        }
+    }
+
+    if (options.requireMeta === true) {
+        if (!isObject(state.meta)) {
+            issues.push('meta must be a persisted object.');
+        } else {
+            if (typeof state.meta.characterId !== 'string' || !state.meta.characterId.trim()) issues.push('meta.characterId must be a persisted non-empty string.');
+            if (typeof state.meta.updatedAt !== 'string' || !state.meta.updatedAt.trim()) issues.push('meta.updatedAt must be a persisted non-empty string.');
+        }
+    }
+
+    return issues;
+}
+
+function isObject(value) {
+    return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}

--- a/js/text/version.js
+++ b/js/text/version.js
@@ -1,4 +1,4 @@
-export const PRODUCT_VERSION = '0.8.600.3';
+export const PRODUCT_VERSION = '0.8.600.4';
 export const PACKAGE_VERSION = '0.8.600';
 
 export const VERSION = Object.freeze({
@@ -8,13 +8,13 @@ export const VERSION = Object.freeze({
     gameState: 6,
     data: 37,
     benchmark: 1,
-    codename: 'Canonical Command Contract',
+    codename: 'Strict Current Schema',
     compatibility: 'pre-release-current-schema',
     released: false,
 });
 
 export const SYSTEM_VERSIONS = Object.freeze({
-    versionManifest: '0.8.600.3',
+    versionManifest: '0.8.600.4',
     actionResults: '0.1.0',
     semanticEvents: '0.1.0',
     foundationReadiness: '0.2.0',
@@ -78,7 +78,7 @@ export const SYSTEM_VERSIONS = Object.freeze({
     canvasUi: '0.8.0',
     uiIntents: '0.10.1',
     slashCommands: '0.5.0',
-    accountSaves: '0.7.0',
+    accountSaves: '0.7.1',
     saveRecovery: '0.1.0',
     saveEncoding: '0.5.0',
     parser: '0.2.0',

--- a/tests/currentSchemaPersistence.test.js
+++ b/tests/currentSchemaPersistence.test.js
@@ -59,6 +59,63 @@ test('an older character state is rejected instead of migrated or rewritten', ()
     assert.equal(unchangedState.version, VERSION.gameState - 1);
 });
 
+test('a current-version save missing a required top-level registry is rejected without lazy reconstruction', () => {
+    installStorage();
+    assert.equal(createAccountWithPassword('Strict Structure Account', 'pwd', { persistentLogin: true }).ok, true);
+
+    const state = createInitialState();
+    state.player.identity.name = 'Strictkeeper';
+    assert.equal(saveGame(state), true);
+
+    const key = 'hearthHorizonAccounts';
+    const registry = decodePayload(globalThis.localStorage.getItem(key));
+    const record = registry.accounts[0].characters[0];
+    const incomplete = decodePayload(record.encodedState);
+    delete incomplete.tasks;
+    record.encodedState = encodePayload(incomplete);
+    globalThis.localStorage.setItem(key, encodePayload(registry));
+
+    assert.equal(loadCharacter('Strictkeeper'), null);
+    const unchangedRegistry = decodePayload(globalThis.localStorage.getItem(key));
+    const unchangedState = decodePayload(unchangedRegistry.accounts[0].characters[0].encodedState);
+    assert.equal(Object.hasOwn(unchangedState, 'tasks'), false);
+});
+
+test('a current-version save missing required character capability state is rejected without lazy reconstruction', () => {
+    installStorage();
+    assert.equal(createAccountWithPassword('Strict Character Account', 'pwd', { persistentLogin: true }).ok, true);
+
+    const state = createInitialState();
+    state.player.identity.name = 'Strictcap';
+    assert.equal(saveGame(state), true);
+
+    const key = 'hearthHorizonAccounts';
+    const registry = decodePayload(globalThis.localStorage.getItem(key));
+    const record = registry.accounts[0].characters[0];
+    const incomplete = decodePayload(record.encodedState);
+    delete incomplete.player.capabilities;
+    record.encodedState = encodePayload(incomplete);
+    globalThis.localStorage.setItem(key, encodePayload(registry));
+
+    assert.equal(loadCharacter('Strictcap'), null);
+    const unchangedRegistry = decodePayload(globalThis.localStorage.getItem(key));
+    const unchangedState = decodePayload(unchangedRegistry.accounts[0].characters[0].encodedState);
+    assert.equal(Object.hasOwn(unchangedState.player, 'capabilities'), false);
+});
+
+test('saveGame rejects a malformed current runtime state instead of filling required registries', () => {
+    installStorage();
+    assert.equal(createAccountWithPassword('Strict Save Account', 'pwd', { persistentLogin: true }).ok, true);
+
+    const state = createInitialState();
+    state.player.identity.name = 'Strictsave';
+    delete state.ecology;
+
+    assert.equal(saveGame(state), false);
+    assert.equal(loadAccount().characters.length, 0);
+    assert.equal(Object.hasOwn(state, 'ecology'), false);
+});
+
 test('world time persists through current-schema save and load without wall-clock recomputation', () => {
     installStorage();
     assert.equal(createAccountWithPassword('World Time Account', 'pwd', { persistentLogin: true }).ok, true);

--- a/tests/currentSchemaPersistence.test.js
+++ b/tests/currentSchemaPersistence.test.js
@@ -93,14 +93,14 @@ test('a current-version save missing required character capability state is reje
     const registry = decodePayload(globalThis.localStorage.getItem(key));
     const record = registry.accounts[0].characters[0];
     const incomplete = decodePayload(record.encodedState);
-    delete incomplete.player.capabilities;
+    delete incomplete.player.progression.capabilities;
     record.encodedState = encodePayload(incomplete);
     globalThis.localStorage.setItem(key, encodePayload(registry));
 
     assert.equal(loadCharacter('Strictcap'), null);
     const unchangedRegistry = decodePayload(globalThis.localStorage.getItem(key));
     const unchangedState = decodePayload(unchangedRegistry.accounts[0].characters[0].encodedState);
-    assert.equal(Object.hasOwn(unchangedState.player, 'capabilities'), false);
+    assert.equal(Object.hasOwn(unchangedState.player.progression, 'capabilities'), false);
 });
 
 test('saveGame rejects a malformed current runtime state instead of filling required registries', () => {

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -15,7 +15,7 @@ import {
 
 
 test('version manifest separates product package persistence data and focused cleanup versions', () => {
-    assert.equal(PRODUCT_VERSION, '0.8.600.3');
+    assert.equal(PRODUCT_VERSION, '0.8.600.4');
     assert.equal(PACKAGE_VERSION, '0.8.600');
     assert.equal(VERSION.product, PRODUCT_VERSION);
     assert.equal(VERSION.package, PACKAGE_VERSION);
@@ -25,7 +25,7 @@ test('version manifest separates product package persistence data and focused cl
     assert.equal(VERSION.benchmark, 1);
     assert.equal(Object.hasOwn(VERSION, 'app'), false);
     assert.equal(Object.hasOwn(VERSION, 'save'), false);
-    assert.equal(VERSION.codename, 'Canonical Command Contract');
+    assert.equal(VERSION.codename, 'Strict Current Schema');
     assert.equal(VERSION.compatibility, 'pre-release-current-schema');
 
     assert.deepEqual(
@@ -44,10 +44,10 @@ test('version manifest separates product package persistence data and focused cl
             gameViewModels: SYSTEM_VERSIONS.gameViewModels,
         },
         {
-            versionManifest: '0.8.600.3',
+            versionManifest: '0.8.600.4',
             commandShell: '0.5.1',
             slashCommands: '0.5.0',
-            accountSaves: '0.7.0',
+            accountSaves: '0.7.1',
             saveEncoding: '0.5.0',
             inventoryContainers: '0.7.0',
             inventoryTransfers: '0.7.0',
@@ -60,15 +60,14 @@ test('version manifest separates product package persistence data and focused cl
     );
 
     assert.equal(Object.hasOwn(SYSTEM_VERSIONS, 'saveMigrations'), false);
-    assert.match(describeVersion(), /Product: 0\.8\.600\.3/);
+    assert.match(describeVersion(), /Product: 0\.8\.600\.4/);
     assert.match(describeVersion(), /Package: 0\.8\.600/);
     assert.match(describeVersion(), /Account Save: 5/);
     assert.match(describeVersion(), /Game State: 6/);
     assert.match(describeVersion(), /Data: 37/);
-    assert.match(describeVersion(), /Codename: Canonical Command Contract/);
+    assert.match(describeVersion(), /Codename: Strict Current Schema/);
     assert.match(describeVersion(), /Compatibility: pre-release-current-schema/);
-    assert.match(describeSystemVersions(), /commandShell: 0\.5\.1/);
-    assert.match(describeSystemVersions(), /slashCommands: 0\.5\.0/);
+    assert.match(describeSystemVersions(), /accountSaves: 0\.7\.1/);
     assert.doesNotMatch(describeSystemVersions(), /saveMigrations:/);
 });
 


### PR DESCRIPTION
Maintenance cycle 2.

Adds an explicit persisted-structure gate for Game State 6. Current-version character payloads must contain required top-level registries and required persistent player structures before revive/reference relinking; incomplete saves are rejected without lazy reconstruction. saveGame likewise refuses malformed current runtime state instead of manufacturing missing registries.

Version decision: Product 0.8.600.4; Account Save 5, Game State 6, Data 37, Benchmark 1 unchanged. accountSaves registration advances to 0.7.1.

Draft until exact-head Test + Benchmark are green.