### PR TITLE
Unify commitment delivery with carried inventory

### DIFF
--- a/js/text/systems/carriedInventoryEngine.js
+++ b/js/text/systems/carriedInventoryEngine.js
@@ -1,0 +1,110 @@
+import { listContainerDefinitions } from '../data/inventoryContainers.js';
+
+export const CARRIED_INVENTORY_ENGINE_VERSION = 1;
+
+export function listCarriedContainerEntries(stateOrInventoryState) {
+    const inventoryState = resolveInventoryState(stateOrInventoryState);
+    if (!inventoryState) return [];
+
+    return listContainerDefinitions()
+        .filter((definition) => definition.countsAsCarriedCargo)
+        .map((definition) => ({
+            definition,
+            container: inventoryState.containers?.[definition.id] ?? null,
+        }))
+        .filter((entry) => entry.container?.unlocked && Array.isArray(entry.container.items));
+}
+
+export function listCarriedItemEntries(stateOrInventoryState, predicate = null) {
+    const matches = typeof predicate === 'function' ? predicate : () => true;
+    const entries = [];
+
+    for (const { definition, container } of listCarriedContainerEntries(stateOrInventoryState)) {
+        for (let index = 0; index < container.items.length; index += 1) {
+            const item = container.items[index];
+            if (!matches(item, definition.id)) continue;
+            entries.push({
+                containerId: definition.id,
+                container,
+                index,
+                item,
+            });
+        }
+    }
+
+    return entries;
+}
+
+export function getCarriedItemQuantity(stateOrInventoryState, predicate) {
+    return listCarriedItemEntries(stateOrInventoryState, predicate)
+        .reduce((sum, entry) => sum + itemQuantity(entry.item), 0);
+}
+
+export function applyCarriedItemRemovalPlan(stateOrInventoryState, removals = []) {
+    const inventoryState = resolveInventoryState(stateOrInventoryState);
+    if (!inventoryState) return { ok: false, reason: 'Inventory state is unavailable.', removed: [] };
+    if (!Array.isArray(removals)) return { ok: false, reason: 'Removal plan must be an array.', removed: [] };
+
+    const carriedIds = new Set(listContainerDefinitions()
+        .filter((definition) => definition.countsAsCarriedCargo)
+        .map((definition) => definition.id));
+    const totals = new Map();
+
+    for (const removal of removals) {
+        const containerId = String(removal?.containerId ?? '');
+        const index = Number(removal?.index);
+        const quantity = Number(removal?.quantity);
+        if (!carriedIds.has(containerId)) return { ok: false, reason: `Container ${containerId} is not carried cargo.`, removed: [] };
+        const container = inventoryState.containers?.[containerId];
+        if (!container?.unlocked || !Array.isArray(container.items)) return { ok: false, reason: `Carried container ${containerId} is unavailable.`, removed: [] };
+        if (!Number.isInteger(index) || index < 0 || index >= container.items.length) return { ok: false, reason: `Removal index ${String(removal?.index)} is invalid for ${containerId}.`, removed: [] };
+        if (!Number.isInteger(quantity) || quantity <= 0) return { ok: false, reason: 'Removal quantity must be a positive integer.', removed: [] };
+        const key = `${containerId}:${index}`;
+        totals.set(key, {
+            containerId,
+            index,
+            quantity: (totals.get(key)?.quantity ?? 0) + quantity,
+        });
+    }
+
+    const planned = [...totals.values()];
+    for (const removal of planned) {
+        const item = inventoryState.containers[removal.containerId].items[removal.index];
+        if (removal.quantity > itemQuantity(item)) {
+            return { ok: false, reason: `Removal plan exceeds available quantity in ${removal.containerId}.`, removed: [] };
+        }
+    }
+
+    const removed = planned.map((removal) => {
+        const item = inventoryState.containers[removal.containerId].items[removal.index];
+        return { ...item, quantity: removal.quantity, containerId: removal.containerId };
+    });
+
+    const byContainer = new Map();
+    for (const removal of planned) {
+        if (!byContainer.has(removal.containerId)) byContainer.set(removal.containerId, []);
+        byContainer.get(removal.containerId).push(removal);
+    }
+
+    for (const [containerId, containerRemovals] of byContainer) {
+        const container = inventoryState.containers[containerId];
+        for (const removal of containerRemovals.sort((left, right) => right.index - left.index)) {
+            const item = container.items[removal.index];
+            const available = itemQuantity(item);
+            if (removal.quantity >= available || item.stackable === false) container.items.splice(removal.index, 1);
+            else item.quantity = available - removal.quantity;
+        }
+    }
+
+    return { ok: true, removed };
+}
+
+function resolveInventoryState(stateOrInventoryState) {
+    return stateOrInventoryState?.player?.inventoryState
+        ?? stateOrInventoryState?.inventoryState
+        ?? (stateOrInventoryState?.containers ? stateOrInventoryState : null);
+}
+
+function itemQuantity(item) {
+    return Math.max(1, Number.parseInt(item?.quantity, 10) || 1);
+}

--- a/js/text/systems/carriedLoadEngine.js
+++ b/js/text/systems/carriedLoadEngine.js
@@ -1,13 +1,16 @@
 import { listContainerDefinitions } from '../data/inventoryContainers.js';
+import { listCarriedContainerEntries } from './carriedInventoryEngine.js';
 
 export const CARRIED_LOAD_ENGINE_VERSION = 2;
 
 export function getCarriedCargoLoad(state) {
     const inventoryState = state?.player?.inventoryState ?? state?.inventoryState ?? null;
+    const activeById = new Map(listCarriedContainerEntries(inventoryState)
+        .map((entry) => [entry.definition.id, entry.container]));
     const containers = listContainerDefinitions()
         .filter((definition) => definition.countsAsCarriedCargo)
         .map((definition) => {
-            const container = inventoryState?.containers?.[definition.id] ?? null;
+            const container = activeById.get(definition.id) ?? inventoryState?.containers?.[definition.id] ?? null;
             const unlocked = Boolean(container?.unlocked);
             const occupiedSlots = unlocked && Array.isArray(container?.items) ? container.items.length : 0;
             return Object.freeze({

--- a/js/text/systems/commitmentEngine.js
+++ b/js/text/systems/commitmentEngine.js
@@ -1,5 +1,10 @@
 import { getCommitmentDefinition } from '../data/commitments.js';
 import { actionFailure, actionSuccess } from './actionResult.js';
+import {
+    applyCarriedItemRemovalPlan,
+    getCarriedItemQuantity,
+    listCarriedItemEntries,
+} from './carriedInventoryEngine.js';
 import { describeNpcScheduleStatus, getNpcScheduleStatus } from './npcScheduleEngine.js';
 import { applyNpcRelationshipChange, ensureRelationshipState } from './relationshipEngine.js';
 import { emitSemanticEvent } from './semanticEventEngine.js';
@@ -131,7 +136,17 @@ export function resolveCommitment(state, commitmentId) {
             display: { text: deliveryPlan.blockers.join(' ') },
         });
     }
-    const removed = applyDeliveryPlan(deliveryPlan);
+    const removal = applyCarriedItemRemovalPlan(state, deliveryPlan.removals);
+    if (!removal.ok) {
+        return actionFailure({
+            action: 'commitment.resolve',
+            code: 'commitment.delivery-failed',
+            outcome: 'blocked',
+            data: { commitmentId: definition.id, blockers: [removal.reason] },
+            display: { text: removal.reason },
+        });
+    }
+    const removed = removal.removed;
 
     const now = ensureWorldTimeState(state).totalSeconds;
     const resolvedDay = dayNumber(now);
@@ -264,7 +279,7 @@ export function validateCommitmentState(commitments) {
         if (record.followUpSeenAtWorldSeconds !== null && !nonNegativeInteger(record.followUpSeenAtWorldSeconds)) issues.push(`commitments.records.${commitmentId}.followUpSeenAtWorldSeconds must be null or non-negative.`);
         if (nonNegativeInteger(record.followUpSeenAtWorldSeconds) && nonNegativeInteger(record.resolvedAtWorldSeconds)
             && record.followUpSeenAtWorldSeconds < record.resolvedAtWorldSeconds) {
-            issues.push(`commitments.records.${commitmentId}.followUpSeenAtWorldSeconds cannot precede resolution.`);
+                issues.push(`commitments.records.${commitmentId}.followUpSeenAtWorldSeconds cannot precede resolution.`);
         }
     }
     return issues;
@@ -282,25 +297,23 @@ function checkGiverContext(state, definition) {
 }
 
 function qualifyingItemQuantity(state, requirement) {
-    return (state.player?.inventoryState?.containers?.inventory?.items ?? [])
-        .filter((item) => itemMatchesRequirement(item, requirement))
-        .reduce((sum, item) => sum + itemQuantity(item), 0);
+    return getCarriedItemQuantity(state, (item) => itemMatchesRequirement(item, requirement));
 }
 
 function createDeliveryPlan(state, requirements) {
-    const container = state.player?.inventoryState?.containers?.inventory;
-    if (!container || !Array.isArray(container.items)) return { ok: false, blockers: ['Inventory is unavailable for commitment delivery.'] };
-    const availableByIndex = container.items.map((item) => itemQuantity(item));
+    if (!state.player?.inventoryState) return { ok: false, blockers: ['Inventory is unavailable for commitment delivery.'] };
+    const entries = listCarriedItemEntries(state);
+    const availableByEntry = entries.map((entry) => itemQuantity(entry.item));
     const removals = [];
 
     for (const requirement of requirements) {
         let remaining = requirement.quantity;
-        for (let index = 0; index < container.items.length && remaining > 0; index += 1) {
-            const item = container.items[index];
-            if (availableByIndex[index] <= 0 || !itemMatchesRequirement(item, requirement)) continue;
-            const quantity = Math.min(availableByIndex[index], remaining);
-            removals.push({ index, quantity });
-            availableByIndex[index] -= quantity;
+        for (let entryIndex = 0; entryIndex < entries.length && remaining > 0; entryIndex += 1) {
+            const entry = entries[entryIndex];
+            if (availableByEntry[entryIndex] <= 0 || !itemMatchesRequirement(entry.item, requirement)) continue;
+            const quantity = Math.min(availableByEntry[entryIndex], remaining);
+            removals.push({ containerId: entry.containerId, index: entry.index, quantity });
+            availableByEntry[entryIndex] -= quantity;
             remaining -= quantity;
         }
         if (remaining > 0) {
@@ -311,21 +324,7 @@ function createDeliveryPlan(state, requirements) {
         }
     }
 
-    return { ok: true, container, removals };
-}
-
-function applyDeliveryPlan(plan) {
-    const totalsByIndex = new Map();
-    for (const removal of plan.removals) totalsByIndex.set(removal.index, (totalsByIndex.get(removal.index) ?? 0) + removal.quantity);
-    const removed = [];
-    for (const [index, quantity] of [...totalsByIndex.entries()].sort((left, right) => right[0] - left[0])) {
-        const item = plan.container.items[index];
-        const available = itemQuantity(item);
-        removed.unshift({ ...item, quantity });
-        if (quantity >= available || item.stackable === false) plan.container.items.splice(index, 1);
-        else item.quantity = available - quantity;
-    }
-    return removed;
+    return { ok: true, removals };
 }
 
 function itemMatchesRequirement(item, requirement) {

--- a/js/text/version.js
+++ b/js/text/version.js
@@ -1,4 +1,4 @@
-export const PRODUCT_VERSION = '0.8.600.4';
+export const PRODUCT_VERSION = '0.8.600.5';
 export const PACKAGE_VERSION = '0.8.600';
 
 export const VERSION = Object.freeze({
@@ -8,13 +8,13 @@ export const VERSION = Object.freeze({
     gameState: 6,
     data: 37,
     benchmark: 1,
-    codename: 'Strict Current Schema',
+    codename: 'Carried Commitment Delivery',
     compatibility: 'pre-release-current-schema',
     released: false,
 });
 
 export const SYSTEM_VERSIONS = Object.freeze({
-    versionManifest: '0.8.600.4',
+    versionManifest: '0.8.600.5',
     actionResults: '0.1.0',
     semanticEvents: '0.1.0',
     foundationReadiness: '0.2.0',
@@ -24,7 +24,7 @@ export const SYSTEM_VERSIONS = Object.freeze({
     timedTasks: '0.1.0',
     projects: '0.1.0',
     homeInfrastructure: '0.4.0',
-    commitments: '0.3.0',
+    commitments: '0.3.1',
     relationships: '0.1.0',
     npcSchedules: '0.1.0',
     playerSocialSchedules: '0.1.0',
@@ -55,7 +55,8 @@ export const SYSTEM_VERSIONS = Object.freeze({
     resourceItemRegistry: '0.2.0',
     routeCatalog: '0.1.0',
     transport: '0.3.0',
-    carriedLoad: '0.2.0',
+    carriedInventory: '0.1.0',
+    carriedLoad: '0.2.1',
     transportServiceBoard: '0.2.0',
     contentPackSchema: '0.1.0',
     regionalContentPacks: '0.2.0',

--- a/tests/carriedCommitmentDelivery.test.js
+++ b/tests/carriedCommitmentDelivery.test.js
@@ -1,0 +1,92 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { getProductionItem } from '../js/text/data/productionItems.js';
+import { createNewGameState } from '../js/text/gameState.js';
+import { getCarriedCargoUnits } from '../js/text/systems/carriedLoadEngine.js';
+import {
+    applyCarriedItemRemovalPlan,
+    listCarriedItemEntries,
+} from '../js/text/systems/carriedInventoryEngine.js';
+import {
+    acceptCommitment,
+    checkCommitmentRequirements,
+    resolveCommitment,
+} from '../js/text/systems/commitmentEngine.js';
+import {
+    addItemToContainer,
+    unlockInventoryContainer,
+} from '../js/text/systems/inventoryEngine.js';
+import { performLocalityPoiAction } from '../js/text/systems/localityEngine.js';
+
+const COMMITMENT_ID = 'commitment-brasshaven-copper-return';
+const INGOT_ID = 'item-redstone-copper-ingot';
+
+function createAcceptedBrasshavenCommitment() {
+    const state = createNewGameState({ nationId: 'brasshaven' });
+    assert.equal(performLocalityPoiAction(state, 'poi-bastok-markets-rabid-wolf', 'talk').ok, true);
+    assert.equal(acceptCommitment(state, COMMITMENT_ID).ok, true);
+    return state;
+}
+
+test('a qualifying item in Field Satchel satisfies and resolves a commitment', () => {
+    const state = createAcceptedBrasshavenCommitment();
+    assert.equal(unlockInventoryContainer(state, 'fieldSatchel').ok, true);
+    assert.equal(addItemToContainer(state.player.inventoryState, 'fieldSatchel', getProductionItem(INGOT_ID)).ok, true);
+    assert.equal(getCarriedCargoUnits(state), 1);
+
+    const check = checkCommitmentRequirements(state, COMMITMENT_ID);
+    assert.equal(check.ok, true, check.blockers.join(' '));
+
+    const resolved = resolveCommitment(state, COMMITMENT_ID);
+    assert.equal(resolved.ok, true, resolved.display?.text ?? resolved.reason);
+    assert.equal(state.player.inventoryState.containers.fieldSatchel.items.length, 0);
+    assert.equal(getCarriedCargoUnits(state), 0);
+});
+
+test('qualifying home storage does not count as carried commitment delivery', () => {
+    const state = createAcceptedBrasshavenCommitment();
+    assert.equal(addItemToContainer(
+        state.player.inventoryState,
+        'homeSafe',
+        getProductionItem(INGOT_ID),
+        { isAtHome: true },
+    ).ok, true);
+
+    const check = checkCommitmentRequirements(state, COMMITMENT_ID);
+    assert.equal(check.ok, false);
+    assert.match(check.blockers.join(' '), /Requires 1 item-redstone-copper-ingot/);
+
+    const resolved = resolveCommitment(state, COMMITMENT_ID);
+    assert.equal(resolved.ok, false);
+    assert.equal(resolved.code, 'commitment.requirements-unmet');
+    assert.equal(state.player.inventoryState.containers.homeSafe.items.length, 1);
+});
+
+test('carried removal plans validate all containers before mutating any of them', () => {
+    const state = createNewGameState({ nationId: 'brasshaven' });
+    assert.equal(unlockInventoryContainer(state, 'fieldSatchel').ok, true);
+    assert.equal(addItemToContainer(state.player.inventoryState, 'inventory', getProductionItem(INGOT_ID)).ok, true);
+    assert.equal(addItemToContainer(state.player.inventoryState, 'fieldSatchel', getProductionItem(INGOT_ID)).ok, true);
+
+    const entries = listCarriedItemEntries(state, (item) => item.id === INGOT_ID);
+    assert.equal(entries.length, 2);
+
+    const invalidPlan = [
+        { containerId: entries[0].containerId, index: entries[0].index, quantity: 1 },
+        { containerId: entries[1].containerId, index: entries[1].index, quantity: 2 },
+    ];
+    const rejected = applyCarriedItemRemovalPlan(state, invalidPlan);
+    assert.equal(rejected.ok, false);
+    assert.equal(listCarriedItemEntries(state, (item) => item.id === INGOT_ID).length, 2, 'failed plan must not partially mutate carried inventory');
+
+    const validPlan = entries.map((entry) => ({
+        containerId: entry.containerId,
+        index: entry.index,
+        quantity: 1,
+    }));
+    const applied = applyCarriedItemRemovalPlan(state, validPlan);
+    assert.equal(applied.ok, true, applied.reason);
+    assert.equal(applied.removed.length, 2);
+    assert.equal(listCarriedItemEntries(state, (item) => item.id === INGOT_ID).length, 0);
+});

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -15,7 +15,7 @@ import {
 
 
 test('version manifest separates product package persistence data and focused cleanup versions', () => {
-    assert.equal(PRODUCT_VERSION, '0.8.600.4');
+    assert.equal(PRODUCT_VERSION, '0.8.600.5');
     assert.equal(PACKAGE_VERSION, '0.8.600');
     assert.equal(VERSION.product, PRODUCT_VERSION);
     assert.equal(VERSION.package, PACKAGE_VERSION);
@@ -25,7 +25,7 @@ test('version manifest separates product package persistence data and focused cl
     assert.equal(VERSION.benchmark, 1);
     assert.equal(Object.hasOwn(VERSION, 'app'), false);
     assert.equal(Object.hasOwn(VERSION, 'save'), false);
-    assert.equal(VERSION.codename, 'Strict Current Schema');
+    assert.equal(VERSION.codename, 'Carried Commitment Delivery');
     assert.equal(VERSION.compatibility, 'pre-release-current-schema');
 
     assert.deepEqual(
@@ -34,40 +34,38 @@ test('version manifest separates product package persistence data and focused cl
             commandShell: SYSTEM_VERSIONS.commandShell,
             slashCommands: SYSTEM_VERSIONS.slashCommands,
             accountSaves: SYSTEM_VERSIONS.accountSaves,
-            saveEncoding: SYSTEM_VERSIONS.saveEncoding,
+            commitments: SYSTEM_VERSIONS.commitments,
+            carriedInventory: SYSTEM_VERSIONS.carriedInventory,
+            carriedLoad: SYSTEM_VERSIONS.carriedLoad,
             inventoryContainers: SYSTEM_VERSIONS.inventoryContainers,
             inventoryTransfers: SYSTEM_VERSIONS.inventoryTransfers,
-            homeInfrastructure: SYSTEM_VERSIONS.homeInfrastructure,
-            homeStorage: SYSTEM_VERSIONS.homeStorage,
-            workstations: SYSTEM_VERSIONS.workstations,
             validation: SYSTEM_VERSIONS.validation,
             gameViewModels: SYSTEM_VERSIONS.gameViewModels,
         },
         {
-            versionManifest: '0.8.600.4',
+            versionManifest: '0.8.600.5',
             commandShell: '0.5.1',
             slashCommands: '0.5.0',
             accountSaves: '0.7.1',
-            saveEncoding: '0.5.0',
+            commitments: '0.3.1',
+            carriedInventory: '0.1.0',
+            carriedLoad: '0.2.1',
             inventoryContainers: '0.7.0',
             inventoryTransfers: '0.7.0',
-            homeInfrastructure: '0.4.0',
-            homeStorage: '0.4.0',
-            workstations: '0.3.1',
             validation: '0.11.0',
             gameViewModels: '0.15.1',
         },
     );
 
     assert.equal(Object.hasOwn(SYSTEM_VERSIONS, 'saveMigrations'), false);
-    assert.match(describeVersion(), /Product: 0\.8\.600\.4/);
+    assert.match(describeVersion(), /Product: 0\.8\.600\.5/);
     assert.match(describeVersion(), /Package: 0\.8\.600/);
     assert.match(describeVersion(), /Account Save: 5/);
     assert.match(describeVersion(), /Game State: 6/);
     assert.match(describeVersion(), /Data: 37/);
-    assert.match(describeVersion(), /Codename: Strict Current Schema/);
+    assert.match(describeVersion(), /Codename: Carried Commitment Delivery/);
     assert.match(describeVersion(), /Compatibility: pre-release-current-schema/);
-    assert.match(describeSystemVersions(), /accountSaves: 0\.7\.1/);
+    assert.match(describeSystemVersions(), /carriedInventory: 0\.1\.0/);
     assert.doesNotMatch(describeSystemVersions(), /saveMigrations:/);
 });
 


### PR DESCRIPTION
Maintenance cycle 3.

Fixes the known carried-inventory consistency bug: commitment requirements and delivery now use the same portable-carried container definition that logistics uses, rather than main Inventory only. Adds a carried-inventory authority for deterministic carried-container queries and atomic cross-container removals; home storage remains excluded.

Version decision: Product 0.8.600.5; Account Save 5, Game State 6, Data 37, Benchmark 1 unchanged. Registers carriedInventory 0.1.0, carriedLoad 0.2.1, commitments 0.3.1.

Draft until exact-head Test + Benchmark are green.