### PR TITLE
Remove ActionResult compatibility aliases

### DIFF
--- a/js/text/commandRouter.js
+++ b/js/text/commandRouter.js
@@ -16,6 +16,7 @@ import { describeLegacyRecoveredData } from './data/legacyRecoveredData.js';
 import { describeMap, describeMaps } from './data/maps.js';
 import { describeNations, findNation } from './data/nations.js';
 import { RACES } from './data/races.js';
+import { describeActionResult } from './systems/actionResult.js';
 import { describeAggroResult, evaluateAggroForGrid } from './systems/aggroEngine.js';
 import { activateAbility, describeAbilities, reconcileAbilityActivation } from './systems/abilityEngine.js';
 import { describeAtlas, describeCurrentGrid } from './systems/atlasEngine.js';
@@ -309,8 +310,7 @@ function describeEncounterStart(state, enemyQuery) {
 
 function describeAbilityActivation(state, abilityQuery) {
     if (!abilityQuery) return 'Invoke what? Try `abilities` to see learned canonical abilities.';
-    const result = activateAbility(state, abilityQuery);
-    return result.ok ? result.message : result.reason;
+    return describeActionResult(activateAbility(state, abilityQuery));
 }
 
 function hasFastCreateArgs(parsed) {
@@ -366,8 +366,7 @@ function describeMove(state, direction) {
 function describeTravelStart(state, destination) {
     if (isActiveBattle(state.activeBattle)) return 'You cannot travel while engaged in battle.';
     if (!destination) return 'Travel where? Try `places` to see known destinations.';
-    const result = startTravel(state, destination);
-    return result.ok ? result.message : result.reason;
+    return describeActionResult(startTravel(state, destination));
 }
 
 function describeWait(state, tickEngine, secondsArg = '1') {
@@ -379,7 +378,7 @@ function describeWait(state, tickEngine, secondsArg = '1') {
     const abilityResult = reconcileAbilityActivation(state);
     const lines = [`Advanced ${seconds}s.`];
     if (travelResult?.message) lines.push(travelResult.message);
-    if (abilityResult?.message) lines.push(abilityResult.message);
+    if (abilityResult) lines.push(describeActionResult(abilityResult));
     if (travelResult?.completed) lines.push('', describeLocation(state));
     else if (state.travel?.active) lines.push(describeTravel(state));
     return lines.join('\n');

--- a/js/text/systems/actionResult.js
+++ b/js/text/systems/actionResult.js
@@ -1,11 +1,11 @@
 export const ACTION_RESULT_VERSION = 1;
 
 export function actionSuccess(options = {}) {
-    return asLegacyActionResult(createActionResult({ ...options, ok: true }));
+    return createActionResult({ ...options, ok: true });
 }
 
 export function actionFailure(options = {}) {
-    return asLegacyActionResult(createActionResult({ ...options, ok: false }));
+    return createActionResult({ ...options, ok: false });
 }
 
 export function createActionResult(options = {}) {
@@ -54,35 +54,6 @@ export function isActionResult(value) {
 export function describeActionResult(result, fallback = '') {
     if (!isActionResult(result)) return fallback;
     return String(result.display.text ?? fallback);
-}
-
-// Transitional adapter for callers that still read .message/.reason or a promoted
-// semantic field directly. The compatibility aliases are non-enumerable so saved,
-// logged, or inspected ActionResult data keeps prose isolated under display.
-export function asLegacyActionResult(result, promotedDataKeys = []) {
-    if (!isActionResult(result)) return result;
-    const view = { ...result };
-    const descriptors = {
-        message: {
-            enumerable: false,
-            get: () => (result.ok ? describeActionResult(result) : undefined),
-        },
-        reason: {
-            enumerable: false,
-            get: () => (!result.ok ? describeActionResult(result) : undefined),
-        },
-    };
-
-    for (const key of promotedDataKeys) {
-        if (!(key in result.data) || key in view) continue;
-        descriptors[key] = {
-            enumerable: false,
-            get: () => result.data[key],
-        };
-    }
-
-    Object.defineProperties(view, descriptors);
-    return Object.freeze(view);
 }
 
 function isNonEmptyString(value) {

--- a/js/text/version.js
+++ b/js/text/version.js
@@ -1,4 +1,4 @@
-export const PRODUCT_VERSION = '0.8.600.5';
+export const PRODUCT_VERSION = '0.8.600.6';
 export const PACKAGE_VERSION = '0.8.600';
 
 export const VERSION = Object.freeze({
@@ -8,14 +8,14 @@ export const VERSION = Object.freeze({
     gameState: 6,
     data: 37,
     benchmark: 1,
-    codename: 'Carried Commitment Delivery',
+    codename: 'Canonical Action Results',
     compatibility: 'pre-release-current-schema',
     released: false,
 });
 
 export const SYSTEM_VERSIONS = Object.freeze({
-    versionManifest: '0.8.600.5',
-    actionResults: '0.1.0',
+    versionManifest: '0.8.600.6',
+    actionResults: '0.2.0',
     semanticEvents: '0.1.0',
     foundationReadiness: '0.2.0',
     worldTime: '0.2.0',

--- a/tests/actionResult.test.js
+++ b/tests/actionResult.test.js
@@ -32,7 +32,7 @@ test('ActionResult separates semantic data from display prose', () => {
     assert.equal(isActionResult(result), true);
 });
 
-test('legacy message and reason aliases are non-enumerable compatibility adapters', () => {
+test('ActionResult exposes no legacy message or reason compatibility aliases', () => {
     const success = actionSuccess({
         action: 'fixture.start',
         code: 'fixture.started',
@@ -46,14 +46,12 @@ test('legacy message and reason aliases are non-enumerable compatibility adapter
         display: { text: 'Blocked.' },
     });
 
-    assert.equal(success.message, 'Started.');
-    assert.equal(success.reason, undefined);
-    assert.equal(failure.message, undefined);
-    assert.equal(failure.reason, 'Blocked.');
-    assert.equal(Object.keys(success).includes('message'), false);
-    assert.equal(Object.keys(failure).includes('reason'), false);
-    assert.equal(JSON.stringify(success).includes('Started.'), true);
-    assert.equal(JSON.stringify(success).includes('message'), false);
+    assert.equal(Object.hasOwn(success, 'message'), false);
+    assert.equal(Object.hasOwn(success, 'reason'), false);
+    assert.equal(Object.hasOwn(failure, 'message'), false);
+    assert.equal(Object.hasOwn(failure, 'reason'), false);
+    assert.equal(describeActionResult(success), 'Started.');
+    assert.equal(describeActionResult(failure), 'Blocked.');
 });
 
 test('ActionResult validates required semantic fields', () => {

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -15,7 +15,7 @@ import {
 
 
 test('version manifest separates product package persistence data and focused cleanup versions', () => {
-    assert.equal(PRODUCT_VERSION, '0.8.600.5');
+    assert.equal(PRODUCT_VERSION, '0.8.600.6');
     assert.equal(PACKAGE_VERSION, '0.8.600');
     assert.equal(VERSION.product, PRODUCT_VERSION);
     assert.equal(VERSION.package, PACKAGE_VERSION);
@@ -25,12 +25,13 @@ test('version manifest separates product package persistence data and focused cl
     assert.equal(VERSION.benchmark, 1);
     assert.equal(Object.hasOwn(VERSION, 'app'), false);
     assert.equal(Object.hasOwn(VERSION, 'save'), false);
-    assert.equal(VERSION.codename, 'Carried Commitment Delivery');
+    assert.equal(VERSION.codename, 'Canonical Action Results');
     assert.equal(VERSION.compatibility, 'pre-release-current-schema');
 
     assert.deepEqual(
         {
             versionManifest: SYSTEM_VERSIONS.versionManifest,
+            actionResults: SYSTEM_VERSIONS.actionResults,
             commandShell: SYSTEM_VERSIONS.commandShell,
             slashCommands: SYSTEM_VERSIONS.slashCommands,
             accountSaves: SYSTEM_VERSIONS.accountSaves,
@@ -43,7 +44,8 @@ test('version manifest separates product package persistence data and focused cl
             gameViewModels: SYSTEM_VERSIONS.gameViewModels,
         },
         {
-            versionManifest: '0.8.600.5',
+            versionManifest: '0.8.600.6',
+            actionResults: '0.2.0',
             commandShell: '0.5.1',
             slashCommands: '0.5.0',
             accountSaves: '0.7.1',
@@ -58,14 +60,14 @@ test('version manifest separates product package persistence data and focused cl
     );
 
     assert.equal(Object.hasOwn(SYSTEM_VERSIONS, 'saveMigrations'), false);
-    assert.match(describeVersion(), /Product: 0\.8\.600\.5/);
+    assert.match(describeVersion(), /Product: 0\.8\.600\.6/);
     assert.match(describeVersion(), /Package: 0\.8\.600/);
     assert.match(describeVersion(), /Account Save: 5/);
     assert.match(describeVersion(), /Game State: 6/);
     assert.match(describeVersion(), /Data: 37/);
-    assert.match(describeVersion(), /Codename: Carried Commitment Delivery/);
+    assert.match(describeVersion(), /Codename: Canonical Action Results/);
     assert.match(describeVersion(), /Compatibility: pre-release-current-schema/);
-    assert.match(describeSystemVersions(), /carriedInventory: 0\.1\.0/);
+    assert.match(describeSystemVersions(), /actionResults: 0\.2\.0/);
     assert.doesNotMatch(describeSystemVersions(), /saveMigrations:/);
 });
 

--- a/tests/travelEngine.test.js
+++ b/tests/travelEngine.test.js
@@ -5,7 +5,7 @@ import { createTestState } from './helpers/createTestState.js';
 import { createCommandRouter } from '../js/text/commandRouter.js';
 import { describeMap, describeMaps, listMaps } from '../js/text/data/maps.js';
 import { getPlace, listPlaces, ZONE_CONNECTIONS } from '../js/text/data/places.js';
-import { isActionResult } from '../js/text/systems/actionResult.js';
+import { describeActionResult, isActionResult } from '../js/text/systems/actionResult.js';
 import { setPositionAndDiscover } from '../js/text/systems/atlasEngine.js';
 import { validateWorldData } from '../js/text/systems/validation.js';
 import {
@@ -93,7 +93,7 @@ test('startTravel returns semantic ActionResult and advanceTravel moves current 
     assert.equal(state.location, 'West Elderwood');
 });
 
-test('startTravel failure uses semantic code while retaining command compatibility text adapter', () => {
+test('startTravel failure exposes semantic code and canonical display text only', () => {
     const state = createTestState();
     const result = startTravel(state, 'Unknown Somewhere');
 
@@ -103,8 +103,8 @@ test('startTravel failure uses semantic code while retaining command compatibili
     assert.equal(result.outcome, 'blocked');
     assert.equal(result.data.destinationQuery, 'Unknown Somewhere');
     assert.match(result.display.text, /Unknown destination/);
-    assert.match(result.reason, /Unknown destination/);
-    assert.equal(Object.keys(result).includes('reason'), false);
+    assert.match(describeActionResult(result), /Unknown destination/);
+    assert.equal(Object.hasOwn(result, 'reason'), false);
 });
 
 test('router exposes maps places travel and wait commands', () => {


### PR DESCRIPTION
Maintenance cycle 4.

Removes the non-enumerable ActionResult .message/.reason compatibility surface so semantic outcomes expose only the canonical contract: ok/action/code/outcome/data/display. ACTION_RESULT_VERSION remains 1 because the canonical enumerable contract is unchanged; actionResults registration advances to 0.2.0.

Version decision: Product 0.8.600.6; Account Save 5, Game State 6, Data 37, Benchmark 1 unchanged.

Draft until exact-head Test + Benchmark are green and all real ActionResult compatibility callers are converted.