### PR TITLE
Refresh CI and architecture guardrails

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,16 +9,22 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: check-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - name: Use Node 20
-        uses: actions/setup-node@v4
+        uses: actions/checkout@v7
+      - name: Use Node 24
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
+          package-manager-cache: false
       - name: Test
         run: npm test
       - name: Benchmark

--- a/js/text/version.js
+++ b/js/text/version.js
@@ -1,4 +1,4 @@
-export const PRODUCT_VERSION = '0.8.600.6';
+export const PRODUCT_VERSION = '0.8.600.7';
 export const PACKAGE_VERSION = '0.8.600';
 
 export const VERSION = Object.freeze({
@@ -8,13 +8,13 @@ export const VERSION = Object.freeze({
     gameState: 6,
     data: 37,
     benchmark: 1,
-    codename: 'Canonical Action Results',
+    codename: 'Runtime Architecture Guardrails',
     compatibility: 'pre-release-current-schema',
     released: false,
 });
 
 export const SYSTEM_VERSIONS = Object.freeze({
-    versionManifest: '0.8.600.6',
+    versionManifest: '0.8.600.7',
     actionResults: '0.2.0',
     semanticEvents: '0.1.0',
     foundationReadiness: '0.2.0',

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
   },
   "devDependencies": {},
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   }
 }

--- a/tests/architectureDebtGuard.test.js
+++ b/tests/architectureDebtGuard.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const TEXT_ROOT = resolve(ROOT, 'js/text');
+
+function source(relativePath) {
+    return readFileSync(resolve(ROOT, relativePath), 'utf8');
+}
+
+function assertAbsent(relativePath, patterns) {
+    const text = source(relativePath);
+    for (const pattern of patterns) {
+        assert.doesNotMatch(text, pattern, `${relativePath} reintroduced architecture debt matching ${pattern}`);
+    }
+}
+
+test('retired FFXI command compatibility modules stay deleted', () => {
+    assert.equal(existsSync(resolve(TEXT_ROOT, 'systems/ffxiCommandAdapter.js')), false);
+    assert.equal(existsSync(resolve(TEXT_ROOT, 'data/ffxiMacroCommands.js')), false);
+    assertAbsent('js/text/commandRouter.js', [/ffxiCommandAdapter/i, /ffxiMacroCommands/i]);
+    assertAbsent('js/text/slashCommandRouter.js', [/macrohelp/i, /routeFfxiSlashCommand/i, /isFfxiSlashCommand/i]);
+});
+
+test('current persistence does not regain old storage or home identifiers', () => {
+    assertAbsent('js/text/save.js', [/ffxiTextRpg/i, /mogHouse/i, /mogSafe/i, /mogLocker/i, /mogSatchel/i]);
+    assertAbsent('js/text/data/inventoryContainers.js', [/mogHouse/i, /mogSafe/i, /mogLocker/i, /mogSatchel/i]);
+    assertAbsent('js/text/systems/homeInfrastructureEngine.js', [/mogHouse/i, /mogSafe/i, /mogLocker/i, /mogSatchel/i]);
+});
+
+test('version and ActionResult compatibility aliases stay removed', () => {
+    assertAbsent('js/text/version.js', [/^\s*app\s*:/m, /^\s*save\s*:/m]);
+    assertAbsent('js/text/systems/actionResult.js', [/asLegacyActionResult/, /\bmessage\s*:/, /\breason\s*:/]);
+});
+
+test('presentation does not regain rejected compatibility payloads', () => {
+    assertAbsent('js/text/ui/gameViewModel.js', [/cargoUnits\s*:/]);
+    assertAbsent('js/text/ui/uiIntentDispatcher.js', [/highContrast/]);
+});

--- a/tests/pipeline.test.js
+++ b/tests/pipeline.test.js
@@ -15,7 +15,7 @@ import {
 
 
 test('version manifest separates product package persistence data and focused cleanup versions', () => {
-    assert.equal(PRODUCT_VERSION, '0.8.600.6');
+    assert.equal(PRODUCT_VERSION, '0.8.600.7');
     assert.equal(PACKAGE_VERSION, '0.8.600');
     assert.equal(VERSION.product, PRODUCT_VERSION);
     assert.equal(VERSION.package, PACKAGE_VERSION);
@@ -25,7 +25,7 @@ test('version manifest separates product package persistence data and focused cl
     assert.equal(VERSION.benchmark, 1);
     assert.equal(Object.hasOwn(VERSION, 'app'), false);
     assert.equal(Object.hasOwn(VERSION, 'save'), false);
-    assert.equal(VERSION.codename, 'Canonical Action Results');
+    assert.equal(VERSION.codename, 'Runtime Architecture Guardrails');
     assert.equal(VERSION.compatibility, 'pre-release-current-schema');
 
     assert.deepEqual(
@@ -44,7 +44,7 @@ test('version manifest separates product package persistence data and focused cl
             gameViewModels: SYSTEM_VERSIONS.gameViewModels,
         },
         {
-            versionManifest: '0.8.600.6',
+            versionManifest: '0.8.600.7',
             actionResults: '0.2.0',
             commandShell: '0.5.1',
             slashCommands: '0.5.0',
@@ -60,12 +60,12 @@ test('version manifest separates product package persistence data and focused cl
     );
 
     assert.equal(Object.hasOwn(SYSTEM_VERSIONS, 'saveMigrations'), false);
-    assert.match(describeVersion(), /Product: 0\.8\.600\.6/);
+    assert.match(describeVersion(), /Product: 0\.8\.600\.7/);
     assert.match(describeVersion(), /Package: 0\.8\.600/);
     assert.match(describeVersion(), /Account Save: 5/);
     assert.match(describeVersion(), /Game State: 6/);
     assert.match(describeVersion(), /Data: 37/);
-    assert.match(describeVersion(), /Codename: Canonical Action Results/);
+    assert.match(describeVersion(), /Codename: Runtime Architecture Guardrails/);
     assert.match(describeVersion(), /Compatibility: pre-release-current-schema/);
     assert.match(describeSystemVersions(), /actionResults: 0\.2\.0/);
     assert.doesNotMatch(describeSystemVersions(), /saveMigrations:/);


### PR DESCRIPTION
Maintenance cycle 5. Update hosted validation to Node 24 and current GitHub Actions, add concurrency/timeout controls, and add regression tests that prevent removed compatibility surfaces from returning. Product 0.8.600.7; persistence, data, and benchmark versions unchanged. Draft until Test and Benchmark pass on the exact head.